### PR TITLE
Cleaning up public API

### DIFF
--- a/src/internal/archetype/impl_debug.rs
+++ b/src/internal/archetype/impl_debug.rs
@@ -1,5 +1,5 @@
 use crate::{
-    entity::EntityIdentifier,
+    entity,
     internal::{archetype, archetype::Archetype, registry::RegistryDebug},
 };
 use alloc::vec::Vec;
@@ -33,7 +33,7 @@ struct Row<R>
 where
     R: RegistryDebug,
 {
-    identifier: EntityIdentifier,
+    identifier: entity::Identifier,
     components: Components<R>,
 }
 

--- a/src/internal/archetype/impl_serde.rs
+++ b/src/internal/archetype/impl_serde.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::Component,
-    entity::EntityIdentifier,
+    entity,
     internal::{
         archetype,
         archetype::{Archetype, IdentifierBuffer},
@@ -208,7 +208,7 @@ where
 
     identifier: archetype::Identifier<R>,
 
-    entity_identifiers: &'a mut (*mut EntityIdentifier, usize),
+    entity_identifiers: &'a mut (*mut entity::Identifier, usize),
     components: &'a mut [(*mut u8, usize)],
     length: usize,
 }
@@ -219,7 +219,7 @@ where
 {
     unsafe fn new(
         identifier: archetype::Identifier<R>,
-        entity_identifiers: &'a mut (*mut EntityIdentifier, usize),
+        entity_identifiers: &'a mut (*mut entity::Identifier, usize),
         components: &'a mut [(*mut u8, usize)],
         length: usize,
     ) -> Self {
@@ -257,7 +257,7 @@ where
             type Value = ();
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("row of (EntityIdentifier, components...)")
+                formatter.write_str("row of (entity::Identifier, components...)")
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
@@ -333,7 +333,7 @@ where
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 write!(
                     formatter,
-                    "{} rows of (EntityIdentifier, components...)",
+                    "{} rows of (entity::Identifier, components...)",
                     self.0.length
                 )
             }

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     entities::{Entities, EntitiesIter},
     entity::{Entity, EntityIdentifier},
     internal::entity_allocator::{EntityAllocator, Location},
-    query::Views,
+    query::view::Views,
     registry::Registry,
 };
 use alloc::vec::Vec;

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -121,7 +121,7 @@ where
         &mut self,
         entities: entities::Batch<E>,
         entity_allocator: &mut EntityAllocator<R>,
-    ) -> impl Iterator<Item = entity::Identifier>
+    ) -> Vec<entity::Identifier>
     where
         E: Entities,
     {
@@ -151,7 +151,7 @@ where
 
         self.length += component_len;
 
-        entity_identifiers.into_iter()
+        entity_identifiers
     }
 
     pub(crate) fn view<'a, V>(&mut self) -> V::Results

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -12,7 +12,8 @@ pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
 use crate::{
     component::Component,
     entities::{Entities, EntitiesIter},
-    entity::{Entity, EntityIdentifier},
+    entity,
+    entity::Entity,
     internal::entity_allocator::{EntityAllocator, Location},
     query::view::Views,
     registry::Registry,
@@ -32,7 +33,7 @@ where
 {
     identifier_buffer: IdentifierBuffer<R>,
 
-    entity_identifiers: (*mut EntityIdentifier, usize),
+    entity_identifiers: (*mut entity::Identifier, usize),
     components: Vec<(*mut u8, usize)>,
     length: usize,
 
@@ -45,7 +46,7 @@ where
 {
     pub(crate) unsafe fn from_raw_parts(
         identifier_buffer: IdentifierBuffer<R>,
-        entity_identifiers: (*mut EntityIdentifier, usize),
+        entity_identifiers: (*mut entity::Identifier, usize),
         components: Vec<(*mut u8, usize)>,
         length: usize,
     ) -> Self {
@@ -88,7 +89,7 @@ where
         &mut self,
         entity: E,
         entity_allocator: &mut EntityAllocator<R>,
-    ) -> EntityIdentifier
+    ) -> entity::Identifier
     where
         E: Entity,
     {
@@ -119,7 +120,7 @@ where
         &mut self,
         entities: EntitiesIter<E>,
         entity_allocator: &mut EntityAllocator<R>,
-    ) -> impl Iterator<Item = EntityIdentifier>
+    ) -> impl Iterator<Item = entity::Identifier>
     where
         E: Entities,
     {
@@ -217,7 +218,7 @@ where
         &mut self,
         index: usize,
         entity_allocator: &mut EntityAllocator<R>,
-    ) -> (EntityIdentifier, Vec<u8>) {
+    ) -> (entity::Identifier, Vec<u8>) {
         let size_of_components = self.identifier_buffer.size_of_components();
         let mut bytes = Vec::with_capacity(size_of_components);
         R::pop_component_row(
@@ -250,7 +251,7 @@ where
 
     pub(crate) unsafe fn push_from_buffer_and_component<C>(
         &mut self,
-        entity_identifier: EntityIdentifier,
+        entity_identifier: entity::Identifier,
         buffer: Vec<u8>,
         component: C,
     ) -> usize
@@ -283,7 +284,7 @@ where
 
     pub(crate) unsafe fn push_from_buffer_skipping_component<C>(
         &mut self,
-        entity_identifier: EntityIdentifier,
+        entity_identifier: entity::Identifier,
         buffer: Vec<u8>,
     ) -> usize
     where
@@ -318,7 +319,7 @@ where
     }
 
     #[cfg(feature = "serde")]
-    pub(crate) fn entity_identifiers(&self) -> impl Iterator<Item = &EntityIdentifier> {
+    pub(crate) fn entity_identifiers(&self) -> impl Iterator<Item = &entity::Identifier> {
         unsafe { slice::from_raw_parts(self.entity_identifiers.0, self.length) }.iter()
     }
 }

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -11,7 +11,8 @@ pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
 
 use crate::{
     component::Component,
-    entities::{Entities, EntitiesIter},
+    entities,
+    entities::Entities,
     entity,
     entity::Entity,
     internal::entity_allocator::{EntityAllocator, Location},
@@ -118,7 +119,7 @@ where
 
     pub(crate) unsafe fn extend<E>(
         &mut self,
-        entities: EntitiesIter<E>,
+        entities: entities::Batch<E>,
         entity_allocator: &mut EntityAllocator<R>,
     ) -> impl Iterator<Item = entity::Identifier>
     where

--- a/src/internal/archetypes/mod.rs
+++ b/src/internal/archetypes/mod.rs
@@ -4,13 +4,15 @@ mod impl_eq;
 mod impl_serde;
 mod iter;
 
+pub(crate) use iter::IterMut;
+
 use crate::{
     internal::{archetype, archetype::Archetype},
     registry::Registry,
 };
 use core::hash::{BuildHasher, Hash, Hasher};
 use hashbrown::raw::RawTable;
-use iter::{Iter, IterMut};
+use iter::Iter;
 
 pub(crate) struct Archetypes<R>
 where

--- a/src/internal/entities/length.rs
+++ b/src/internal/entities/length.rs
@@ -1,4 +1,4 @@
-use crate::{component::Component, entities::NullEntities};
+use crate::{component::Component, entities::Null};
 use alloc::vec::Vec;
 
 pub trait EntitiesLength {
@@ -7,7 +7,7 @@ pub trait EntitiesLength {
     fn check_len_against(&self, len: usize) -> bool;
 }
 
-impl EntitiesLength for NullEntities {
+impl EntitiesLength for Null {
     fn component_len(&self) -> usize {
         0
     }

--- a/src/internal/entities/mod.rs
+++ b/src/internal/entities/mod.rs
@@ -1,14 +1,14 @@
 mod length;
 mod storage;
 
-use crate::{component::Component, entities::NullEntities};
+use crate::{component::Component, entities::Null};
 use alloc::vec::Vec;
 use length::EntitiesLength;
 use storage::EntitiesStorage;
 
 pub trait EntitiesSeal: EntitiesLength + EntitiesStorage {}
 
-impl EntitiesSeal for NullEntities {}
+impl EntitiesSeal for Null {}
 
 impl<C, E> EntitiesSeal for (Vec<C>, E)
 where

--- a/src/internal/entities/storage.rs
+++ b/src/internal/entities/storage.rs
@@ -1,4 +1,4 @@
-use crate::{component::Component, entities::NullEntities};
+use crate::{component::Component, entities::Null};
 use alloc::vec::Vec;
 use core::{any::TypeId, mem::ManuallyDrop};
 use hashbrown::HashMap;
@@ -14,7 +14,7 @@ pub trait EntitiesStorage {
     unsafe fn to_key(key: &mut [u8], component_map: &HashMap<TypeId, usize>);
 }
 
-impl EntitiesStorage for NullEntities {
+impl EntitiesStorage for Null {
     unsafe fn extend_components(
         self,
         _component_map: &HashMap<TypeId, usize>,

--- a/src/internal/entity/mod.rs
+++ b/src/internal/entity/mod.rs
@@ -1,11 +1,11 @@
 mod storage;
 
-use crate::{component::Component, entity::NullEntity};
+use crate::{component::Component, entity::Null};
 use storage::EntityStorage;
 
 pub trait EntitySeal: EntityStorage {}
 
-impl EntitySeal for NullEntity {}
+impl EntitySeal for Null {}
 
 impl<C, E> EntitySeal for (C, E)
 where

--- a/src/internal/entity/storage.rs
+++ b/src/internal/entity/storage.rs
@@ -1,4 +1,4 @@
-use crate::{component::Component, entity::NullEntity};
+use crate::{component::Component, entity::Null};
 use alloc::vec::Vec;
 use core::{any::TypeId, mem::ManuallyDrop};
 use hashbrown::HashMap;
@@ -14,7 +14,7 @@ pub trait EntityStorage {
     unsafe fn to_key(key: &mut [u8], component_map: &HashMap<TypeId, usize>);
 }
 
-impl EntityStorage for NullEntity {
+impl EntityStorage for Null {
     unsafe fn push_components(
         self,
         _component_map: &HashMap<TypeId, usize>,

--- a/src/internal/entity_allocator/impl_serde.rs
+++ b/src/internal/entity_allocator/impl_serde.rs
@@ -1,5 +1,5 @@
 use crate::{
-    entity::EntityIdentifier,
+    entity,
     internal::{
         archetypes::Archetypes,
         entity_allocator::{EntityAllocator, Location, Slot},
@@ -29,7 +29,7 @@ where
     {
         let mut seq = serializer.serialize_seq(Some(self.0.free.len()))?;
         for index in &self.0.free {
-            seq.serialize_element(&EntityIdentifier {
+            seq.serialize_element(&entity::Identifier {
                 index: *index,
                 generation: unsafe { self.0.slots.get_unchecked(*index) }.generation,
             })?;
@@ -184,7 +184,7 @@ where
 {
     fn from_serialized_parts<E>(
         length: usize,
-        free: Vec<EntityIdentifier>,
+        free: Vec<entity::Identifier>,
         archetypes: &Archetypes<R>,
         _deserializer: PhantomData<E>,
     ) -> Result<Self, E>

--- a/src/internal/query/filter.rs
+++ b/src/internal/query/filter.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::Component,
-    entity::EntityIdentifier,
+    entity,
     query::{filter::{And, Filter, Has, None, Not, Or}, view, view::{View, Views}},
 };
 use core::any::TypeId;
@@ -93,7 +93,7 @@ where
     }
 }
 
-impl FilterSeal for EntityIdentifier {
+impl FilterSeal for entity::Identifier {
     unsafe fn filter(_key: &[u8], _component_map: &HashMap<TypeId, usize>) -> bool {
         true
     }

--- a/src/internal/query/filter.rs
+++ b/src/internal/query/filter.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::Component,
     entity::EntityIdentifier,
-    query::{And, Filter, Has, None, Not, NullViews, Or, View, Views},
+    query::{filter::{And, Filter, Has, None, Not, Or}, view::{NullViews, View, Views}},
 };
 use core::any::TypeId;
 use hashbrown::HashMap;

--- a/src/internal/query/filter.rs
+++ b/src/internal/query/filter.rs
@@ -1,7 +1,11 @@
 use crate::{
     component::Component,
     entity,
-    query::{filter::{And, Filter, Has, None, Not, Or}, view, view::{View, Views}},
+    query::{
+        filter::{And, Filter, Has, None, Not, Or},
+        view,
+        view::{View, Views},
+    },
 };
 use core::any::TypeId;
 use hashbrown::HashMap;

--- a/src/internal/query/filter.rs
+++ b/src/internal/query/filter.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::Component,
     entity::EntityIdentifier,
-    query::{filter::{And, Filter, Has, None, Not, Or}, view::{NullViews, View, Views}},
+    query::{filter::{And, Filter, Has, None, Not, Or}, view, view::{View, Views}},
 };
 use core::any::TypeId;
 use hashbrown::HashMap;
@@ -99,7 +99,7 @@ impl FilterSeal for EntityIdentifier {
     }
 }
 
-impl FilterSeal for NullViews {
+impl FilterSeal for view::Null {
     unsafe fn filter(_key: &[u8], _component_map: &HashMap<TypeId, usize>) -> bool {
         true
     }

--- a/src/internal/query/mod.rs
+++ b/src/internal/query/mod.rs
@@ -1,5 +1,2 @@
-mod filter;
-mod view;
-
-pub use filter::FilterSeal;
-pub use view::{ViewSeal, ViewsSeal};
+pub(crate) mod filter;
+pub(crate) mod view;

--- a/src/internal/query/view.rs
+++ b/src/internal/query/view.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::Component,
     entity::EntityIdentifier,
-    query::{NullResult, NullViews},
+    query::{result::NullResult, view::NullViews},
 };
 use core::{any::TypeId, iter, slice};
 use either::Either;

--- a/src/internal/query/view.rs
+++ b/src/internal/query/view.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::Component,
-    entity::EntityIdentifier,
+    entity,
     query::{result, view::Null},
 };
 use core::{any::TypeId, iter, slice};
@@ -12,7 +12,7 @@ pub trait ViewSeal<'a> {
 
     unsafe fn view(
         columns: &[(*mut u8, usize)],
-        entity_identifiers: (*mut EntityIdentifier, usize),
+        entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result;
@@ -26,7 +26,7 @@ where
 
     unsafe fn view(
         columns: &[(*mut u8, usize)],
-        _entity_identifiers: (*mut EntityIdentifier, usize),
+        _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
@@ -48,7 +48,7 @@ where
 
     unsafe fn view(
         columns: &[(*mut u8, usize)],
-        _entity_identifiers: (*mut EntityIdentifier, usize),
+        _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
@@ -77,7 +77,7 @@ where
 
     unsafe fn view(
         columns: &[(*mut u8, usize)],
-        _entity_identifiers: (*mut EntityIdentifier, usize),
+        _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
@@ -103,7 +103,7 @@ where
 
     unsafe fn view(
         columns: &[(*mut u8, usize)],
-        _entity_identifiers: (*mut EntityIdentifier, usize),
+        _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
@@ -122,12 +122,12 @@ where
     }
 }
 
-impl<'a> ViewSeal<'a> for EntityIdentifier {
+impl<'a> ViewSeal<'a> for entity::Identifier {
     type Result = iter::Cloned<slice::Iter<'a, Self>>;
 
     unsafe fn view(
         _columns: &[(*mut u8, usize)],
-        entity_identifiers: (*mut EntityIdentifier, usize),
+        entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
         _component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
@@ -142,7 +142,7 @@ pub trait ViewsSeal<'a> {
 
     unsafe fn view(
         columns: &[(*mut u8, usize)],
-        entity_identifiers: (*mut EntityIdentifier, usize),
+        entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Results;
@@ -153,7 +153,7 @@ impl<'a> ViewsSeal<'a> for Null {
 
     unsafe fn view(
         _columns: &[(*mut u8, usize)],
-        _entity_identifiers: (*mut EntityIdentifier, usize),
+        _entity_identifiers: (*mut entity::Identifier, usize),
         _length: usize,
         _component_map: &HashMap<TypeId, usize>,
     ) -> Self::Results {
@@ -170,7 +170,7 @@ where
 
     unsafe fn view(
         columns: &[(*mut u8, usize)],
-        entity_identifiers: (*mut EntityIdentifier, usize),
+        entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Results {

--- a/src/internal/query/view.rs
+++ b/src/internal/query/view.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::Component,
     entity::EntityIdentifier,
-    query::{result, view::NullViews},
+    query::{result, view::Null},
 };
 use core::{any::TypeId, iter, slice};
 use either::Either;
@@ -148,7 +148,7 @@ pub trait ViewsSeal<'a> {
     ) -> Self::Results;
 }
 
-impl<'a> ViewsSeal<'a> for NullViews {
+impl<'a> ViewsSeal<'a> for Null {
     type Results = iter::Repeat<result::Null>;
 
     unsafe fn view(

--- a/src/internal/query/view.rs
+++ b/src/internal/query/view.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::Component,
     entity::EntityIdentifier,
-    query::{result::NullResult, view::NullViews},
+    query::{result, view::NullViews},
 };
 use core::{any::TypeId, iter, slice};
 use either::Either;
@@ -149,7 +149,7 @@ pub trait ViewsSeal<'a> {
 }
 
 impl<'a> ViewsSeal<'a> for NullViews {
-    type Results = iter::Repeat<NullResult>;
+    type Results = iter::Repeat<result::Null>;
 
     unsafe fn view(
         _columns: &[(*mut u8, usize)],
@@ -157,7 +157,7 @@ impl<'a> ViewsSeal<'a> for NullViews {
         _length: usize,
         _component_map: &HashMap<TypeId, usize>,
     ) -> Self::Results {
-        iter::repeat(NullResult)
+        iter::repeat(result::Null)
     }
 }
 

--- a/src/internal/registry/debug.rs
+++ b/src/internal/registry/debug.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::Component,
     internal::archetype,
-    registry::{NullRegistry, Registry},
+    registry::{Null, Registry},
 };
 use alloc::vec::Vec;
 use core::{
@@ -27,7 +27,7 @@ pub trait RegistryDebug: Registry {
         R: Registry;
 }
 
-impl RegistryDebug for NullRegistry {
+impl RegistryDebug for Null {
     unsafe fn extract_component_pointers<R>(
         _index: usize,
         _components: &[(*mut u8, usize)],

--- a/src/internal/registry/eq.rs
+++ b/src/internal/registry/eq.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::Component,
     internal::archetype,
-    registry::{NullRegistry, Registry},
+    registry::{Null, Registry},
 };
 use alloc::vec::Vec;
 use core::mem::ManuallyDrop;
@@ -17,7 +17,7 @@ pub trait RegistryPartialEq: Registry {
         R: Registry;
 }
 
-impl RegistryPartialEq for NullRegistry {
+impl RegistryPartialEq for Null {
     unsafe fn component_eq<R>(
         _components_a: &[(*mut u8, usize)],
         _components_b: &[(*mut u8, usize)],
@@ -71,7 +71,7 @@ where
 
 pub trait RegistryEq: RegistryPartialEq {}
 
-impl RegistryEq for NullRegistry {}
+impl RegistryEq for Null {}
 
 impl<C, R> RegistryEq for (C, R)
 where

--- a/src/internal/registry/length.rs
+++ b/src/internal/registry/length.rs
@@ -1,10 +1,10 @@
-use crate::{component::Component, registry::NullRegistry};
+use crate::{component::Component, registry::Null};
 
 pub trait RegistryLength {
     const LEN: usize;
 }
 
-impl RegistryLength for NullRegistry {
+impl RegistryLength for Null {
     const LEN: usize = 0;
 }
 

--- a/src/internal/registry/mod.rs
+++ b/src/internal/registry/mod.rs
@@ -14,13 +14,13 @@ pub(crate) use eq::{RegistryEq, RegistryPartialEq};
 pub(crate) use send::RegistrySend;
 pub(crate) use sync::RegistrySync;
 
-use crate::{component::Component, registry::NullRegistry};
+use crate::{component::Component, registry::Null};
 use length::RegistryLength;
 use storage::RegistryStorage;
 
 pub trait RegistrySeal: RegistryLength + RegistryStorage {}
 
-impl RegistrySeal for NullRegistry {}
+impl RegistrySeal for Null {}
 
 impl<C, R> RegistrySeal for (C, R)
 where

--- a/src/internal/registry/send.rs
+++ b/src/internal/registry/send.rs
@@ -1,11 +1,11 @@
 use crate::{
     component::Component,
-    registry::{NullRegistry, Registry},
+    registry::{Null, Registry},
 };
 
 pub trait RegistrySend: Registry {}
 
-impl RegistrySend for NullRegistry {}
+impl RegistrySend for Null {}
 
 impl<C, R> RegistrySend for (C, R)
 where

--- a/src/internal/registry/serde.rs
+++ b/src/internal/registry/serde.rs
@@ -4,7 +4,7 @@ use crate::{
         archetype,
         archetype::{DeserializeColumn, SerializeColumn},
     },
-    registry::{NullRegistry, Registry},
+    registry::{Null, Registry},
 };
 use ::serde::{de, de::SeqAccess, ser::SerializeTuple, Deserialize, Serialize};
 use alloc::{format, vec::Vec};
@@ -33,7 +33,7 @@ pub trait RegistrySerialize: Registry {
         S: SerializeTuple;
 }
 
-impl RegistrySerialize for NullRegistry {
+impl RegistrySerialize for Null {
     unsafe fn serialize_components_by_column<R, S>(
         _components: &[(*mut u8, usize)],
         _length: usize,
@@ -144,7 +144,7 @@ pub trait RegistryDeserialize<'de>: Registry + 'de {
         V: SeqAccess<'de>;
 }
 
-impl<'de> RegistryDeserialize<'de> for NullRegistry {
+impl<'de> RegistryDeserialize<'de> for Null {
     unsafe fn deserialize_components_by_column<R, V>(
         _components: &mut Vec<(*mut u8, usize)>,
         _length: usize,

--- a/src/internal/registry/storage.rs
+++ b/src/internal/registry/storage.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::Component,
     internal::archetype,
-    registry::{NullRegistry, Registry},
+    registry::{Null, Registry},
 };
 use alloc::vec::Vec;
 use core::{
@@ -94,7 +94,7 @@ pub trait RegistryStorage {
         R: Registry;
 }
 
-impl RegistryStorage for NullRegistry {
+impl RegistryStorage for Null {
     fn create_component_map(_component_map: &mut HashMap<TypeId, usize>, _index: usize) {}
 
     unsafe fn create_component_map_for_key<R>(

--- a/src/internal/registry/sync.rs
+++ b/src/internal/registry/sync.rs
@@ -1,11 +1,11 @@
 use crate::{
     component::Component,
-    registry::{NullRegistry, Registry},
+    registry::{Null, Registry},
 };
 
 pub trait RegistrySync: Registry {}
 
-impl RegistrySync for NullRegistry {}
+impl RegistrySync for Null {}
 
 impl<C, R> RegistrySync for (C, R)
 where

--- a/src/public/entities.rs
+++ b/src/public/entities.rs
@@ -2,53 +2,53 @@ use crate::{component::Component, internal::entities::EntitiesSeal};
 use alloc::vec::Vec;
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct NullEntities;
+pub struct Null;
 
 #[cfg(feature = "serde")]
 mod impl_serde {
-    use crate::entities::NullEntities;
+    use super::Null;
     use core::fmt;
     use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
-    impl Serialize for NullEntities {
+    impl Serialize for Null {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
-            serializer.serialize_unit_struct("NullEntities")
+            serializer.serialize_unit_struct("Null")
         }
     }
 
-    impl<'de> Deserialize<'de> for NullEntities {
+    impl<'de> Deserialize<'de> for Null {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
-            struct NullEntitiesVisitor;
+            struct NullVisitor;
 
-            impl<'de> Visitor<'de> for NullEntitiesVisitor {
-                type Value = NullEntities;
+            impl<'de> Visitor<'de> for NullVisitor {
+                type Value = Null;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("struct NullEntities")
+                    formatter.write_str("struct Null")
                 }
 
                 fn visit_unit<E>(self) -> Result<Self::Value, E>
                 where
                     E: de::Error,
                 {
-                    Ok(NullEntities)
+                    Ok(Null)
                 }
             }
 
-            deserializer.deserialize_unit_struct("NullEntities", NullEntitiesVisitor)
+            deserializer.deserialize_unit_struct("Null", NullVisitor)
         }
     }
 }
 
 pub trait Entities: EntitiesSeal {}
 
-impl Entities for NullEntities {}
+impl Entities for Null {}
 
 impl<C, E> Entities for (Vec<C>, E)
 where
@@ -97,19 +97,19 @@ macro_rules! entities {
     };
     ((); $n:expr) => {
         unsafe {
-            $crate::entities::EntitiesIter::new_unchecked($crate::entities::NullEntities)
+            $crate::entities::EntitiesIter::new_unchecked($crate::entities::Null)
         }
     };
     () => {
         unsafe {
-            $crate::entities::EntitiesIter::new_unchecked($crate::entities::NullEntities)
+            $crate::entities::EntitiesIter::new_unchecked($crate::entities::Null)
         }
     };
     (@cloned ($component:expr $(,$components:expr)* $(,)?); $n:expr) => {
         ($crate::reexports::vec![$component; $n], entities!(@cloned ($($components),*); $n))
     };
     (@cloned (); $n:expr) => {
-        $crate::entities::NullEntities
+        $crate::entities::Null
     };
     (@transpose [$([$($column:expr),*])*] $(($component:expr $(,$components:expr)*  $(,)?)),*) => {
         entities!(@transpose [$([$($column),*])* [$($component),*]] $(($($components),*)),*)
@@ -121,6 +121,6 @@ macro_rules! entities {
         ($crate::reexports::vec![$($column),*], entities!(@as_vec ($(($($columns),*)),*)))
     };
     (@as_vec ()) => {
-        $crate::entities::NullEntities
+        $crate::entities::Null
     };
 }

--- a/src/public/entities.rs
+++ b/src/public/entities.rs
@@ -57,15 +57,14 @@ where
 {
 }
 
-// TODO: Bikeshed this name. Yuck.
-pub struct EntitiesIter<E>
+pub struct Batch<E>
 where
     E: Entities,
 {
     pub(crate) entities: E,
 }
 
-impl<E> EntitiesIter<E>
+impl<E> Batch<E>
 where
     E: Entities,
 {
@@ -83,26 +82,26 @@ where
 macro_rules! entities {
     (($component:expr $(,$components:expr)* $(,)?); $n:expr) => {
         unsafe {
-            $crate::entities::EntitiesIter::new_unchecked(
+            $crate::entities::Batch::new_unchecked(
                 ($crate::reexports::vec![$component; $n], entities!(@cloned ($($components),*); $n))
             )
         }
     };
     ($(($($components:expr),*)),* $(,)?) => {
         unsafe {
-            $crate::entities::EntitiesIter::new_unchecked(
+            $crate::entities::Batch::new_unchecked(
                 entities!(@transpose [] $(($($components),*)),*)
             )
         }
     };
     ((); $n:expr) => {
         unsafe {
-            $crate::entities::EntitiesIter::new_unchecked($crate::entities::Null)
+            $crate::entities::Batch::new_unchecked($crate::entities::Null)
         }
     };
     () => {
         unsafe {
-            $crate::entities::EntitiesIter::new_unchecked($crate::entities::Null)
+            $crate::entities::Batch::new_unchecked($crate::entities::Null)
         }
     };
     (@cloned ($component:expr $(,$components:expr)* $(,)?); $n:expr) => {

--- a/src/public/entity/identifier/impl_serde.rs
+++ b/src/public/entity/identifier/impl_serde.rs
@@ -1,4 +1,4 @@
-use super::EntityIdentifier;
+use super::Identifier;
 use core::fmt;
 use serde::{
     de::{self, MapAccess, SeqAccess, Visitor},
@@ -6,19 +6,19 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-impl Serialize for EntityIdentifier {
+impl Serialize for Identifier {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("EntityIdentifier", 2)?;
+        let mut state = serializer.serialize_struct("Identifier", 2)?;
         state.serialize_field("index", &self.index)?;
         state.serialize_field("generation", &self.generation)?;
         state.end()
     }
 }
 
-impl<'de> Deserialize<'de> for EntityIdentifier {
+impl<'de> Deserialize<'de> for Identifier {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -58,16 +58,16 @@ impl<'de> Deserialize<'de> for EntityIdentifier {
             }
         }
 
-        struct EntityIdentifierVisitor;
+        struct IdentifierVisitor;
 
-        impl<'de> Visitor<'de> for EntityIdentifierVisitor {
-            type Value = EntityIdentifier;
+        impl<'de> Visitor<'de> for IdentifierVisitor {
+            type Value = Identifier;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct EntityIdentifier")
+                formatter.write_str("struct Identifier")
             }
 
-            fn visit_seq<V>(self, mut seq: V) -> Result<EntityIdentifier, V::Error>
+            fn visit_seq<V>(self, mut seq: V) -> Result<Identifier, V::Error>
             where
                 V: SeqAccess<'de>,
             {
@@ -77,10 +77,10 @@ impl<'de> Deserialize<'de> for EntityIdentifier {
                 let generation = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                Ok(EntityIdentifier::new(index, generation))
+                Ok(Identifier::new(index, generation))
             }
 
-            fn visit_map<V>(self, mut map: V) -> Result<EntityIdentifier, V::Error>
+            fn visit_map<V>(self, mut map: V) -> Result<Identifier, V::Error>
             where
                 V: MapAccess<'de>,
             {
@@ -105,18 +105,18 @@ impl<'de> Deserialize<'de> for EntityIdentifier {
                 let index = index.ok_or_else(|| de::Error::missing_field("index"))?;
                 let generation =
                     generation.ok_or_else(|| de::Error::missing_field("generation"))?;
-                Ok(EntityIdentifier::new(index, generation))
+                Ok(Identifier::new(index, generation))
             }
         }
 
         const FIELDS: &[&str] = &["index", "generation"];
-        deserializer.deserialize_struct("EntityIdentifier", FIELDS, EntityIdentifierVisitor)
+        deserializer.deserialize_struct("Identifier", FIELDS, IdentifierVisitor)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::entity::EntityIdentifier;
+    use crate::entity::Identifier;
     use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
 
     #[test]
@@ -127,7 +127,7 @@ mod tests {
             &identifier,
             &[
                 Token::Struct {
-                    name: "EntityIdentifier",
+                    name: "Identifier",
                     len: 2,
                 },
                 Token::String("index"),
@@ -141,10 +141,10 @@ mod tests {
 
     #[test]
     fn deserialize_missing_index() {
-        assert_de_tokens_error::<EntityIdentifier>(
+        assert_de_tokens_error::<Identifier>(
             &[
                 Token::Struct {
-                    name: "EntityIdentifier",
+                    name: "Identifier",
                     len: 1,
                 },
                 Token::String("generation"),
@@ -157,10 +157,10 @@ mod tests {
 
     #[test]
     fn deserialize_missing_generation() {
-        assert_de_tokens_error::<EntityIdentifier>(
+        assert_de_tokens_error::<Identifier>(
             &[
                 Token::Struct {
-                    name: "EntityIdentifier",
+                    name: "Identifier",
                     len: 1,
                 },
                 Token::String("index"),
@@ -173,10 +173,10 @@ mod tests {
 
     #[test]
     fn deserialize_duplicate_index() {
-        assert_de_tokens_error::<EntityIdentifier>(
+        assert_de_tokens_error::<Identifier>(
             &[
                 Token::Struct {
-                    name: "EntityIdentifier",
+                    name: "Identifier",
                     len: 2,
                 },
                 Token::String("index"),
@@ -189,10 +189,10 @@ mod tests {
 
     #[test]
     fn deserialize_duplicate_generation() {
-        assert_de_tokens_error::<EntityIdentifier>(
+        assert_de_tokens_error::<Identifier>(
             &[
                 Token::Struct {
-                    name: "EntityIdentifier",
+                    name: "Identifier",
                     len: 2,
                 },
                 Token::String("generation"),
@@ -205,10 +205,10 @@ mod tests {
 
     #[test]
     fn deserialize_unknown_field() {
-        assert_de_tokens_error::<EntityIdentifier>(
+        assert_de_tokens_error::<Identifier>(
             &[
                 Token::Struct {
-                    name: "EntityIdentifier",
+                    name: "Identifier",
                     len: 2,
                 },
                 Token::String("unknown"),
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn deserialize_from_seq() {
-        let identifier = EntityIdentifier::new(1, 2);
+        let identifier = Identifier::new(1, 2);
 
         assert_de_tokens(
             &identifier,
@@ -234,24 +234,24 @@ mod tests {
 
     #[test]
     fn deserialize_from_seq_no_items() {
-        assert_de_tokens_error::<EntityIdentifier>(
+        assert_de_tokens_error::<Identifier>(
             &[Token::Seq { len: Some(0) }, Token::SeqEnd],
-            "invalid length 0, expected struct EntityIdentifier",
+            "invalid length 0, expected struct Identifier",
         );
     }
 
     #[test]
     fn deserialize_from_seq_missing_item() {
-        assert_de_tokens_error::<EntityIdentifier>(
+        assert_de_tokens_error::<Identifier>(
             &[Token::Seq { len: Some(1) }, Token::U64(1), Token::SeqEnd],
-            "invalid length 1, expected struct EntityIdentifier",
+            "invalid length 1, expected struct Identifier",
         );
     }
 
     #[test]
     #[should_panic(expected = "expected Token::U64(3) but deserialization wants Token::SeqEnd")]
     fn deserialize_from_seq_too_many_items() {
-        assert_de_tokens_error::<EntityIdentifier>(
+        assert_de_tokens_error::<Identifier>(
             &[
                 Token::Seq { len: Some(3) },
                 Token::U64(1),

--- a/src/public/entity/identifier/impl_serde.rs
+++ b/src/public/entity/identifier/impl_serde.rs
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn serialize_deserialize() {
-        let identifier = EntityIdentifier::new(1, 2);
+        let identifier = Identifier::new(1, 2);
 
         assert_tokens(
             &identifier,

--- a/src/public/entity/identifier/mod.rs
+++ b/src/public/entity/identifier/mod.rs
@@ -2,12 +2,12 @@
 mod impl_serde;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct EntityIdentifier {
+pub struct Identifier {
     pub(crate) index: usize,
     pub(crate) generation: u64,
 }
 
-impl EntityIdentifier {
+impl Identifier {
     pub(crate) fn new(index: usize, generation: u64) -> Self {
         Self { index, generation }
     }
@@ -15,18 +15,18 @@ impl EntityIdentifier {
 
 #[cfg(test)]
 mod tests {
-    use crate::entity::EntityIdentifier;
+    use crate::entity::Identifier;
 
     #[test]
     fn new_index() {
-        let identifier = EntityIdentifier::new(1, 2);
+        let identifier = Identifier::new(1, 2);
 
         assert_eq!(identifier.index, 1);
     }
 
     #[test]
     fn new_generation() {
-        let identifier = EntityIdentifier::new(1, 2);
+        let identifier = Identifier::new(1, 2);
 
         assert_eq!(identifier.generation, 2);
     }

--- a/src/public/entity/mod.rs
+++ b/src/public/entity/mod.rs
@@ -1,6 +1,6 @@
 mod identifier;
 
-pub use identifier::EntityIdentifier;
+pub use identifier::Identifier;
 
 use crate::{component::Component, internal::entity::EntitySeal};
 use core::any::Any;

--- a/src/public/entity/mod.rs
+++ b/src/public/entity/mod.rs
@@ -6,53 +6,53 @@ use crate::{component::Component, internal::entity::EntitySeal};
 use core::any::Any;
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct NullEntity;
+pub struct Null;
 
 #[cfg(feature = "serde")]
 mod impl_serde {
-    use crate::entity::NullEntity;
+    use super::Null;
     use core::fmt;
     use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
-    impl Serialize for NullEntity {
+    impl Serialize for Null {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
-            serializer.serialize_unit_struct("NullEntity")
+            serializer.serialize_unit_struct("Null")
         }
     }
 
-    impl<'de> Deserialize<'de> for NullEntity {
+    impl<'de> Deserialize<'de> for Null {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
-            struct NullEntityVisitor;
+            struct NullVisitor;
 
-            impl<'de> Visitor<'de> for NullEntityVisitor {
-                type Value = NullEntity;
+            impl<'de> Visitor<'de> for NullVisitor {
+                type Value = Null;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("struct NullEntity")
+                    formatter.write_str("struct Null")
                 }
 
                 fn visit_unit<E>(self) -> Result<Self::Value, E>
                 where
                     E: de::Error,
                 {
-                    Ok(NullEntity)
+                    Ok(Null)
                 }
             }
 
-            deserializer.deserialize_unit_struct("NullEntity", NullEntityVisitor)
+            deserializer.deserialize_unit_struct("Null", NullVisitor)
         }
     }
 }
 
 pub trait Entity: EntitySeal + Any {}
 
-impl Entity for NullEntity {}
+impl Entity for Null {}
 
 impl<C, E> Entity for (C, E)
 where
@@ -67,6 +67,6 @@ macro_rules! entity {
         ($component, entity!($($components,)*))
     };
     () => {
-        $crate::entity::NullEntity
+        $crate::entity::Null
     };
 }

--- a/src/public/query/filter.rs
+++ b/src/public/query/filter.rs
@@ -2,7 +2,10 @@ use crate::{
     component::Component,
     entity,
     internal::query::filter::FilterSeal,
-    query::{view, view::{View, Views}},
+    query::{
+        view,
+        view::{View, Views},
+    },
 };
 use core::marker::PhantomData;
 

--- a/src/public/query/filter.rs
+++ b/src/public/query/filter.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::Component,
-    entity::EntityIdentifier,
+    entity,
     internal::query::filter::FilterSeal,
     query::{view, view::{View, Views}},
 };
@@ -70,7 +70,7 @@ impl<C> Filter for Option<&C> where C: Component {}
 
 impl<C> Filter for Option<&mut C> where C: Component {}
 
-impl Filter for EntityIdentifier {}
+impl Filter for entity::Identifier {}
 
 impl Filter for view::Null {}
 

--- a/src/public/query/filter.rs
+++ b/src/public/query/filter.rs
@@ -2,7 +2,7 @@ use crate::{
     component::Component,
     entity::EntityIdentifier,
     internal::query::filter::FilterSeal,
-    query::view::{NullViews, View, Views},
+    query::{view, view::{View, Views}},
 };
 use core::marker::PhantomData;
 
@@ -72,7 +72,7 @@ impl<C> Filter for Option<&mut C> where C: Component {}
 
 impl Filter for EntityIdentifier {}
 
-impl Filter for NullViews {}
+impl Filter for view::Null {}
 
 impl<'a, V, W> Filter for (V, W)
 where

--- a/src/public/query/filter.rs
+++ b/src/public/query/filter.rs
@@ -1,8 +1,8 @@
 use crate::{
     component::Component,
     entity::EntityIdentifier,
-    internal::query::FilterSeal,
-    query::{NullViews, View, Views},
+    internal::query::filter::FilterSeal,
+    query::view::{NullViews, View, Views},
 };
 use core::marker::PhantomData;
 

--- a/src/public/query/mod.rs
+++ b/src/public/query/mod.rs
@@ -1,7 +1,6 @@
-mod filter;
-mod result;
-mod view;
+pub mod filter;
+pub mod result;
+pub mod view;
 
-pub use filter::*;
-pub use result::*;
-pub use view::*;
+#[doc(inline)]
+pub use crate::result;

--- a/src/public/query/mod.rs
+++ b/src/public/query/mod.rs
@@ -4,3 +4,4 @@ pub mod view;
 
 #[doc(inline)]
 pub use crate::result;
+pub use result::Results;

--- a/src/public/query/mod.rs
+++ b/src/public/query/mod.rs
@@ -4,4 +4,3 @@ pub mod view;
 
 #[doc(inline)]
 pub use crate::result;
-pub use result::Results;

--- a/src/public/query/result.rs
+++ b/src/public/query/result.rs
@@ -1,4 +1,11 @@
-use crate::{internal::{archetypes, query::filter::FilterSeal}, query::{filter::{Filter, And}, view::Views}, registry::Registry};
+use crate::{
+    internal::{archetypes, query::filter::FilterSeal},
+    query::{
+        filter::{And, Filter},
+        view::Views,
+    },
+    registry::Registry,
+};
 use core::{any::TypeId, marker::PhantomData};
 use hashbrown::HashMap;
 
@@ -57,7 +64,12 @@ macro_rules! result {
     };
 }
 
-pub struct Results<'a, R, F, V> where R: Registry, F: Filter, V: Views<'a> {
+pub struct Results<'a, R, F, V>
+where
+    R: Registry,
+    F: Filter,
+    V: Views<'a>,
+{
     archetypes_iter: archetypes::IterMut<'a, R>,
 
     front_results_iter: Option<V::Results>,
@@ -68,14 +80,22 @@ pub struct Results<'a, R, F, V> where R: Registry, F: Filter, V: Views<'a> {
     filter: PhantomData<F>,
 }
 
-impl<'a, R, F, V> Results<'a, R, F, V> where R: Registry, F: Filter, V: Views<'a> {
+impl<'a, R, F, V> Results<'a, R, F, V>
+where
+    R: Registry,
+    F: Filter,
+    V: Views<'a>,
+{
     // fn filter((identifier, _archetype): (archetype::Identifier, &mut Archetype<R>)) -> bool {
     //     unsafe {
     //         And::<V, F>::filter(identifier.as_slice(), &self.component_map)
     //     }
     // }
 
-    pub(crate) fn new(archetypes_iter: archetypes::IterMut<'a, R>, component_map: &'a HashMap<TypeId, usize>) -> Self {
+    pub(crate) fn new(
+        archetypes_iter: archetypes::IterMut<'a, R>,
+        component_map: &'a HashMap<TypeId, usize>,
+    ) -> Self {
         Self {
             archetypes_iter,
 
@@ -89,7 +109,12 @@ impl<'a, R, F, V> Results<'a, R, F, V> where R: Registry, F: Filter, V: Views<'a
     }
 }
 
-impl<'a, R, F, V> Iterator for Results<'a, R, F, V> where R: Registry + 'a, F: Filter, V: Views<'a> {
+impl<'a, R, F, V> Iterator for Results<'a, R, F, V>
+where
+    R: Registry + 'a,
+    F: Filter,
+    V: Views<'a>,
+{
     type Item = <V::Results as Iterator>::Item;
 
     #[inline]
@@ -101,17 +126,21 @@ impl<'a, R, F, V> Iterator for Results<'a, R, F, V> where R: Registry + 'a, F: F
                     None => self.front_results_iter = None,
                 }
             }
-            match self.archetypes_iter.find(|(identifier, _archetype)| unsafe {
-                And::<V, F>::filter(identifier.as_slice(), self.component_map)
-            }) {
-                Some((_identifier, archetype)) => self.front_results_iter = Some(archetype.view::<V>()),
+            match self
+                .archetypes_iter
+                .find(|(identifier, _archetype)| unsafe {
+                    And::<V, F>::filter(identifier.as_slice(), self.component_map)
+                }) {
+                Some((_identifier, archetype)) => {
+                    self.front_results_iter = Some(archetype.view::<V>())
+                }
                 None => match self.back_results_iter.as_mut()?.next() {
                     result @ Some(_) => return result,
                     None => {
                         self.back_results_iter = None;
                         return None;
                     }
-                }
+                },
             }
         }
     }

--- a/src/public/query/result.rs
+++ b/src/public/query/result.rs
@@ -1,3 +1,7 @@
+use crate::{internal::{archetypes, query::filter::FilterSeal}, query::{filter::{Filter, And}, view::Views}, registry::Registry};
+use core::{any::TypeId, marker::PhantomData};
+use hashbrown::HashMap;
+
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Null;
 
@@ -51,4 +55,64 @@ macro_rules! result {
     ($component:ident $(,$components:ident)* $(,)?) => {
         ($component, result!($($components,)*))
     };
+}
+
+pub struct Results<'a, R, F, V> where R: Registry, F: Filter, V: Views<'a> {
+    archetypes_iter: archetypes::IterMut<'a, R>,
+
+    front_results_iter: Option<V::Results>,
+    back_results_iter: Option<V::Results>,
+
+    component_map: &'a HashMap<TypeId, usize>,
+
+    filter: PhantomData<F>,
+}
+
+impl<'a, R, F, V> Results<'a, R, F, V> where R: Registry, F: Filter, V: Views<'a> {
+    // fn filter((identifier, _archetype): (archetype::Identifier, &mut Archetype<R>)) -> bool {
+    //     unsafe {
+    //         And::<V, F>::filter(identifier.as_slice(), &self.component_map)
+    //     }
+    // }
+
+    pub(crate) fn new(archetypes_iter: archetypes::IterMut<'a, R>, component_map: &'a HashMap<TypeId, usize>) -> Self {
+        Self {
+            archetypes_iter,
+
+            front_results_iter: None,
+            back_results_iter: None,
+
+            component_map,
+
+            filter: PhantomData,
+        }
+    }
+}
+
+impl<'a, R, F, V> Iterator for Results<'a, R, F, V> where R: Registry + 'a, F: Filter, V: Views<'a> {
+    type Item = <V::Results as Iterator>::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(ref mut results) = self.front_results_iter {
+                match results.next() {
+                    result @ Some(_) => return result,
+                    None => self.front_results_iter = None,
+                }
+            }
+            match self.archetypes_iter.find(|(identifier, _archetype)| unsafe {
+                And::<V, F>::filter(identifier.as_slice(), self.component_map)
+            }) {
+                Some((_identifier, archetype)) => self.front_results_iter = Some(archetype.view::<V>()),
+                None => match self.back_results_iter.as_mut()?.next() {
+                    result @ Some(_) => return result,
+                    None => {
+                        self.back_results_iter = None;
+                        return None;
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/public/query/result.rs
+++ b/src/public/query/result.rs
@@ -1,44 +1,44 @@
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct NullResult;
+pub struct Null;
 
 #[cfg(feature = "serde")]
 mod impl_serde {
-    use crate::query::result::NullResult;
+    use super::Null;
     use core::fmt;
     use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
-    impl Serialize for NullResult {
+    impl Serialize for Null {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
-            serializer.serialize_unit_struct("NullResult")
+            serializer.serialize_unit_struct("Null")
         }
     }
 
-    impl<'de> Deserialize<'de> for NullResult {
+    impl<'de> Deserialize<'de> for Null {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
-            struct NullResultVisitor;
+            struct NullVisitor;
 
-            impl<'de> Visitor<'de> for NullResultVisitor {
-                type Value = NullResult;
+            impl<'de> Visitor<'de> for NullVisitor {
+                type Value = Null;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("struct NullResult")
+                    formatter.write_str("struct Null")
                 }
 
                 fn visit_unit<E>(self) -> Result<Self::Value, E>
                 where
                     E: de::Error,
                 {
-                    Ok(NullResult)
+                    Ok(Null)
                 }
             }
 
-            deserializer.deserialize_unit_struct("NullResult", NullResultVisitor)
+            deserializer.deserialize_unit_struct("Null", NullVisitor)
         }
     }
 }

--- a/src/public/query/result.rs
+++ b/src/public/query/result.rs
@@ -1,3 +1,7 @@
+use core::iter;
+use crate::query::view::Views;
+use alloc::vec;
+
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Null;
 
@@ -51,4 +55,18 @@ macro_rules! result {
     ($component:ident $(,$components:ident)* $(,)?) => {
         ($component, result!($($components,)*))
     };
+}
+
+pub struct Results<'a, V>(pub(crate) iter::Flatten<vec::IntoIter<V::Results>>) where V: Views<'a>;
+
+impl<'a, V> Iterator for Results<'a, V> where V: Views<'a> {
+    type Item = <V::Results as Iterator>::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
 }

--- a/src/public/query/result.rs
+++ b/src/public/query/result.rs
@@ -1,7 +1,3 @@
-use core::iter;
-use crate::query::view::Views;
-use alloc::vec;
-
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Null;
 
@@ -55,18 +51,4 @@ macro_rules! result {
     ($component:ident $(,$components:ident)* $(,)?) => {
         ($component, result!($($components,)*))
     };
-}
-
-pub struct Results<'a, V>(pub(crate) iter::Flatten<vec::IntoIter<V::Results>>) where V: Views<'a>;
-
-impl<'a, V> Iterator for Results<'a, V> where V: Views<'a> {
-    type Item = <V::Results as Iterator>::Item;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.size_hint()
-    }
 }

--- a/src/public/query/view.rs
+++ b/src/public/query/view.rs
@@ -1,8 +1,8 @@
 use crate::{
     component::Component,
     entity::EntityIdentifier,
-    internal::query::{ViewSeal, ViewsSeal},
-    query::Filter,
+    internal::query::view::{ViewSeal, ViewsSeal},
+    query::filter::Filter,
 };
 
 pub trait View<'a>: Filter + ViewSeal<'a> {}

--- a/src/public/query/view.rs
+++ b/src/public/query/view.rs
@@ -1,6 +1,6 @@
 use crate::{
     component::Component,
-    entity::EntityIdentifier,
+    entity,
     internal::query::view::{ViewSeal, ViewsSeal},
     query::filter::Filter,
 };
@@ -15,7 +15,7 @@ impl<'a, C> View<'a> for Option<&C> where C: Component {}
 
 impl<'a, C> View<'a> for Option<&mut C> where C: Component {}
 
-impl<'a> View<'a> for EntityIdentifier {}
+impl<'a> View<'a> for entity::Identifier {}
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Null;

--- a/src/public/query/view.rs
+++ b/src/public/query/view.rs
@@ -18,53 +18,53 @@ impl<'a, C> View<'a> for Option<&mut C> where C: Component {}
 impl<'a> View<'a> for EntityIdentifier {}
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct NullViews;
+pub struct Null;
 
 #[cfg(feature = "serde")]
 mod impl_serde {
-    use crate::query::view::NullViews;
+    use super::Null;
     use core::fmt;
     use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
-    impl Serialize for NullViews {
+    impl Serialize for Null {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
-            serializer.serialize_unit_struct("NullViews")
+            serializer.serialize_unit_struct("Null")
         }
     }
 
-    impl<'de> Deserialize<'de> for NullViews {
+    impl<'de> Deserialize<'de> for Null {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
-            struct NullViewsVisitor;
+            struct NullVisitor;
 
-            impl<'de> Visitor<'de> for NullViewsVisitor {
-                type Value = NullViews;
+            impl<'de> Visitor<'de> for NullVisitor {
+                type Value = Null;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("struct NullViews")
+                    formatter.write_str("struct Null")
                 }
 
                 fn visit_unit<E>(self) -> Result<Self::Value, E>
                 where
                     E: de::Error,
                 {
-                    Ok(NullViews)
+                    Ok(Null)
                 }
             }
 
-            deserializer.deserialize_unit_struct("NullViews", NullViewsVisitor)
+            deserializer.deserialize_unit_struct("Null", NullVisitor)
         }
     }
 }
 
 pub trait Views<'a>: Filter + ViewsSeal<'a> {}
 
-impl<'a> Views<'a> for NullViews {}
+impl<'a> Views<'a> for Null {}
 
 impl<'a, V, W> Views<'a> for (V, W)
 where
@@ -79,6 +79,6 @@ macro_rules! views {
         ($view, views!($($views,)*))
     };
     () => {
-        $crate::query::NullViews
+        $crate::query::Null
     };
 }

--- a/src/public/query/view.rs
+++ b/src/public/query/view.rs
@@ -79,6 +79,6 @@ macro_rules! views {
         ($view, views!($($views,)*))
     };
     () => {
-        $crate::query::Null
+        $crate::query::view::Null
     };
 }

--- a/src/public/registry.rs
+++ b/src/public/registry.rs
@@ -1,53 +1,53 @@
 use crate::{component::Component, internal::registry::RegistrySeal};
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct NullRegistry;
+pub struct Null;
 
 #[cfg(feature = "serde")]
 mod impl_serde {
-    use crate::registry::NullRegistry;
+    use super::Null;
     use core::fmt;
     use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 
-    impl Serialize for NullRegistry {
+    impl Serialize for Null {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
-            serializer.serialize_unit_struct("NullRegistry")
+            serializer.serialize_unit_struct("Null")
         }
     }
 
-    impl<'de> Deserialize<'de> for NullRegistry {
+    impl<'de> Deserialize<'de> for Null {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
-            struct NullRegistryVisitor;
+            struct NullVisitor;
 
-            impl<'de> Visitor<'de> for NullRegistryVisitor {
-                type Value = NullRegistry;
+            impl<'de> Visitor<'de> for NullVisitor {
+                type Value = Null;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("struct NullRegistry")
+                    formatter.write_str("struct Null")
                 }
 
                 fn visit_unit<E>(self) -> Result<Self::Value, E>
                 where
                     E: de::Error,
                 {
-                    Ok(NullRegistry)
+                    Ok(Null)
                 }
             }
 
-            deserializer.deserialize_unit_struct("NullRegistry", NullRegistryVisitor)
+            deserializer.deserialize_unit_struct("Null", NullVisitor)
         }
     }
 }
 
 pub trait Registry: RegistrySeal {}
 
-impl Registry for NullRegistry {}
+impl Registry for Null {}
 
 impl<C, R> Registry for (C, R)
 where
@@ -62,6 +62,6 @@ macro_rules! registry {
         ($component, registry!($($components,)*))
     };
     () => {
-        $crate::registry::NullRegistry
+        $crate::registry::Null
     };
 }

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -11,7 +11,8 @@ pub use entry::Entry;
 
 use crate::{
     entities::{Entities, EntitiesIter},
-    entity::{Entity, EntityIdentifier},
+    entity,
+    entity::Entity,
     internal::{
         archetype, archetypes::Archetypes, entity_allocator::EntityAllocator, query::filter::FilterSeal,
     },
@@ -52,7 +53,7 @@ where
         Self::from_raw_parts(Archetypes::new(), EntityAllocator::new())
     }
 
-    pub fn push<E>(&mut self, entity: E) -> EntityIdentifier
+    pub fn push<E>(&mut self, entity: E) -> entity::Identifier
     where
         E: Entity,
     {
@@ -70,7 +71,7 @@ where
     }
 
     // TODO: Figure out a way to remove the `must_use` attribute on the returned value.
-    pub fn extend<E>(&mut self, entities: EntitiesIter<E>) -> impl Iterator<Item = EntityIdentifier>
+    pub fn extend<E>(&mut self, entities: EntitiesIter<E>) -> impl Iterator<Item = entity::Identifier>
     where
         E: Entities,
     {
@@ -103,13 +104,13 @@ where
             .flatten()
     }
 
-    pub fn entry(&mut self, entity_identifier: EntityIdentifier) -> Option<Entry<R>> {
+    pub fn entry(&mut self, entity_identifier: entity::Identifier) -> Option<Entry<R>> {
         self.entity_allocator
             .get(entity_identifier)
             .map(|location| Entry::new(self, location))
     }
 
-    pub fn remove(&mut self, entity_identifier: EntityIdentifier) {
+    pub fn remove(&mut self, entity_identifier: entity::Identifier) {
         // Get location of entity.
         if let Some(location) = self.entity_allocator.get(entity_identifier) {
             // Remove row from Archetype.

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -17,11 +17,12 @@ use crate::{
     internal::{
         archetype, archetypes::Archetypes, entity_allocator::EntityAllocator, query::filter::FilterSeal,
     },
+    query,
     query::{filter::{And, Filter}, view::Views},
     registry::Registry,
 };
 use alloc::{vec, vec::Vec};
-use core::{any::TypeId, iter};
+use core::any::TypeId;
 use hashbrown::HashMap;
 
 pub struct World<R>
@@ -88,12 +89,12 @@ where
         }
     }
 
-    pub fn query<'a, V, F>(&'a mut self) -> iter::Flatten<vec::IntoIter<V::Results>>
+    pub fn query<'a, V, F>(&'a mut self) -> query::Results<'a, V>
     where
         V: Views<'a>,
         F: Filter,
     {
-        self.archetypes
+        query::Results(self.archetypes
             .iter_mut()
             .filter(|(identifier, _archetype)| unsafe {
                 And::<V, F>::filter(identifier.as_slice(), &self.component_map)
@@ -101,7 +102,7 @@ where
             .map(|(_identifier, archetype)| archetype.view::<V>())
             .collect::<Vec<_>>()
             .into_iter()
-            .flatten()
+            .flatten())
     }
 
     pub fn entry(&mut self, entity_identifier: entity::Identifier) -> Option<Entry<R>> {

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -71,8 +71,7 @@ where
         }
     }
 
-    // TODO: Figure out a way to remove the `must_use` attribute on the returned value.
-    pub fn extend<E>(&mut self, entities: entities::Batch<E>) -> impl Iterator<Item = entity::Identifier>
+    pub fn extend<E>(&mut self, entities: entities::Batch<E>) -> Vec<entity::Identifier>
     where
         E: Entities,
     {

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -14,9 +14,7 @@ use crate::{
     entities::Entities,
     entity,
     entity::Entity,
-    internal::{
-        archetype, archetypes::Archetypes, entity_allocator::EntityAllocator,
-    },
+    internal::{archetype, archetypes::Archetypes, entity_allocator::EntityAllocator},
     query,
     query::{filter::Filter, view::Views},
     registry::Registry,

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -13,9 +13,9 @@ use crate::{
     entities::{Entities, EntitiesIter},
     entity::{Entity, EntityIdentifier},
     internal::{
-        archetype, archetypes::Archetypes, entity_allocator::EntityAllocator, query::FilterSeal,
+        archetype, archetypes::Archetypes, entity_allocator::EntityAllocator, query::filter::FilterSeal,
     },
-    query::{And, Filter, Views},
+    query::{filter::{And, Filter}, view::Views},
     registry::Registry,
 };
 use alloc::{vec, vec::Vec};

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -17,12 +17,11 @@ use crate::{
     internal::{
         archetype, archetypes::Archetypes, entity_allocator::EntityAllocator, query::filter::FilterSeal,
     },
-    query,
     query::{filter::{And, Filter}, view::Views},
     registry::Registry,
 };
 use alloc::{vec, vec::Vec};
-use core::any::TypeId;
+use core::{any::TypeId, iter};
 use hashbrown::HashMap;
 
 pub struct World<R>
@@ -89,12 +88,12 @@ where
         }
     }
 
-    pub fn query<'a, V, F>(&'a mut self) -> query::Results<'a, V>
+    pub fn query<'a, V, F>(&'a mut self) -> iter::Flatten<vec::IntoIter<V::Results>>
     where
         V: Views<'a>,
         F: Filter,
     {
-        query::Results(self.archetypes
+        self.archetypes
             .iter_mut()
             .filter(|(identifier, _archetype)| unsafe {
                 And::<V, F>::filter(identifier.as_slice(), &self.component_map)
@@ -102,7 +101,7 @@ where
             .map(|(_identifier, archetype)| archetype.view::<V>())
             .collect::<Vec<_>>()
             .into_iter()
-            .flatten())
+            .flatten()
     }
 
     pub fn entry(&mut self, entity_identifier: entity::Identifier) -> Option<Entry<R>> {

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -10,7 +10,8 @@ mod impl_sync;
 pub use entry::Entry;
 
 use crate::{
-    entities::{Entities, EntitiesIter},
+    entities,
+    entities::Entities,
     entity,
     entity::Entity,
     internal::{
@@ -71,7 +72,7 @@ where
     }
 
     // TODO: Figure out a way to remove the `must_use` attribute on the returned value.
-    pub fn extend<E>(&mut self, entities: EntitiesIter<E>) -> impl Iterator<Item = entity::Identifier>
+    pub fn extend<E>(&mut self, entities: entities::Batch<E>) -> impl Iterator<Item = entity::Identifier>
     where
         E: Entities,
     {


### PR DESCRIPTION
Renaming a bunch of things to remove redundant module names from the type names (e.g. `NullRegistry` => `registry::Null`). Also wraps the output of `World::query()` in a newtype to hide the internal implementation (as well as removes the unnecessary allocation to give over a 2x speed increase).