### PR TITLE
Fully implement `serde` traits

### DIFF
--- a/src/internal/archetype/identifier/impl_serde.rs
+++ b/src/internal/archetype/identifier/impl_serde.rs
@@ -16,17 +16,13 @@ where
     where
         S: Serializer,
     {
-        if serializer.is_human_readable() {
-            unimplemented!("human readable serialization is not yet implemented")
-        } else {
-            let mut tuple = serializer.serialize_tuple((R::LEN + 7) / 8)?;
+        let mut tuple = serializer.serialize_tuple((R::LEN + 7) / 8)?;
 
-            for byte in unsafe { self.as_slice() } {
-                tuple.serialize_element(byte)?;
-            }
-
-            tuple.end()
+        for byte in unsafe { self.as_slice() } {
+            tuple.serialize_element(byte)?;
         }
+
+        tuple.end()
     }
 }
 

--- a/src/internal/archetype/impl_serde.rs
+++ b/src/internal/archetype/impl_serde.rs
@@ -1,12 +1,16 @@
-use crate::internal::{
-    archetype::{Archetype, IdentifierBuffer},
-    registry::{RegistryDeserialize, RegistrySerialize},
+use crate::{
+    entity::EntityIdentifier,
+    internal::{
+        archetype,
+        archetype::{Archetype, IdentifierBuffer},
+        registry::{RegistryDeserialize, RegistrySerialize},
+    },
 };
 use alloc::vec::Vec;
 use core::{fmt, marker::PhantomData, mem::ManuallyDrop};
 use serde::{
-    de::{self, SeqAccess, Visitor},
-    ser::SerializeSeq,
+    de::{self, DeserializeSeed, SeqAccess, Visitor},
+    ser::{SerializeSeq, SerializeTuple},
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
@@ -59,6 +63,47 @@ where
     }
 }
 
+struct SerializeRow<'a, R>
+where
+    R: RegistrySerialize,
+{
+    archetype: &'a Archetype<R>,
+    index: usize,
+}
+
+impl<R> Serialize for SerializeRow<'_, R>
+where
+    R: RegistrySerialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(R::LEN + 1)?;
+
+        tuple.serialize_element(unsafe {
+            ManuallyDrop::new(Vec::from_raw_parts(
+                self.archetype.entity_identifiers.0,
+                self.archetype.length,
+                self.archetype.entity_identifiers.1,
+            ))
+            .get_unchecked(self.index)
+        })?;
+
+        unsafe {
+            R::serialize_components_by_row(
+                &self.archetype.components,
+                self.archetype.length,
+                self.index,
+                &mut tuple,
+                self.archetype.identifier_buffer.iter(),
+            )?;
+        }
+
+        tuple.end()
+    }
+}
+
 struct SerializeArchetypeByRow<'a, R>(&'a Archetype<R>)
 where
     R: RegistrySerialize;
@@ -71,40 +116,18 @@ where
     where
         S: Serializer,
     {
-        let mut seq = serializer.serialize_seq(Some(
-            self.0.length
-                * (unsafe { self.0.identifier_buffer.iter() }
-                    .filter(|b| *b)
-                    .count()
-                    + 1)
-                + 2,
-        ))?;
+        let mut seq = serializer.serialize_seq(Some(self.0.length + 2))?;
 
         seq.serialize_element(&self.0.identifier_buffer)?;
 
         seq.serialize_element(&self.0.length)?;
 
-        let entity_identifiers = ManuallyDrop::new(unsafe {
-            Vec::from_raw_parts(
-                self.0.entity_identifiers.0,
-                self.0.length,
-                self.0.entity_identifiers.1,
-            )
-        });
-
         // Serialize by row with entity identifiers included.
-        for (i, entity_identifier) in entity_identifiers.iter().enumerate() {
-            // TODO: Should be in tuples, rather than free-form.
-            seq.serialize_element(entity_identifier)?;
-            unsafe {
-                R::serialize_components_by_row(
-                    &self.0.components,
-                    self.0.length,
-                    i,
-                    &mut seq,
-                    self.0.identifier_buffer.iter(),
-                )?;
-            }
+        for index in 0..self.0.length {
+            seq.serialize_element(&SerializeRow::<R> {
+                archetype: self.0,
+                index,
+            })?;
         }
 
         seq.end()
@@ -124,6 +147,107 @@ where
         } else {
             serializer.serialize_newtype_struct("Archetype", &SerializeArchetypeByColumn(self))
         }
+    }
+}
+
+// The deserialization should be done in-place. How can that be done?
+struct DeserializeRow<'a, 'de, R>
+where
+    R: RegistryDeserialize<'de>,
+{
+    lifetime: PhantomData<&'de ()>,
+
+    identifier: archetype::Identifier<R>,
+
+    entity_identifiers: &'a mut (*mut EntityIdentifier, usize),
+    components: &'a mut [(*mut u8, usize)],
+    length: usize,
+}
+
+impl<'a, 'de, R> DeserializeRow<'a, 'de, R>
+where
+    R: RegistryDeserialize<'de>,
+{
+    unsafe fn new(
+        identifier: archetype::Identifier<R>,
+        entity_identifiers: &'a mut (*mut EntityIdentifier, usize),
+        components: &'a mut [(*mut u8, usize)],
+        length: usize,
+    ) -> Self {
+        Self {
+            lifetime: PhantomData,
+
+            identifier,
+
+            entity_identifiers,
+            components,
+            length,
+        }
+    }
+}
+
+impl<'de, R> DeserializeSeed<'de> for DeserializeRow<'_, 'de, R>
+where
+    R: RegistryDeserialize<'de>,
+{
+    // The deserialized values are stored directly in the buffers to avoid reallocations.
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct DeserializeRowVisitor<'a, 'de, R>(DeserializeRow<'a, 'de, R>)
+        where
+            R: RegistryDeserialize<'de>;
+
+        impl<'de, R> Visitor<'de> for DeserializeRowVisitor<'_, 'de, R>
+        where
+            R: RegistryDeserialize<'de>,
+        {
+            type Value = ();
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("row of (EntityIdentifier, components...)")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut entity_identifiers = ManuallyDrop::new(unsafe {
+                    Vec::from_raw_parts(
+                        self.0.entity_identifiers.0,
+                        self.0.length,
+                        self.0.entity_identifiers.1,
+                    )
+                });
+                entity_identifiers
+                    .push(seq.next_element()?.ok_or_else(|| {
+                        de::Error::invalid_length(0, &"number of components + 1")
+                    })?);
+                *self.0.entity_identifiers = (
+                    entity_identifiers.as_mut_ptr(),
+                    entity_identifiers.capacity(),
+                );
+
+                unsafe {
+                    R::deserialize_components_by_row(
+                        self.0.components,
+                        self.0.length,
+                        &mut seq,
+                        self.0.identifier.iter(),
+                    )
+                }?;
+
+                Ok(())
+            }
+        }
+
+        deserializer.deserialize_tuple(
+            unsafe { self.identifier.iter() }.count() + 1,
+            DeserializeRowVisitor(self),
+        )
     }
 }
 
@@ -235,51 +359,63 @@ where
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
 
-                let mut entity_identifiers = Vec::with_capacity(length);
+                let mut entity_identifiers_vec = ManuallyDrop::new(Vec::with_capacity(length));
+                let mut entity_identifiers = (
+                    entity_identifiers_vec.as_mut_ptr(),
+                    entity_identifiers_vec.capacity(),
+                );
+
                 let components_len = unsafe { identifier.iter() }.filter(|b| *b).count();
                 let mut components = Vec::with_capacity(components_len);
-                // TODO: Move this logic into the deserialize_components_by_column logic. Vecs
-                // should be deconstructed and populated at the same time.
                 for _ in 0..components_len {
                     let mut v = ManuallyDrop::new(Vec::new());
                     components.push((v.as_mut_ptr(), v.capacity()));
                 }
+                let mut vec_length = 0;
 
                 for i in 0..length {
-                    entity_identifiers.push(seq.next_element()?.ok_or_else(|| {
-                        de::Error::invalid_length(i, &"`length` entity identifiers")
-                    })?);
-
-                    let result = unsafe {
-                        R::deserialize_components_by_row(
+                    let result = seq.next_element_seed(unsafe {
+                        DeserializeRow::new(
+                            identifier.as_identifier(),
+                            &mut entity_identifiers,
                             &mut components,
-                            length,
-                            &mut seq,
-                            identifier.iter(),
+                            vec_length,
                         )
-                    };
+                    });
                     if result.is_err() {
+                        let _ = unsafe {
+                            Vec::from_raw_parts(
+                                entity_identifiers.0,
+                                vec_length,
+                                entity_identifiers.1,
+                            )
+                        };
                         unsafe {
-                            R::free_components(&components, length, identifier.iter());
+                            R::free_components(&components, vec_length, identifier.iter());
                         }
+
                         return Err(unsafe { result.unwrap_err_unchecked() });
+                    }
+                    if let Some(()) = unsafe { result.unwrap_unchecked() } {
+                        vec_length += 1;
+                    } else {
+                        let _ = unsafe {
+                            Vec::from_raw_parts(
+                                entity_identifiers.0,
+                                vec_length,
+                                entity_identifiers.1,
+                            )
+                        };
+                        unsafe {
+                            R::free_components(&components, vec_length, identifier.iter());
+                        }
+
+                        return Err(de::Error::invalid_length(i, &self));
                     }
                 }
 
-                // At this point we know the deserialization was successful, so ownership of the
-                // EntityIdentifier Vec is transferred to the Archetype.
-                let mut entity_identifiers = ManuallyDrop::new(entity_identifiers);
-
                 Ok(unsafe {
-                    Archetype::from_raw_parts(
-                        identifier,
-                        (
-                            entity_identifiers.as_mut_ptr(),
-                            entity_identifiers.capacity(),
-                        ),
-                        components,
-                        length,
-                    )
+                    Archetype::from_raw_parts(identifier, entity_identifiers, components, length)
                 })
             }
         }

--- a/src/internal/archetype/impl_serde.rs
+++ b/src/internal/archetype/impl_serde.rs
@@ -351,9 +351,12 @@ where
 
                 let components_len = unsafe { self.0.identifier.iter() }.filter(|b| *b).count();
                 let mut components = Vec::with_capacity(components_len);
-                for _ in 0..components_len {
-                    let mut v = ManuallyDrop::new(Vec::new());
-                    components.push((v.as_mut_ptr(), v.capacity()));
+                unsafe {
+                    R::new_components_with_capacity(
+                        &mut components,
+                        self.0.length,
+                        self.0.identifier.iter(),
+                    )
                 }
                 let mut vec_length = 0;
 

--- a/src/internal/archetype/impl_serde.rs
+++ b/src/internal/archetype/impl_serde.rs
@@ -421,7 +421,11 @@ where
                         )
                     };
                     unsafe {
-                        R::try_free_components(&components, self.0.length, self.0.identifier.iter());
+                        R::try_free_components(
+                            &components,
+                            self.0.length,
+                            self.0.identifier.iter(),
+                        );
                     }
 
                     return Err(unsafe { result.unwrap_err_unchecked() });
@@ -439,10 +443,7 @@ where
         }
 
         deserializer.deserialize_tuple(
-            unsafe { self.identifier.iter() }
-                .filter(|b| *b)
-                .count()
-                + 1,
+            unsafe { self.identifier.iter() }.filter(|b| *b).count() + 1,
             DeserializeColumnsVisitor(self),
         )
     }
@@ -490,7 +491,8 @@ where
 
                     identifier,
                     length,
-                })?.ok_or_else(|| de::Error::invalid_length(2, &self))
+                })?
+                .ok_or_else(|| de::Error::invalid_length(2, &self))
             }
         }
 

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -6,6 +6,8 @@ mod impl_eq;
 mod impl_serde;
 
 pub(crate) use identifier::{Identifier, IdentifierBuffer, IdentifierIterator};
+#[cfg(feature = "serde")]
+pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
 
 use crate::{
     component::Component,

--- a/src/internal/entity_allocator/mod.rs
+++ b/src/internal/entity_allocator/mod.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "serde")]
-pub(crate) mod impl_serde;
+mod impl_serde;
+
+#[cfg(feature = "serde")]
+pub(crate) use impl_serde::DeserializeEntityAllocator;
 
 use crate::{
     entity::EntityIdentifier,

--- a/src/internal/registry/serde.rs
+++ b/src/internal/registry/serde.rs
@@ -6,12 +6,7 @@ use crate::{
     },
     registry::{NullRegistry, Registry},
 };
-use ::serde::{
-    de,
-    de::SeqAccess,
-    ser::{SerializeSeq, SerializeTuple},
-    Deserialize, Serialize,
-};
+use ::serde::{de, de::SeqAccess, ser::SerializeTuple, Deserialize, Serialize};
 use alloc::{format, vec::Vec};
 use core::{any::type_name, mem::ManuallyDrop};
 
@@ -19,12 +14,12 @@ pub trait RegistrySerialize: Registry {
     unsafe fn serialize_components_by_column<R, S>(
         components: &[(*mut u8, usize)],
         length: usize,
-        seq: &mut S,
+        tuple: &mut S,
         identifier_iter: impl archetype::IdentifierIterator<R>,
     ) -> Result<(), S::Error>
     where
         R: Registry,
-        S: SerializeSeq;
+        S: SerializeTuple;
 
     unsafe fn serialize_components_by_row<R, S>(
         components: &[(*mut u8, usize)],
@@ -42,12 +37,12 @@ impl RegistrySerialize for NullRegistry {
     unsafe fn serialize_components_by_column<R, S>(
         _components: &[(*mut u8, usize)],
         _length: usize,
-        _seq: &mut S,
+        _tuple: &mut S,
         _identifier_iter: impl archetype::IdentifierIterator<R>,
     ) -> Result<(), S::Error>
     where
         R: Registry,
-        S: SerializeSeq,
+        S: SerializeTuple,
     {
         Ok(())
     }
@@ -75,16 +70,16 @@ where
     unsafe fn serialize_components_by_column<R_, S>(
         mut components: &[(*mut u8, usize)],
         length: usize,
-        seq: &mut S,
+        tuple: &mut S,
         mut identifier_iter: impl archetype::IdentifierIterator<R_>,
     ) -> Result<(), S::Error>
     where
         R_: Registry,
-        S: SerializeSeq,
+        S: SerializeTuple,
     {
         if identifier_iter.next().unwrap_unchecked() {
             let component_column = components.get_unchecked(0);
-            seq.serialize_element(&SerializeColumn(&ManuallyDrop::new(
+            tuple.serialize_element(&SerializeColumn(&ManuallyDrop::new(
                 Vec::<C>::from_raw_parts(
                     component_column.0.cast::<C>(),
                     length,
@@ -95,7 +90,7 @@ where
             components = components.get_unchecked(1..);
         }
 
-        R::serialize_components_by_column(components, length, seq, identifier_iter)
+        R::serialize_components_by_column(components, length, tuple, identifier_iter)
     }
 
     unsafe fn serialize_components_by_row<R_, S>(

--- a/src/public/world/impl_serde.rs
+++ b/src/public/world/impl_serde.rs
@@ -1,7 +1,6 @@
 use crate::{
     internal::{
-        archetypes::Archetypes,
-        entity_allocator::{impl_serde::SerializedEntityAllocator, EntityAllocator},
+        entity_allocator::DeserializeEntityAllocator,
         registry::{RegistryDeserialize, RegistrySerialize},
     },
     World,
@@ -9,8 +8,8 @@ use crate::{
 use core::{fmt, marker::PhantomData};
 use serde::{
     de,
-    de::{MapAccess, SeqAccess, Visitor},
-    ser::SerializeStruct,
+    de::{SeqAccess, Visitor},
+    ser::SerializeTuple,
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
@@ -22,10 +21,10 @@ where
     where
         S: Serializer,
     {
-        let mut r#struct = serializer.serialize_struct("World", 2)?;
-        r#struct.serialize_field("archetypes", &self.archetypes)?;
-        r#struct.serialize_field("entity_allocator", &self.entity_allocator)?;
-        r#struct.end()
+        let mut tuple = serializer.serialize_tuple(2)?;
+        tuple.serialize_element(&self.archetypes)?;
+        tuple.serialize_element(&self.entity_allocator)?;
+        tuple.end()
     }
 }
 
@@ -37,51 +36,6 @@ where
     where
         D: Deserializer<'de>,
     {
-        enum Field {
-            Archetypes,
-            EntityAllocator,
-        }
-
-        impl<'de> Deserialize<'de> for Field {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: Deserializer<'de>,
-            {
-                struct FieldVisitor;
-
-                impl<'de> Visitor<'de> for FieldVisitor {
-                    type Value = Field;
-
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                        formatter.write_str("`archetypes` or `entity_allocator`")
-                    }
-
-                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
-                    where
-                        E: de::Error,
-                    {
-                        match value {
-                            "archetypes" => Ok(Field::Archetypes),
-                            "entity_allocator" => Ok(Field::EntityAllocator),
-                            _ => Err(de::Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-
-                deserializer.deserialize_identifier(FieldVisitor)
-            }
-        }
-
-        struct SerializedWorld<'de, R>
-        where
-            R: RegistryDeserialize<'de>,
-        {
-            archetypes: Archetypes<R>,
-            serialized_entity_allocator: SerializedEntityAllocator,
-
-            lifetime: PhantomData<&'de ()>,
-        }
-
         struct WorldVisitor<'de, R>
         where
             R: RegistryDeserialize<'de>,
@@ -93,7 +47,7 @@ where
         where
             R: RegistryDeserialize<'de>,
         {
-            type Value = SerializedWorld<'de, R>;
+            type Value = World<R>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("serialized World")
@@ -106,67 +60,20 @@ where
                 let archetypes = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let serialized_entity_allocator = seq
-                    .next_element()?
+                let entity_allocator = seq
+                    .next_element_seed(DeserializeEntityAllocator {
+                        archetypes: &archetypes,
+                    })?
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                Ok(SerializedWorld {
+                Ok(World::from_raw_parts(
                     archetypes,
-                    serialized_entity_allocator,
-
-                    lifetime: PhantomData,
-                })
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
-            where
-                V: MapAccess<'de>,
-            {
-                let mut archetypes = None;
-                let mut entity_allocator = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Archetypes => {
-                            if archetypes.is_some() {
-                                return Err(de::Error::duplicate_field("archetypes"));
-                            }
-                            archetypes = Some(map.next_value()?);
-                        }
-                        Field::EntityAllocator => {
-                            if entity_allocator.is_some() {
-                                return Err(de::Error::duplicate_field("entity_allocator"));
-                            }
-                            entity_allocator = Some(map.next_value()?);
-                        }
-                    }
-                }
-                Ok(SerializedWorld {
-                    archetypes: archetypes.ok_or_else(|| de::Error::missing_field("archetypes"))?,
-                    serialized_entity_allocator: entity_allocator
-                        .ok_or_else(|| de::Error::missing_field("archetypes"))?,
-
-                    lifetime: PhantomData,
-                })
+                    entity_allocator,
+                ))
             }
         }
 
-        const FIELDS: &[&str] = &["archetypes", "entity_allocator"];
-        let serialized_world = deserializer.deserialize_struct(
-            "World",
-            FIELDS,
-            WorldVisitor::<R> {
-                registry: PhantomData,
-            },
-        )?;
-        // Construct the full entity allocator.
-        let entity_allocator = EntityAllocator::from_serialized_parts::<D>(
-            serialized_world.serialized_entity_allocator,
-            &serialized_world.archetypes,
-            PhantomData,
-            PhantomData,
-        )?;
-        Ok(World::from_raw_parts(
-            serialized_world.archetypes,
-            entity_allocator,
-        ))
+        deserializer.deserialize_tuple(2, WorldVisitor::<R> {
+            registry: PhantomData,
+        })
     }
 }


### PR DESCRIPTION
This PR provides a human-readable `serde` implementation alongside the machine-readable one. Prior to this, human-readable (de)serialization just led to a `todo!()` panic.

Human-readable `serde` is used by certain serialization formats (such as `ron`), as opposed to machine-readable formats (like `bincode`). The main difference here is that human-readable serialization of `Archetype`s is row-wise, while machine-readable serialization of `Archetype`s is column-wise. 