### PR TITLE
`Archetypes` container

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+ahash = {version = "0.7.6", default-features = false}
 either = {version = "1.6.1", default-features = false}
-hashbrown = "0.11.2"
+hashbrown = {version = "0.11.2", features = ["raw"]}
 serde = {version = "1.0.130", default-features = false, features = ["alloc"], optional = true}
 
 [dev-dependencies]

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -311,7 +311,6 @@ where
         self.length - 1
     }
 
-    #[cfg(feature = "serde")]
     pub(crate) unsafe fn identifier(&self) -> Identifier<R> {
         self.identifier_buffer.as_identifier()
     }

--- a/src/internal/archetypes/impl_debug.rs
+++ b/src/internal/archetypes/impl_debug.rs
@@ -1,0 +1,11 @@
+use crate::internal::{archetypes::Archetypes, registry::RegistryDebug};
+use core::{fmt, fmt::Debug};
+
+impl<R> Debug for Archetypes<R>
+where
+    R: RegistryDebug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
+    }
+}

--- a/src/internal/archetypes/impl_eq.rs
+++ b/src/internal/archetypes/impl_eq.rs
@@ -1,0 +1,23 @@
+use crate::internal::{
+    archetypes::Archetypes,
+    registry::{RegistryEq, RegistryPartialEq},
+};
+
+impl<R> PartialEq for Archetypes<R>
+where
+    R: RegistryPartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        if self.raw_archetypes.len() != other.raw_archetypes.len() {
+            return false;
+        }
+
+        self.iter().all(|(identifier, archetype)| {
+            other
+                .get(identifier)
+                .map_or(false, |other_archetype| archetype == other_archetype)
+        })
+    }
+}
+
+impl<R> Eq for Archetypes<R> where R: RegistryEq {}

--- a/src/internal/archetypes/impl_serde.rs
+++ b/src/internal/archetypes/impl_serde.rs
@@ -1,0 +1,63 @@
+use crate::internal::{
+    archetypes::Archetypes,
+    registry::{RegistryDeserialize, RegistrySerialize},
+};
+use core::{cmp, fmt, format_args, marker::PhantomData};
+use serde::{de, de::{Expected, SeqAccess, Visitor}, Deserialize, Deserializer, Serialize, Serializer};
+
+impl<R> Serialize for Archetypes<R>
+where
+    R: RegistrySerialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_seq(self.iter().map(|(_identifier, archetype)| archetype))
+    }
+}
+
+impl<'de, R> Deserialize<'de> for Archetypes<R>
+where
+    R: RegistryDeserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ArchetypesVisitor<'de, R>
+        where
+            R: RegistryDeserialize<'de>,
+        {
+            registry: PhantomData<&'de R>,
+        }
+
+        impl<'de, R> Visitor<'de> for ArchetypesVisitor<'de, R>
+        where
+            R: RegistryDeserialize<'de>,
+        {
+            type Value = Archetypes<R>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("sequence of `Archetype`s with unique `Identifier`s")
+            }
+
+            fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
+            where
+                S: SeqAccess<'de>,
+            {
+                let mut archetypes = Archetypes::with_capacity(cmp::min(seq.size_hint().unwrap_or(0), 4096));
+                while let Some(archetype) = seq.next_element()? {
+                    if !archetypes.insert(archetype) {
+                        return Err(de::Error::custom(format_args!("non-unique `Identifier`, expected {}", (&self as &dyn Expected))));
+                    }
+                }
+                Ok(archetypes)
+            }
+        }
+
+        deserializer.deserialize_seq(ArchetypesVisitor {
+            registry: PhantomData,
+        })
+    }
+}

--- a/src/internal/archetypes/impl_serde.rs
+++ b/src/internal/archetypes/impl_serde.rs
@@ -3,7 +3,11 @@ use crate::internal::{
     registry::{RegistryDeserialize, RegistrySerialize},
 };
 use core::{cmp, fmt, format_args, marker::PhantomData};
-use serde::{de, de::{Expected, SeqAccess, Visitor}, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de,
+    de::{Expected, SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 
 impl<R> Serialize for Archetypes<R>
 where
@@ -46,10 +50,14 @@ where
             where
                 S: SeqAccess<'de>,
             {
-                let mut archetypes = Archetypes::with_capacity(cmp::min(seq.size_hint().unwrap_or(0), 4096));
+                let mut archetypes =
+                    Archetypes::with_capacity(cmp::min(seq.size_hint().unwrap_or(0), 4096));
                 while let Some(archetype) = seq.next_element()? {
                     if !archetypes.insert(archetype) {
-                        return Err(de::Error::custom(format_args!("non-unique `Identifier`, expected {}", (&self as &dyn Expected))));
+                        return Err(de::Error::custom(format_args!(
+                            "non-unique `Identifier`, expected {}",
+                            (&self as &dyn Expected)
+                        )));
                     }
                 }
                 Ok(archetypes)

--- a/src/internal/archetypes/iter.rs
+++ b/src/internal/archetypes/iter.rs
@@ -39,6 +39,10 @@ where
             (unsafe { archetype.identifier() }, archetype)
         })
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.raw_iter.size_hint()
+    }
 }
 
 pub(crate) struct IterMut<'a, R>

--- a/src/internal/archetypes/iter.rs
+++ b/src/internal/archetypes/iter.rs
@@ -1,0 +1,78 @@
+use crate::{
+    internal::{archetype, archetype::Archetype},
+    registry::Registry,
+};
+use core::marker::PhantomData;
+use hashbrown::raw::RawIter;
+
+pub(crate) struct Iter<'a, R>
+where
+    R: Registry,
+{
+    lifetime: PhantomData<&'a ()>,
+
+    raw_iter: RawIter<Archetype<R>>,
+}
+
+impl<'a, R> Iter<'a, R>
+where
+    R: Registry,
+{
+    pub(super) fn new(raw_iter: RawIter<Archetype<R>>) -> Self {
+        Self {
+            lifetime: PhantomData,
+
+            raw_iter,
+        }
+    }
+}
+
+impl<'a, R> Iterator for Iter<'a, R>
+where
+    R: Registry + 'a,
+{
+    type Item = (archetype::Identifier<R>, &'a Archetype<R>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.raw_iter.next().map(|archetype_bucket| {
+            let archetype = unsafe { archetype_bucket.as_ref() };
+            (unsafe { archetype.identifier() }, archetype)
+        })
+    }
+}
+
+pub(crate) struct IterMut<'a, R>
+where
+    R: Registry,
+{
+    lifetime: PhantomData<&'a ()>,
+
+    raw_iter: RawIter<Archetype<R>>,
+}
+
+impl<'a, R> IterMut<'a, R>
+where
+    R: Registry,
+{
+    pub(super) fn new(raw_iter: RawIter<Archetype<R>>) -> Self {
+        Self {
+            lifetime: PhantomData,
+
+            raw_iter,
+        }
+    }
+}
+
+impl<'a, R> Iterator for IterMut<'a, R>
+where
+    R: Registry + 'a,
+{
+    type Item = (archetype::Identifier<R>, &'a mut Archetype<R>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.raw_iter.next().map(|archetype_bucket| {
+            let archetype = unsafe { archetype_bucket.as_mut() };
+            (unsafe { archetype.identifier() }, archetype)
+        })
+    }
+}

--- a/src/internal/archetypes/mod.rs
+++ b/src/internal/archetypes/mod.rs
@@ -1,0 +1,157 @@
+mod impl_debug;
+mod impl_eq;
+#[cfg(feature = "serde")]
+mod impl_serde;
+mod iter;
+
+use crate::{
+    internal::{archetype, archetype::Archetype},
+    registry::Registry,
+};
+use core::hash::{BuildHasher, Hash, Hasher};
+use hashbrown::raw::RawTable;
+use iter::{Iter, IterMut};
+
+pub(crate) struct Archetypes<R>
+where
+    R: Registry,
+{
+    raw_archetypes: RawTable<Archetype<R>>,
+    hash_builder: ahash::RandomState,
+}
+
+impl<R> Archetypes<R>
+where
+    R: Registry,
+{
+    pub(crate) fn new() -> Self {
+        Self {
+            raw_archetypes: RawTable::new(),
+            hash_builder: ahash::RandomState::new(),
+        }
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            raw_archetypes: RawTable::with_capacity(capacity),
+            hash_builder: ahash::RandomState::new(),
+        }
+    }
+
+    fn make_hash(identifier: archetype::Identifier<R>, hash_builder: &ahash::RandomState) -> u64 {
+        let mut state = hash_builder.build_hasher();
+        identifier.hash(&mut state);
+        state.finish()
+    }
+
+    fn make_hasher(hash_builder: &ahash::RandomState) -> impl Fn(&Archetype<R>) -> u64 + '_ {
+        move |archetype| Self::make_hash(unsafe { archetype.identifier() }, hash_builder)
+    }
+
+    fn equivalent_identifier(
+        identifier: archetype::Identifier<R>,
+    ) -> impl Fn(&Archetype<R>) -> bool {
+        move |archetype: &Archetype<R>| unsafe { archetype.identifier() } == identifier
+    }
+
+    pub(crate) fn get(&self, identifier: archetype::Identifier<R>) -> Option<&Archetype<R>> {
+        self.raw_archetypes.get(
+            Self::make_hash(identifier, &self.hash_builder),
+            Self::equivalent_identifier(identifier),
+        )
+    }
+
+    pub(crate) fn get_mut_or_insert_new(
+        &mut self,
+        identifier_buffer: archetype::IdentifierBuffer<R>,
+    ) -> &mut Archetype<R> {
+        let hash = Self::make_hash(
+            unsafe { identifier_buffer.as_identifier() },
+            &self.hash_builder,
+        );
+
+        match self.raw_archetypes.find(
+            hash,
+            Self::equivalent_identifier(unsafe { identifier_buffer.as_identifier() }),
+        ) {
+            Some(archetype_bucket) => unsafe { archetype_bucket.as_mut() },
+            None => self.raw_archetypes.insert_entry(
+                hash,
+                unsafe { Archetype::new(identifier_buffer) },
+                Self::make_hasher(&self.hash_builder),
+            ),
+        }
+    }
+
+    pub(crate) unsafe fn get_unchecked_mut(
+        &mut self,
+        identifier: archetype::Identifier<R>,
+    ) -> &mut Archetype<R> {
+        self.raw_archetypes
+            .get_mut(
+                Self::make_hash(identifier, &self.hash_builder),
+                Self::equivalent_identifier(identifier),
+            )
+            .unwrap_unchecked()
+    }
+
+    pub(crate) fn insert(&mut self, archetype: Archetype<R>) -> bool {
+        let hash = Self::make_hash(unsafe {archetype.identifier()}, &self.hash_builder);
+        if let Some(existing_archetype) = self.raw_archetypes.get(hash, Self::equivalent_identifier(unsafe {archetype.identifier()})) {
+            false
+        } else {
+            self.raw_archetypes.insert(hash, archetype, Self::make_hasher(&self.hash_builder));
+            true
+        }
+    }
+
+    pub(crate) fn iter(&self) -> Iter<R> {
+        Iter::new(unsafe { self.raw_archetypes.iter() })
+    }
+
+    pub(crate) fn iter_mut(&mut self) -> IterMut<R> {
+        IterMut::new(unsafe { self.raw_archetypes.iter() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        internal::{archetype, archetypes::Archetypes},
+        registry,
+    };
+    use alloc::vec;
+
+    macro_rules! create_components {
+        ($( $variants:ident ),*) => {
+            $(
+                struct $variants(f32);
+            )*
+        };
+    }
+
+    create_components!(
+        A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z
+    );
+
+    type Registry =
+        registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+
+    #[test]
+    fn get_mut_or_insert_new_insertion() {
+        let mut archetypes = Archetypes::<Registry>::new();
+        let buffer = unsafe { archetype::IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
+
+        let archetype = archetypes.get_mut_or_insert_new(buffer);
+    }
+
+    #[test]
+    fn get_mut_or_insert_new_already_inserted() {
+        let mut archetypes = Archetypes::<Registry>::new();
+        let buffer_a = unsafe { archetype::IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
+        let buffer_b = unsafe { archetype::IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
+        archetypes.get_mut_or_insert_new(buffer_a);
+
+        let archetype = archetypes.get_mut_or_insert_new(buffer_b);
+    }
+}

--- a/src/internal/archetypes/mod.rs
+++ b/src/internal/archetypes/mod.rs
@@ -96,11 +96,15 @@ where
     }
 
     pub(crate) fn insert(&mut self, archetype: Archetype<R>) -> bool {
-        let hash = Self::make_hash(unsafe {archetype.identifier()}, &self.hash_builder);
-        if let Some(existing_archetype) = self.raw_archetypes.get(hash, Self::equivalent_identifier(unsafe {archetype.identifier()})) {
+        let hash = Self::make_hash(unsafe { archetype.identifier() }, &self.hash_builder);
+        if let Some(existing_archetype) = self.raw_archetypes.get(
+            hash,
+            Self::equivalent_identifier(unsafe { archetype.identifier() }),
+        ) {
             false
         } else {
-            self.raw_archetypes.insert(hash, archetype, Self::make_hasher(&self.hash_builder));
+            self.raw_archetypes
+                .insert(hash, archetype, Self::make_hasher(&self.hash_builder));
             true
         }
     }

--- a/src/internal/entity_allocator/impl_serde.rs
+++ b/src/internal/entity_allocator/impl_serde.rs
@@ -3,6 +3,7 @@ use crate::{
     internal::{
         archetype,
         archetype::Archetype,
+        archetypes::Archetypes,
         entity_allocator::{EntityAllocator, Location, Slot},
     },
     registry::Registry,
@@ -163,7 +164,7 @@ where
 {
     pub(crate) fn from_serialized_parts<'de, D>(
         serialized_entity_allocator: SerializedEntityAllocator,
-        archetypes: &HashMap<archetype::Identifier<R>, Archetype<R>>,
+        archetypes: &Archetypes<R>,
         _deserializer: PhantomData<D>,
         _lifetime: PhantomData<&'de ()>,
     ) -> Result<Self, D::Error>
@@ -194,7 +195,7 @@ where
         }
 
         // Populate active slots from archetypes.
-        for (archetype_identifier, archetype) in archetypes {
+        for (archetype_identifier, archetype) in archetypes.iter() {
             for (i, entity_identifier) in archetype.entity_identifiers().enumerate() {
                 let slot = slots.get_mut(entity_identifier.index).ok_or_else(|| {
                     de::Error::custom(format!(
@@ -211,7 +212,7 @@ where
                         *slot = Some(Slot {
                             generation: entity_identifier.generation,
                             location: Some(Location {
-                                identifier: *archetype_identifier,
+                                identifier: archetype_identifier,
                                 index: i,
                             }),
                         });

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod archetype;
+pub(crate) mod archetypes;
 pub(crate) mod entities;
 pub(crate) mod entity;
 pub(crate) mod entity_allocator;

--- a/src/public/world/entry.rs
+++ b/src/public/world/entry.rs
@@ -38,8 +38,7 @@ where
             unsafe {
                 self.world
                     .archetypes
-                    .get_mut(&self.location.identifier)
-                    .unwrap_unchecked()
+                    .get_unchecked_mut(self.location.identifier)
                     .set_component_unchecked(self.location.index, component)
             };
         } else {
@@ -47,8 +46,7 @@ where
             let (entity_identifier, current_component_bytes) = unsafe {
                 self.world
                     .archetypes
-                    .get_mut(&self.location.identifier)
-                    .unwrap_unchecked()
+                    .get_unchecked_mut(self.location.identifier)
                     .pop_row_unchecked(self.location.index, &mut self.world.entity_allocator)
             };
             // Create new identifier buffer.
@@ -60,26 +58,18 @@ where
                 unsafe { archetype::IdentifierBuffer::<R>::new(raw_identifier_buffer) };
 
             // Insert to the corresponding archetype using the bytes and the new component.
-            let archetype_entry = self
-                .world
-                .archetypes
-                .entry(unsafe { identifier_buffer.as_identifier() });
-            let archetype_identifier = *archetype_entry.key();
-            let index = unsafe {
-                archetype_entry
-                    .or_insert(Archetype::<R>::new(identifier_buffer))
-                    .push_from_buffer_and_component(
-                        entity_identifier,
-                        current_component_bytes,
-                        component,
-                    )
-            };
+            let archetype = self.world.archetypes.get_mut_or_insert_new(identifier_buffer);
+            let index = unsafe {archetype.push_from_buffer_and_component(
+                entity_identifier,
+                current_component_bytes,
+                component,
+            )};
 
             // Update the location.
             unsafe {
                 self.world.entity_allocator.modify_location_unchecked(
                     entity_identifier,
-                    Location::new(archetype_identifier, index),
+                    Location::new(archetype.identifier(), index),
                 );
             }
         }
@@ -101,8 +91,7 @@ where
             let (entity_identifier, current_component_bytes) = unsafe {
                 self.world
                     .archetypes
-                    .get_mut(&self.location.identifier)
-                    .unwrap_unchecked()
+                    .get_unchecked_mut(self.location.identifier)
                     .pop_row_unchecked(self.location.index, &mut self.world.entity_allocator)
             };
             // Create new identifier buffer.
@@ -115,25 +104,17 @@ where
 
             // Insert to the corresponding archetype using the bytes, skipping the removed
             // component.
-            let archetype_entry = self
-                .world
-                .archetypes
-                .entry(unsafe { identifier_buffer.as_identifier() });
-            let archetype_identifier = *archetype_entry.key();
-            let index = unsafe {
-                archetype_entry
-                    .or_insert(Archetype::<R>::new(identifier_buffer))
-                    .push_from_buffer_skipping_component::<C>(
-                        entity_identifier,
-                        current_component_bytes,
-                    )
-            };
+            let archetype = self.world.archetypes.get_mut_or_insert_new(identifier_buffer);
+            let index = unsafe {archetype.push_from_buffer_skipping_component::<C>(
+                entity_identifier,
+                current_component_bytes,
+            )};
 
             // Update the location.
             unsafe {
                 self.world.entity_allocator.modify_location_unchecked(
                     entity_identifier,
-                    Location::new(archetype_identifier, index),
+                    Location::new(archetype.identifier(), index),
                 );
             }
         }

--- a/src/public/world/entry.rs
+++ b/src/public/world/entry.rs
@@ -58,12 +58,17 @@ where
                 unsafe { archetype::IdentifierBuffer::<R>::new(raw_identifier_buffer) };
 
             // Insert to the corresponding archetype using the bytes and the new component.
-            let archetype = self.world.archetypes.get_mut_or_insert_new(identifier_buffer);
-            let index = unsafe {archetype.push_from_buffer_and_component(
-                entity_identifier,
-                current_component_bytes,
-                component,
-            )};
+            let archetype = self
+                .world
+                .archetypes
+                .get_mut_or_insert_new(identifier_buffer);
+            let index = unsafe {
+                archetype.push_from_buffer_and_component(
+                    entity_identifier,
+                    current_component_bytes,
+                    component,
+                )
+            };
 
             // Update the location.
             unsafe {
@@ -104,11 +109,16 @@ where
 
             // Insert to the corresponding archetype using the bytes, skipping the removed
             // component.
-            let archetype = self.world.archetypes.get_mut_or_insert_new(identifier_buffer);
-            let index = unsafe {archetype.push_from_buffer_skipping_component::<C>(
-                entity_identifier,
-                current_component_bytes,
-            )};
+            let archetype = self
+                .world
+                .archetypes
+                .get_mut_or_insert_new(identifier_buffer);
+            let index = unsafe {
+                archetype.push_from_buffer_skipping_component::<C>(
+                    entity_identifier,
+                    current_component_bytes,
+                )
+            };
 
             // Update the location.
             unsafe {

--- a/src/public/world/impl_serde.rs
+++ b/src/public/world/impl_serde.rs
@@ -143,8 +143,7 @@ where
                     }
                 }
                 Ok(SerializedWorld {
-                    archetypes: archetypes
-                        .ok_or_else(|| de::Error::missing_field("archetypes"))?,
+                    archetypes: archetypes.ok_or_else(|| de::Error::missing_field("archetypes"))?,
                     serialized_entity_allocator: entity_allocator
                         .ok_or_else(|| de::Error::missing_field("archetypes"))?,
 

--- a/src/public/world/impl_serde.rs
+++ b/src/public/world/impl_serde.rs
@@ -2,6 +2,7 @@ use crate::{
     internal::{
         archetype,
         archetype::Archetype,
+        archetypes::Archetypes,
         entity_allocator::{impl_serde::SerializedEntityAllocator, EntityAllocator},
         registry::{RegistryDeserialize, RegistrySerialize},
     },
@@ -16,26 +17,6 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-struct SerializeArchetypes<'a, R>(&'a HashMap<archetype::Identifier<R>, Archetype<R>>)
-where
-    R: RegistrySerialize;
-
-impl<R> Serialize for SerializeArchetypes<'_, R>
-where
-    R: RegistrySerialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
-        for archetype in self.0.values() {
-            seq.serialize_element(archetype)?;
-        }
-        seq.end()
-    }
-}
-
 impl<R> Serialize for World<R>
 where
     R: RegistrySerialize,
@@ -45,59 +26,9 @@ where
         S: Serializer,
     {
         let mut r#struct = serializer.serialize_struct("World", 2)?;
-        r#struct.serialize_field("archetypes", &SerializeArchetypes(&self.archetypes))?;
+        r#struct.serialize_field("archetypes", &self.archetypes)?;
         r#struct.serialize_field("entity_allocator", &self.entity_allocator)?;
         r#struct.end()
-    }
-}
-
-struct DeserializeArchetypes<'de, R>(
-    HashMap<archetype::Identifier<R>, Archetype<R>>,
-    PhantomData<&'de ()>,
-)
-where
-    R: RegistryDeserialize<'de>;
-
-impl<'de, R> Deserialize<'de> for DeserializeArchetypes<'de, R>
-where
-    R: RegistryDeserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct DeserializeArchetypesVisitor<'de, R>
-        where
-            R: RegistryDeserialize<'de>,
-        {
-            registry: PhantomData<&'de R>,
-        }
-
-        impl<'de, R> Visitor<'de> for DeserializeArchetypesVisitor<'de, R>
-        where
-            R: RegistryDeserialize<'de>,
-        {
-            type Value = DeserializeArchetypes<'de, R>;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("sequence of `Archetype`s")
-            }
-
-            fn visit_seq<S>(self, mut seq: S) -> Result<Self::Value, S::Error>
-            where
-                S: SeqAccess<'de>,
-            {
-                let mut archetypes = HashMap::with_capacity(seq.size_hint().unwrap_or(0));
-                while let Some(archetype) = seq.next_element::<Archetype<R>>()? {
-                    archetypes.insert(unsafe { archetype.identifier() }, archetype);
-                }
-                Ok(DeserializeArchetypes(archetypes, PhantomData))
-            }
-        }
-
-        deserializer.deserialize_seq(DeserializeArchetypesVisitor::<'de, R> {
-            registry: PhantomData,
-        })
     }
 }
 
@@ -148,7 +79,7 @@ where
         where
             R: RegistryDeserialize<'de>,
         {
-            archetypes: HashMap<archetype::Identifier<R>, Archetype<R>>,
+            archetypes: Archetypes<R>,
             serialized_entity_allocator: SerializedEntityAllocator,
 
             lifetime: PhantomData<&'de ()>,
@@ -175,14 +106,14 @@ where
             where
                 V: SeqAccess<'de>,
             {
-                let archetypes: DeserializeArchetypes<R> = seq
+                let archetypes = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
                 let serialized_entity_allocator = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
                 Ok(SerializedWorld {
-                    archetypes: archetypes.0,
+                    archetypes,
                     serialized_entity_allocator,
 
                     lifetime: PhantomData,
@@ -193,7 +124,7 @@ where
             where
                 V: MapAccess<'de>,
             {
-                let mut archetypes: Option<DeserializeArchetypes<R>> = None;
+                let mut archetypes = None;
                 let mut entity_allocator = None;
                 while let Some(key) = map.next_key()? {
                     match key {
@@ -213,8 +144,7 @@ where
                 }
                 Ok(SerializedWorld {
                     archetypes: archetypes
-                        .ok_or_else(|| de::Error::missing_field("archetypes"))?
-                        .0,
+                        .ok_or_else(|| de::Error::missing_field("archetypes"))?,
                     serialized_entity_allocator: entity_allocator
                         .ok_or_else(|| de::Error::missing_field("archetypes"))?,
 

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -37,10 +37,7 @@ impl<R> World<R>
 where
     R: Registry,
 {
-    fn from_raw_parts(
-        archetypes: Archetypes<R>,
-        entity_allocator: EntityAllocator<R>,
-    ) -> Self {
+    fn from_raw_parts(archetypes: Archetypes<R>, entity_allocator: EntityAllocator<R>) -> Self {
         let mut component_map = HashMap::new();
         R::create_component_map(&mut component_map, 0);
 

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     entity::{Entity, EntityIdentifier},
     internal::{
         archetype::{self, Archetype},
+        archetypes::Archetypes,
         entity_allocator::EntityAllocator,
         query::FilterSeal,
     },
@@ -26,7 +27,7 @@ pub struct World<R>
 where
     R: Registry,
 {
-    archetypes: HashMap<archetype::Identifier<R>, Archetype<R>>,
+    archetypes: Archetypes<R>,
     entity_allocator: EntityAllocator<R>,
 
     component_map: HashMap<TypeId, usize>,
@@ -37,7 +38,7 @@ where
     R: Registry,
 {
     fn from_raw_parts(
-        archetypes: HashMap<archetype::Identifier<R>, Archetype<R>>,
+        archetypes: Archetypes<R>,
         entity_allocator: EntityAllocator<R>,
     ) -> Self {
         let mut component_map = HashMap::new();
@@ -52,7 +53,7 @@ where
     }
 
     pub fn new() -> Self {
-        Self::from_raw_parts(HashMap::new(), EntityAllocator::new())
+        Self::from_raw_parts(Archetypes::new(), EntityAllocator::new())
     }
 
     pub fn push<E>(&mut self, entity: E) -> EntityIdentifier
@@ -67,8 +68,7 @@ where
 
         unsafe {
             self.archetypes
-                .entry(identifier_buffer.as_identifier())
-                .or_insert(Archetype::<R>::new(identifier_buffer))
+                .get_mut_or_insert_new(identifier_buffer)
                 .push(entity, &mut self.entity_allocator)
         }
     }
@@ -86,8 +86,7 @@ where
 
         unsafe {
             self.archetypes
-                .entry(identifier_buffer.as_identifier())
-                .or_insert(Archetype::<R>::new(identifier_buffer))
+                .get_mut_or_insert_new(identifier_buffer)
                 .extend(entities, &mut self.entity_allocator)
         }
     }
@@ -99,10 +98,10 @@ where
     {
         self.archetypes
             .iter_mut()
-            .filter(|(key, _archetype)| unsafe {
-                And::<V, F>::filter(key.as_slice(), &self.component_map)
+            .filter(|(identifier, _archetype)| unsafe {
+                And::<V, F>::filter(identifier.as_slice(), &self.component_map)
             })
-            .map(|(_key, archetype)| archetype.view::<V>())
+            .map(|(_identifier, archetype)| archetype.view::<V>())
             .collect::<Vec<_>>()
             .into_iter()
             .flatten()
@@ -120,8 +119,7 @@ where
             // Remove row from Archetype.
             unsafe {
                 self.archetypes
-                    .get_mut(&location.identifier)
-                    .unwrap_unchecked()
+                    .get_unchecked_mut(location.identifier)
                     .remove_row_unchecked(location.index, &mut self.entity_allocator);
             }
             // Free slot in EntityAllocator.


### PR DESCRIPTION
Stores `Archetype` values in a custom-built `Archetypes` container. This container is built on top of the `hashbrown::raw` API and is similar to a `HashSet` that provides mutable access to values. The hash is created using the `Archetype`'s `Identifier` without having to store the `Identifier` twice (which was unable to be done with the previous `HashMap` solution). 

This fixes #10.