### PR TITLE
Add trait implementations for Null types

### DIFF
--- a/src/internal/entity_allocator/mod.rs
+++ b/src/internal/entity_allocator/mod.rs
@@ -4,11 +4,7 @@ mod impl_serde;
 #[cfg(feature = "serde")]
 pub(crate) use impl_serde::DeserializeEntityAllocator;
 
-use crate::{
-    entity::EntityIdentifier,
-    internal::archetype,
-    registry::Registry,
-};
+use crate::{entity::EntityIdentifier, internal::archetype, registry::Registry};
 use alloc::{collections::VecDeque, vec::Vec};
 use core::{fmt, fmt::Debug, iter::ExactSizeIterator};
 

--- a/src/internal/entity_allocator/mod.rs
+++ b/src/internal/entity_allocator/mod.rs
@@ -6,10 +6,7 @@ pub(crate) use impl_serde::DeserializeEntityAllocator;
 
 use crate::{
     entity::EntityIdentifier,
-    internal::{
-        archetype,
-        registry::{RegistryDebug, RegistryPartialEq},
-    },
+    internal::archetype,
     registry::Registry,
 };
 use alloc::{collections::VecDeque, vec::Vec};
@@ -48,7 +45,7 @@ impl<R> Copy for Location<R> where R: Registry {}
 
 impl<R> Debug for Location<R>
 where
-    R: RegistryDebug,
+    R: Registry,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Location")
@@ -60,7 +57,7 @@ where
 
 impl<R> PartialEq for Location<R>
 where
-    R: RegistryPartialEq,
+    R: Registry,
 {
     fn eq(&self, other: &Self) -> bool {
         self.identifier == other.identifier && self.index == other.index
@@ -112,7 +109,7 @@ where
 
 impl<R> Debug for Slot<R>
 where
-    R: RegistryDebug,
+    R: Registry,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Slot")
@@ -124,7 +121,7 @@ where
 
 impl<R> PartialEq for Slot<R>
 where
-    R: RegistryPartialEq,
+    R: Registry,
 {
     fn eq(&self, other: &Self) -> bool {
         self.generation == other.generation && self.location == other.location
@@ -231,7 +228,7 @@ where
 
 impl<R> Debug for EntityAllocator<R>
 where
-    R: RegistryDebug,
+    R: Registry,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EntityAllocator")
@@ -243,7 +240,7 @@ where
 
 impl<R> PartialEq for EntityAllocator<R>
 where
-    R: RegistryPartialEq,
+    R: Registry,
 {
     fn eq(&self, other: &Self) -> bool {
         self.slots == other.slots && self.free == other.free

--- a/src/public/entities.rs
+++ b/src/public/entities.rs
@@ -4,6 +4,48 @@ use alloc::vec::Vec;
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullEntities;
 
+#[cfg(feature = "serde")]
+mod impl_serde {
+    use crate::entities::NullEntities;
+    use core::fmt;
+    use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+    impl Serialize for NullEntities {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_unit_struct("NullEntities")
+        }
+    }
+
+    impl<'de> Deserialize<'de> for NullEntities {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct NullEntitiesVisitor;
+
+            impl<'de> Visitor<'de> for NullEntitiesVisitor {
+                type Value = NullEntities;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("struct NullEntities")
+                }
+
+                fn visit_unit<E>(self) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    Ok(NullEntities)
+                }
+            }
+
+            deserializer.deserialize_unit_struct("NullEntities", NullEntitiesVisitor)
+        }
+    }
+}
+
 pub trait Entities: EntitiesSeal {}
 
 impl Entities for NullEntities {}

--- a/src/public/entities.rs
+++ b/src/public/entities.rs
@@ -1,6 +1,7 @@
 use crate::{component::Component, internal::entities::EntitiesSeal};
 use alloc::vec::Vec;
 
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullEntities;
 
 pub trait Entities: EntitiesSeal {}

--- a/src/public/entity/mod.rs
+++ b/src/public/entity/mod.rs
@@ -8,6 +8,48 @@ use core::any::Any;
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullEntity;
 
+#[cfg(feature = "serde")]
+mod impl_serde {
+    use crate::entity::NullEntity;
+    use core::fmt;
+    use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+    impl Serialize for NullEntity {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_unit_struct("NullEntity")
+        }
+    }
+
+    impl<'de> Deserialize<'de> for NullEntity {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct NullEntityVisitor;
+
+            impl<'de> Visitor<'de> for NullEntityVisitor {
+                type Value = NullEntity;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("struct NullEntity")
+                }
+
+                fn visit_unit<E>(self) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    Ok(NullEntity)
+                }
+            }
+
+            deserializer.deserialize_unit_struct("NullEntity", NullEntityVisitor)
+        }
+    }
+}
+
 pub trait Entity: EntitySeal + Any {}
 
 impl Entity for NullEntity {}

--- a/src/public/entity/mod.rs
+++ b/src/public/entity/mod.rs
@@ -5,6 +5,7 @@ pub use identifier::EntityIdentifier;
 use crate::{component::Component, internal::entity::EntitySeal};
 use core::any::Any;
 
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullEntity;
 
 pub trait Entity: EntitySeal + Any {}

--- a/src/public/query/result.rs
+++ b/src/public/query/result.rs
@@ -1,6 +1,48 @@
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullResult;
 
+#[cfg(feature = "serde")]
+mod impl_serde {
+    use crate::query::result::NullResult;
+    use core::fmt;
+    use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+    impl Serialize for NullResult {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_unit_struct("NullResult")
+        }
+    }
+
+    impl<'de> Deserialize<'de> for NullResult {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct NullResultVisitor;
+
+            impl<'de> Visitor<'de> for NullResultVisitor {
+                type Value = NullResult;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("struct NullResult")
+                }
+
+                fn visit_unit<E>(self) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    Ok(NullResult)
+                }
+            }
+
+            deserializer.deserialize_unit_struct("NullResult", NullResultVisitor)
+        }
+    }
+}
+
 #[macro_export]
 macro_rules! result {
     () => {

--- a/src/public/query/result.rs
+++ b/src/public/query/result.rs
@@ -1,4 +1,4 @@
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullResult;
 
 #[macro_export]

--- a/src/public/query/view.rs
+++ b/src/public/query/view.rs
@@ -17,6 +17,7 @@ impl<'a, C> View<'a> for Option<&mut C> where C: Component {}
 
 impl<'a> View<'a> for EntityIdentifier {}
 
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullViews;
 
 pub trait Views<'a>: Filter + ViewsSeal<'a> {}

--- a/src/public/query/view.rs
+++ b/src/public/query/view.rs
@@ -20,6 +20,48 @@ impl<'a> View<'a> for EntityIdentifier {}
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullViews;
 
+#[cfg(feature = "serde")]
+mod impl_serde {
+    use crate::query::view::NullViews;
+    use core::fmt;
+    use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+    impl Serialize for NullViews {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_unit_struct("NullViews")
+        }
+    }
+
+    impl<'de> Deserialize<'de> for NullViews {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct NullViewsVisitor;
+
+            impl<'de> Visitor<'de> for NullViewsVisitor {
+                type Value = NullViews;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("struct NullViews")
+                }
+
+                fn visit_unit<E>(self) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    Ok(NullViews)
+                }
+            }
+
+            deserializer.deserialize_unit_struct("NullViews", NullViewsVisitor)
+        }
+    }
+}
+
 pub trait Views<'a>: Filter + ViewsSeal<'a> {}
 
 impl<'a> Views<'a> for NullViews {}

--- a/src/public/registry.rs
+++ b/src/public/registry.rs
@@ -3,6 +3,48 @@ use crate::{component::Component, internal::registry::RegistrySeal};
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullRegistry;
 
+#[cfg(feature = "serde")]
+mod impl_serde {
+    use crate::registry::NullRegistry;
+    use core::fmt;
+    use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+    impl Serialize for NullRegistry {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_unit_struct("NullRegistry")
+        }
+    }
+
+    impl<'de> Deserialize<'de> for NullRegistry {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct NullRegistryVisitor;
+
+            impl<'de> Visitor<'de> for NullRegistryVisitor {
+                type Value = NullRegistry;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("struct NullRegistry")
+                }
+
+                fn visit_unit<E>(self) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    Ok(NullRegistry)
+                }
+            }
+
+            deserializer.deserialize_unit_struct("NullRegistry", NullRegistryVisitor)
+        }
+    }
+}
+
 pub trait Registry: RegistrySeal {}
 
 impl Registry for NullRegistry {}

--- a/src/public/registry.rs
+++ b/src/public/registry.rs
@@ -1,5 +1,6 @@
 use crate::{component::Component, internal::registry::RegistrySeal};
 
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NullRegistry;
 
 pub trait Registry: RegistrySeal {}


### PR DESCRIPTION
Adds several standard trait implementations to the various null types to improve interoperability of the public API. Additionally, this PR relaxes some unnecessary trait bounds on the `EntityAllocator`.