### PR TITLE
Improve thread safety of `World`

### DIFF
--- a/src/internal/entity_allocator/impl_serde.rs
+++ b/src/internal/entity_allocator/impl_serde.rs
@@ -133,12 +133,7 @@ where
                 let free = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                EntityAllocator::from_serialized_parts(
-                    length,
-                    free,
-                    self.archetypes,
-                    PhantomData,
-                )
+                EntityAllocator::from_serialized_parts(length, free, self.archetypes, PhantomData)
             }
 
             fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>

--- a/src/internal/registry/mod.rs
+++ b/src/internal/registry/mod.rs
@@ -5,12 +5,14 @@ mod send;
 #[cfg(feature = "serde")]
 mod serde;
 mod storage;
+mod sync;
 
 #[cfg(feature = "serde")]
 pub(crate) use self::serde::{RegistryDeserialize, RegistrySerialize};
 pub(crate) use debug::RegistryDebug;
 pub(crate) use eq::{RegistryEq, RegistryPartialEq};
 pub(crate) use send::RegistrySend;
+pub(crate) use sync::RegistrySync;
 
 use crate::{component::Component, registry::NullRegistry};
 use length::RegistryLength;

--- a/src/internal/registry/mod.rs
+++ b/src/internal/registry/mod.rs
@@ -1,6 +1,7 @@
 mod debug;
 mod eq;
 mod length;
+mod send;
 #[cfg(feature = "serde")]
 mod serde;
 mod storage;
@@ -9,6 +10,7 @@ mod storage;
 pub(crate) use self::serde::{RegistryDeserialize, RegistrySerialize};
 pub(crate) use debug::RegistryDebug;
 pub(crate) use eq::{RegistryEq, RegistryPartialEq};
+pub(crate) use send::RegistrySend;
 
 use crate::{component::Component, registry::NullRegistry};
 use length::RegistryLength;

--- a/src/internal/registry/send.rs
+++ b/src/internal/registry/send.rs
@@ -1,7 +1,15 @@
-use crate::{component::Component, registry::{NullRegistry, Registry}};
+use crate::{
+    component::Component,
+    registry::{NullRegistry, Registry},
+};
 
 pub trait RegistrySend: Registry {}
 
 impl RegistrySend for NullRegistry {}
 
-impl<C, R> RegistrySend for (C, R) where C: Component + Send, R: RegistrySend {}
+impl<C, R> RegistrySend for (C, R)
+where
+    C: Component + Send,
+    R: RegistrySend,
+{
+}

--- a/src/internal/registry/send.rs
+++ b/src/internal/registry/send.rs
@@ -1,0 +1,7 @@
+use crate::{component::Component, registry::{NullRegistry, Registry}};
+
+pub trait RegistrySend: Registry {}
+
+impl RegistrySend for NullRegistry {}
+
+impl<C, R> RegistrySend for (C, R) where C: Component + Send, R: RegistrySend {}

--- a/src/internal/registry/sync.rs
+++ b/src/internal/registry/sync.rs
@@ -1,7 +1,15 @@
-use crate::{component::Component, registry::{NullRegistry, Registry}};
+use crate::{
+    component::Component,
+    registry::{NullRegistry, Registry},
+};
 
 pub trait RegistrySync: Registry {}
 
 impl RegistrySync for NullRegistry {}
 
-impl<C, R> RegistrySync for (C, R) where C: Component + Sync, R: RegistrySync {}
+impl<C, R> RegistrySync for (C, R)
+where
+    C: Component + Sync,
+    R: RegistrySync,
+{
+}

--- a/src/internal/registry/sync.rs
+++ b/src/internal/registry/sync.rs
@@ -1,0 +1,7 @@
+use crate::{component::Component, registry::{NullRegistry, Registry}};
+
+pub trait RegistrySync: Registry {}
+
+impl RegistrySync for NullRegistry {}
+
+impl<C, R> RegistrySync for (C, R) where C: Component + Sync, R: RegistrySync {}

--- a/src/public/world/impl_send.rs
+++ b/src/public/world/impl_send.rs
@@ -1,3 +1,3 @@
-use crate::{registry::Registry, world::World};
+use crate::{internal::registry::RegistrySend, world::World};
 
-unsafe impl<R> Send for World<R> where R: Registry {}
+unsafe impl<R> Send for World<R> where R: RegistrySend {}

--- a/src/public/world/impl_sync.rs
+++ b/src/public/world/impl_sync.rs
@@ -1,3 +1,3 @@
-use crate::{registry::Registry, world::World};
+use crate::{internal::registry::RegistrySync, world::World};
 
-unsafe impl<R> Sync for World<R> where R: Registry {}
+unsafe impl<R> Sync for World<R> where R: RegistrySync {}


### PR DESCRIPTION
This PR implements both `Send` and `Sync` for `World<R>` only if `R` also implements `Send` and `Sync`. This ensures that the stored components will not cause thread safety issues.