### PR TITLE
Parallel iteration using `rayon`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: hack
-        args: build --feature-powerset --optional-deps --exclude-features parallel rayon --target thumbv6m-none-eabi
+        args: build --feature-powerset --optional-deps --exclude-features parallel --exclude-features rayon --target thumbv6m-none-eabi
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: hack
-        args: build --feature-powerset --optional-deps --target thumbv6m-none-eabi
+        args: build --feature-powerset --optional-deps --exclude-features parallel rayon --target thumbv6m-none-eabi
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2021"
 ahash = {version = "0.7.6", default-features = false}
 either = {version = "1.6.1", default-features = false}
 hashbrown = {version = "0.11.2", features = ["raw"]}
+rayon = {version = "1.5.1", optional = true}
 serde = {version = "1.0.130", default-features = false, features = ["alloc"], optional = true}
 
 [dev-dependencies]
 serde_test = "1.0.130"
+
+[features]
+# TODO: Rename this to "rayon" when namespaced dependencies are stabilized in 1.60.0.
+parallel = ["rayon", "hashbrown/rayon"]

--- a/src/internal/archetype/impl_send.rs
+++ b/src/internal/archetype/impl_send.rs
@@ -1,0 +1,3 @@
+use crate::{internal::archetype::Archetype, registry::Registry};
+
+unsafe impl<R> Send for Archetype<R> where R: Registry {}

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -2,6 +2,7 @@ mod identifier;
 mod impl_debug;
 mod impl_drop;
 mod impl_eq;
+mod impl_send;
 #[cfg(feature = "serde")]
 mod impl_serde;
 
@@ -19,6 +20,8 @@ use crate::{
     query::view::Views,
     registry::Registry,
 };
+#[cfg(feature = "parallel")]
+use crate::query::view::ParViews;
 use alloc::vec::Vec;
 use core::{
     any::TypeId,
@@ -160,6 +163,18 @@ where
     {
         unsafe {
             V::view(
+                &self.components,
+                self.entity_identifiers,
+                self.length,
+                &self.component_map,
+            )
+        }
+    }
+
+    #[cfg(feature = "parallel")]
+    pub(crate) fn par_view<'a, V>(&mut self) -> V::ParResults where V: ParViews<'a> {
+        unsafe {
+            V::par_view(
                 &self.components,
                 self.entity_identifiers,
                 self.length,

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -10,6 +10,8 @@ pub(crate) use identifier::{Identifier, IdentifierBuffer, IdentifierIterator};
 #[cfg(feature = "serde")]
 pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
 
+#[cfg(feature = "parallel")]
+use crate::query::view::ParViews;
 use crate::{
     component::Component,
     entities,
@@ -20,8 +22,6 @@ use crate::{
     query::view::Views,
     registry::Registry,
 };
-#[cfg(feature = "parallel")]
-use crate::query::view::ParViews;
 use alloc::vec::Vec;
 use core::{
     any::TypeId,
@@ -172,7 +172,10 @@ where
     }
 
     #[cfg(feature = "parallel")]
-    pub(crate) fn par_view<'a, V>(&mut self) -> V::ParResults where V: ParViews<'a> {
+    pub(crate) fn par_view<'a, V>(&mut self) -> V::ParResults
+    where
+        V: ParViews<'a>,
+    {
         unsafe {
             V::par_view(
                 &self.components,

--- a/src/internal/archetypes/mod.rs
+++ b/src/internal/archetypes/mod.rs
@@ -3,8 +3,12 @@ mod impl_eq;
 #[cfg(feature = "serde")]
 mod impl_serde;
 mod iter;
+#[cfg(feature = "parallel")]
+mod par_iter;
 
 pub(crate) use iter::IterMut;
+#[cfg(feature = "parallel")]
+pub(crate) use par_iter::ParIterMut;
 
 use crate::{
     internal::{archetype, archetype::Archetype},

--- a/src/internal/archetypes/par_iter.rs
+++ b/src/internal/archetypes/par_iter.rs
@@ -1,0 +1,54 @@
+use crate::{
+    internal::{archetype::Archetype, archetypes::Archetypes},
+    registry::Registry,
+};
+use core::marker::PhantomData;
+use hashbrown::raw::rayon::RawParIter;
+use rayon::iter::{plumbing::UnindexedConsumer, ParallelIterator};
+
+pub(crate) struct ParIterMut<'a, R>
+where
+    R: Registry,
+{
+    lifetime: PhantomData<&'a ()>,
+
+    raw_iter: RawParIter<Archetype<R>>,
+}
+
+impl<R> ParIterMut<'_, R>
+where
+    R: Registry,
+{
+    fn new(raw_iter: RawParIter<Archetype<R>>) -> Self {
+        Self {
+            lifetime: PhantomData,
+
+            raw_iter,
+        }
+    }
+}
+
+impl<'a, R> ParallelIterator for ParIterMut<'a, R>
+where
+    R: Registry + 'a,
+{
+    type Item = &'a mut Archetype<R>;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        self.raw_iter
+            .map(|archetype_bucket| unsafe { archetype_bucket.as_mut() })
+            .drive_unindexed(consumer)
+    }
+}
+
+impl<R> Archetypes<R>
+where
+    R: Registry,
+{
+    pub(crate) fn par_iter_mut(&mut self) -> ParIterMut<R> {
+        ParIterMut::new(unsafe { self.raw_archetypes.par_iter() })
+    }
+}

--- a/src/internal/query/mod.rs
+++ b/src/internal/query/mod.rs
@@ -1,2 +1,4 @@
 pub(crate) mod filter;
+#[cfg(feature = "parallel")]
+pub(crate) mod par_view;
 pub(crate) mod view;

--- a/src/internal/query/par_view/mod.rs
+++ b/src/internal/query/par_view/mod.rs
@@ -1,0 +1,193 @@
+mod repeat;
+
+use crate::{
+    component::Component,
+    entity,
+    query::{
+        result,
+        view::{Null, View, Views},
+    },
+};
+use core::any::TypeId;
+use hashbrown::HashMap;
+use rayon::{
+    iter,
+    iter::{
+        Either, IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator,
+        ParallelIterator,
+    },
+    slice,
+};
+use repeat::RepeatNone;
+
+pub trait ParViewSeal<'a>: View<'a> {
+    type ParResult: IndexedParallelIterator;
+
+    unsafe fn par_view(
+        columns: &[(*mut u8, usize)],
+        entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> Self::ParResult;
+}
+
+impl<'a, C> ParViewSeal<'a> for &C
+where
+    C: Component + Sync,
+{
+    type ParResult = slice::Iter<'a, C>;
+
+    unsafe fn par_view(
+        columns: &[(*mut u8, usize)],
+        _entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> Self::ParResult {
+        core::slice::from_raw_parts::<'a, C>(
+            columns
+                .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
+                .0 as *mut C,
+            length,
+        )
+        .par_iter()
+    }
+}
+
+impl<'a, C> ParViewSeal<'a> for &mut C
+where
+    C: Component + Send,
+{
+    type ParResult = slice::IterMut<'a, C>;
+
+    unsafe fn par_view(
+        columns: &[(*mut u8, usize)],
+        _entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> Self::ParResult {
+        core::slice::from_raw_parts_mut::<'a, C>(
+            columns
+                .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
+                .0 as *mut C,
+            length,
+        )
+        .par_iter_mut()
+    }
+}
+
+fn wrap_some<T>(val: T) -> Option<T> {
+    Some(val)
+}
+
+impl<'a, C> ParViewSeal<'a> for Option<&C>
+where
+    C: Component + Sync,
+{
+    type ParResult = Either<
+        iter::RepeatN<Option<&'a C>>,
+        iter::Map<slice::Iter<'a, C>, fn(&'a C) -> Option<&'a C>>,
+    >;
+
+    unsafe fn par_view(
+        columns: &[(*mut u8, usize)],
+        _entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> Self::ParResult {
+        match component_map.get(&TypeId::of::<C>()) {
+            Some(index) => Either::Right(
+                core::slice::from_raw_parts(columns.get_unchecked(*index).0 as *mut C, length)
+                    .par_iter()
+                    .map(wrap_some),
+            ),
+            None => Either::Left(iter::repeat(None).take(length)),
+        }
+    }
+}
+
+impl<'a, C> ParViewSeal<'a> for Option<&mut C>
+where
+    C: Component + Send,
+{
+    type ParResult = Either<
+        RepeatNone<&'a mut C>,
+        iter::Map<slice::IterMut<'a, C>, fn(&'a mut C) -> Option<&'a mut C>>,
+    >;
+
+    unsafe fn par_view(
+        columns: &[(*mut u8, usize)],
+        _entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> Self::ParResult {
+        match component_map.get(&TypeId::of::<C>()) {
+            Some(index) => Either::Right(
+                core::slice::from_raw_parts_mut(columns.get_unchecked(*index).0 as *mut C, length)
+                    .par_iter_mut()
+                    .map(wrap_some),
+            ),
+            None => Either::Left(RepeatNone::new(length)),
+        }
+    }
+}
+
+impl<'a> ParViewSeal<'a> for entity::Identifier {
+    type ParResult = iter::Cloned<slice::Iter<'a, Self>>;
+
+    unsafe fn par_view(
+        _columns: &[(*mut u8, usize)],
+        entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        _component_map: &HashMap<TypeId, usize>,
+    ) -> Self::ParResult {
+        core::slice::from_raw_parts_mut::<'a, Self>(entity_identifiers.0, length)
+            .par_iter()
+            .cloned()
+    }
+}
+
+pub trait ParViewsSeal<'a>: Views<'a> {
+    type ParResults: IndexedParallelIterator;
+
+    unsafe fn par_view(
+        columns: &[(*mut u8, usize)],
+        entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> Self::ParResults;
+}
+
+impl<'a> ParViewsSeal<'a> for Null {
+    type ParResults = iter::RepeatN<result::Null>;
+
+    unsafe fn par_view(
+        _columns: &[(*mut u8, usize)],
+        _entity_identifiers: (*mut entity::Identifier, usize),
+        _length: usize,
+        _component_map: &HashMap<TypeId, usize>,
+    ) -> Self::ParResults {
+        iter::repeatn(result::Null, usize::MAX)
+    }
+}
+
+impl<'a, V, W> ParViewsSeal<'a> for (V, W)
+where
+    V: ParViewSeal<'a>,
+    W: ParViewsSeal<'a>,
+{
+    type ParResults = iter::Zip<V::ParResult, W::ParResults>;
+
+    unsafe fn par_view(
+        columns: &[(*mut u8, usize)],
+        entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> Self::ParResults {
+        V::par_view(columns, entity_identifiers, length, component_map).zip(W::par_view(
+            columns,
+            entity_identifiers,
+            length,
+            component_map,
+        ))
+    }
+}

--- a/src/internal/query/par_view/repeat.rs
+++ b/src/internal/query/par_view/repeat.rs
@@ -1,0 +1,134 @@
+use core::marker::PhantomData;
+use rayon::iter::{
+    plumbing::{bridge, Consumer, Producer, ProducerCallback, UnindexedConsumer},
+    IndexedParallelIterator, ParallelIterator,
+};
+
+pub struct RepeatNone<T> {
+    inner: PhantomData<T>,
+    count: usize,
+}
+
+impl<T> RepeatNone<T> {
+    pub(crate) fn new(count: usize) -> Self {
+        Self {
+            inner: PhantomData,
+            count,
+        }
+    }
+}
+
+impl<T> ParallelIterator for RepeatNone<T>
+where
+    T: Send,
+{
+    type Item = Option<T>;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        Some(self.count)
+    }
+}
+
+impl<T> IndexedParallelIterator for RepeatNone<T>
+where
+    T: Send,
+{
+    fn drive<C>(self, consumer: C) -> C::Result
+    where
+        C: Consumer<Self::Item>,
+    {
+        bridge(self, consumer)
+    }
+
+    fn with_producer<CB>(self, callback: CB) -> CB::Output
+    where
+        CB: ProducerCallback<Self::Item>,
+    {
+        callback.callback(RepeatNoneProducer {
+            inner: self.inner,
+            count: self.count,
+        })
+    }
+
+    fn len(&self) -> usize {
+        self.count
+    }
+}
+
+struct RepeatNoneProducer<T> {
+    inner: PhantomData<T>,
+    count: usize,
+}
+
+impl<T> Producer for RepeatNoneProducer<T>
+where
+    T: Send,
+{
+    type Item = Option<T>;
+    type IntoIter = RepeatNoneIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RepeatNoneIter {
+            inner: self.inner,
+            count: self.count,
+        }
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        (
+            Self {
+                inner: self.inner,
+                count: index,
+            },
+            Self {
+                inner: self.inner,
+                count: self.count - index,
+            },
+        )
+    }
+}
+
+struct RepeatNoneIter<T> {
+    inner: PhantomData<T>,
+    count: usize,
+}
+
+impl<T> Iterator for RepeatNoneIter<T> {
+    type Item = Option<T>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.count > 0 {
+            self.count -= 1;
+            Some(None)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.count, Some(self.count))
+    }
+}
+
+impl<T> DoubleEndedIterator for RepeatNoneIter<T> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.next()
+    }
+}
+
+impl<T> ExactSizeIterator for RepeatNoneIter<T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.count
+    }
+}

--- a/src/public/query/mod.rs
+++ b/src/public/query/mod.rs
@@ -4,4 +4,3 @@ pub mod view;
 
 #[doc(inline)]
 pub use crate::result;
-pub use result::Results;

--- a/src/public/query/result/iter.rs
+++ b/src/public/query/result/iter.rs
@@ -9,62 +9,7 @@ use crate::{
 use core::{any::TypeId, marker::PhantomData};
 use hashbrown::HashMap;
 
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Null;
-
-#[cfg(feature = "serde")]
-mod impl_serde {
-    use super::Null;
-    use core::fmt;
-    use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
-
-    impl Serialize for Null {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            serializer.serialize_unit_struct("Null")
-        }
-    }
-
-    impl<'de> Deserialize<'de> for Null {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            struct NullVisitor;
-
-            impl<'de> Visitor<'de> for NullVisitor {
-                type Value = Null;
-
-                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("struct Null")
-                }
-
-                fn visit_unit<E>(self) -> Result<Self::Value, E>
-                where
-                    E: de::Error,
-                {
-                    Ok(Null)
-                }
-            }
-
-            deserializer.deserialize_unit_struct("Null", NullVisitor)
-        }
-    }
-}
-
-#[macro_export]
-macro_rules! result {
-    () => {
-        _
-    };
-    ($component:ident $(,$components:ident)* $(,)?) => {
-        ($component, result!($($components,)*))
-    };
-}
-
-pub struct Results<'a, R, F, V>
+pub struct Iter<'a, R, F, V>
 where
     R: Registry,
     F: Filter,
@@ -80,7 +25,7 @@ where
     filter: PhantomData<F>,
 }
 
-impl<'a, R, F, V> Results<'a, R, F, V>
+impl<'a, R, F, V> Iter<'a, R, F, V>
 where
     R: Registry,
     F: Filter,
@@ -109,7 +54,7 @@ where
     }
 }
 
-impl<'a, R, F, V> Iterator for Results<'a, R, F, V>
+impl<'a, R, F, V> Iterator for Iter<'a, R, F, V>
 where
     R: Registry + 'a,
     F: Filter,

--- a/src/public/query/result/mod.rs
+++ b/src/public/query/result/mod.rs
@@ -1,21 +1,10 @@
-use crate::{
-    component::Component,
-    entity,
-    internal::query::view::{ViewSeal, ViewsSeal},
-    query::filter::Filter,
-};
+mod iter;
+#[cfg(feature = "parallel")]
+mod par_iter;
 
-pub trait View<'a>: Filter + ViewSeal<'a> {}
-
-impl<'a, C> View<'a> for &C where C: Component {}
-
-impl<'a, C> View<'a> for &mut C where C: Component {}
-
-impl<'a, C> View<'a> for Option<&C> where C: Component {}
-
-impl<'a, C> View<'a> for Option<&mut C> where C: Component {}
-
-impl<'a> View<'a> for entity::Identifier {}
+pub use iter::Iter;
+#[cfg(feature = "parallel")]
+pub use par_iter::ParIter;
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Null;
@@ -62,23 +51,12 @@ mod impl_serde {
     }
 }
 
-pub trait Views<'a>: Filter + ViewsSeal<'a> {}
-
-impl<'a> Views<'a> for Null {}
-
-impl<'a, V, W> Views<'a> for (V, W)
-where
-    V: View<'a>,
-    W: Views<'a>,
-{
-}
-
 #[macro_export]
-macro_rules! views {
-    ($view:ty $(,$views:ty)* $(,)?) => {
-        ($view, views!($($views,)*))
-    };
+macro_rules! result {
     () => {
-        $crate::query::view::Null
+        _
+    };
+    ($component:ident $(,$components:ident)* $(,)?) => {
+        ($component, result!($($components,)*))
     };
 }

--- a/src/public/query/result/par_iter.rs
+++ b/src/public/query/result/par_iter.rs
@@ -1,0 +1,175 @@
+use crate::{
+    internal::{archetype::Archetype, archetypes, query::filter::FilterSeal},
+    query::{
+        filter::{And, Filter},
+        view::ParViews,
+    },
+    registry::Registry,
+};
+use core::{any::TypeId, marker::PhantomData};
+use hashbrown::HashMap;
+use rayon::iter::{ParallelIterator, plumbing::{Consumer, Folder, Reducer, UnindexedConsumer}};
+
+pub struct ParIter<'a, R, F, V>
+where
+    R: Registry,
+    F: Filter,
+    V: ParViews<'a>,
+{
+    archetypes_iter: archetypes::ParIterMut<'a, R>,
+
+    component_map: &'a HashMap<TypeId, usize>,
+
+    filter: PhantomData<F>,
+    views: PhantomData<V>,
+}
+
+impl<'a, R, F, V> ParIter<'a, R, F, V>
+where
+    R: Registry,
+    F: Filter,
+    V: ParViews<'a>,
+{
+    pub(crate) fn new(
+        archetypes_iter: archetypes::ParIterMut<'a, R>,
+        component_map: &'a HashMap<TypeId, usize>,
+    ) -> Self {
+        Self {
+            archetypes_iter,
+
+            component_map,
+
+            filter: PhantomData,
+            views: PhantomData,
+        }
+    }
+}
+
+unsafe impl<'a, R, F, V> Send for ParIter<'a, R, F, V> where R: Registry, F: Filter, V: ParViews<'a> {}
+
+unsafe impl<'a, R, F, V> Sync for ParIter<'a, R, F, V> where R: Registry, F: Filter, V: ParViews<'a> {}
+
+impl<'a, R, F, V> ParallelIterator for ParIter<'a, R, F, V> where R: Registry + 'a, F: Filter, V: ParViews<'a> {
+    type Item = <V::ParResults as ParallelIterator>::Item;
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result where C: UnindexedConsumer<Self::Item> {
+        let consumer = ResultsConsumer::<_, F, V>::new(consumer, self.component_map);
+        self.archetypes_iter.drive_unindexed(consumer)
+    }
+}
+
+struct ResultsConsumer<'a, C, F, V> {
+    base: C,
+    component_map: &'a HashMap<TypeId, usize>,
+
+    filter: PhantomData<F>,
+    views: PhantomData<V>,
+}
+
+impl<'a, C, F, V> ResultsConsumer<'a, C, F, V> {
+    fn new(base: C, component_map: &'a HashMap<TypeId, usize>) -> Self {
+        Self {
+            base,
+            component_map,
+
+            filter: PhantomData,
+            views: PhantomData,
+        }
+    }
+}
+
+unsafe impl<C, F, V> Send for ResultsConsumer<'_, C, F, V> {}
+
+unsafe impl<C, F, V> Sync for ResultsConsumer<'_, C, F, V> {}
+
+impl<'a, C, R, F, V> Consumer<&'a mut Archetype<R>> for ResultsConsumer<'a, C, F, V> where C: UnindexedConsumer<<V::ParResults as ParallelIterator>::Item>, R: Registry, F: Filter, V: ParViews<'a> {
+    type Folder = ResultsFolder<'a, C, C::Result, F, V>;
+    type Reducer = C::Reducer;
+    type Result = C::Result;
+
+    fn split_at(self, index: usize) -> (Self, Self, C::Reducer) {
+        let (left, right, reducer) = self.base.split_at(index);
+        (
+            ResultsConsumer::new(left, self.component_map),
+            ResultsConsumer::new(right, self.component_map),
+            reducer,
+        )
+    }
+
+    fn into_folder(self) -> Self::Folder {
+        ResultsFolder {
+            base: self.base,
+            component_map: self.component_map,
+            previous: None,
+
+            filter: PhantomData,
+            views: PhantomData,
+        }
+    }
+
+    fn full(&self) -> bool {
+        self.base.full()
+    }
+}
+
+impl<'a, C, R, F, V> UnindexedConsumer<&'a mut Archetype<R>> for ResultsConsumer<'a, C, F, V> where C: UnindexedConsumer<<V::ParResults as ParallelIterator>::Item>, R: Registry, F: Filter, V: ParViews<'a> {
+    fn split_off_left(&self) -> Self {
+        ResultsConsumer::new(self.base.split_off_left(), self.component_map)
+    }
+
+    fn to_reducer(&self) -> Self::Reducer {
+        self.base.to_reducer()
+    }
+}
+
+struct ResultsFolder<'a, C, P, F, V> {
+    base: C,
+    component_map: &'a HashMap<TypeId, usize>,
+    previous: Option<P>,
+
+    filter: PhantomData<F>,
+    views: PhantomData<V>,
+}
+
+impl<'a, C, R, F, V> Folder<&'a mut Archetype<R>> for ResultsFolder<'a, C, C::Result, F, V> where C: UnindexedConsumer<<V::ParResults as ParallelIterator>::Item>, R: Registry, F: Filter, V: ParViews<'a> {
+    type Result = C::Result;
+
+    fn consume(self, archetype: &'a mut Archetype<R>) -> Self {
+        if unsafe {
+            And::<V, F>::filter(archetype.identifier().as_slice(), self.component_map)
+        } {
+            let consumer = self.base.split_off_left();
+            let result = archetype.par_view::<V>().drive_unindexed(consumer);
+
+            let previous = match self.previous {
+                None => Some(result),
+                Some(previous) => {
+                    let reducer = self.base.to_reducer();
+                    Some(reducer.reduce(previous, result))
+                }
+            };
+
+            ResultsFolder {
+                base: self.base,
+                component_map: self.component_map,
+                previous,
+    
+                filter: self.filter,
+                views: self.views,
+            }
+        } else {
+            self
+        }
+    }
+
+    fn complete(self) -> Self::Result {
+        match self.previous {
+            Some(previous) => previous,
+            None => self.base.into_folder().complete(),
+        }
+    }
+
+    fn full(&self) -> bool {
+        self.base.full()
+    }
+}

--- a/src/public/query/view/mod.rs
+++ b/src/public/query/view/mod.rs
@@ -1,0 +1,90 @@
+#[cfg(feature = "parallel")]
+mod par;
+
+#[cfg(feature = "parallel")]
+pub use par::{ParView, ParViews};
+
+use crate::{
+    component::Component,
+    entity,
+    internal::query::view::{ViewSeal, ViewsSeal},
+    query::filter::Filter,
+};
+
+pub trait View<'a>: Filter + ViewSeal<'a> {}
+
+impl<'a, C> View<'a> for &C where C: Component {}
+
+impl<'a, C> View<'a> for &mut C where C: Component {}
+
+impl<'a, C> View<'a> for Option<&C> where C: Component {}
+
+impl<'a, C> View<'a> for Option<&mut C> where C: Component {}
+
+impl<'a> View<'a> for entity::Identifier {}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Null;
+
+#[cfg(feature = "serde")]
+mod impl_serde {
+    use super::Null;
+    use core::fmt;
+    use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+
+    impl Serialize for Null {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_unit_struct("Null")
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Null {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct NullVisitor;
+
+            impl<'de> Visitor<'de> for NullVisitor {
+                type Value = Null;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("struct Null")
+                }
+
+                fn visit_unit<E>(self) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    Ok(Null)
+                }
+            }
+
+            deserializer.deserialize_unit_struct("Null", NullVisitor)
+        }
+    }
+}
+
+pub trait Views<'a>: Filter + ViewsSeal<'a> {}
+
+impl<'a> Views<'a> for Null {}
+
+impl<'a, V, W> Views<'a> for (V, W)
+where
+    V: View<'a>,
+    W: Views<'a>,
+{
+}
+
+#[macro_export]
+macro_rules! views {
+    ($view:ty $(,$views:ty)* $(,)?) => {
+        ($view, views!($($views,)*))
+    };
+    () => {
+        $crate::query::view::Null
+    };
+}

--- a/src/public/query/view/par.rs
+++ b/src/public/query/view/par.rs
@@ -1,0 +1,29 @@
+use crate::{
+    component::Component,
+    entity,
+    internal::query::par_view::{ParViewSeal, ParViewsSeal},
+    query::{filter::Filter, view::Null},
+};
+
+pub trait ParView<'a>: Filter + ParViewSeal<'a> {}
+
+impl<'a, C> ParView<'a> for &C where C: Component + Sync {}
+
+impl<'a, C> ParView<'a> for &mut C where C: Component + Send {}
+
+impl<'a, C> ParView<'a> for Option<&C> where C: Component + Sync {}
+
+impl<'a, C> ParView<'a> for Option<&mut C> where C: Component + Send {}
+
+impl<'a> ParView<'a> for entity::Identifier {}
+
+pub trait ParViews<'a>: Filter + ParViewsSeal<'a> {}
+
+impl<'a> ParViews<'a> for Null {}
+
+impl<'a, V, W> ParViews<'a> for (V, W)
+where
+    V: ParView<'a>,
+    W: ParViews<'a>,
+{
+}

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -9,14 +9,15 @@ mod impl_sync;
 
 pub use entry::Entry;
 
+#[cfg(feature = "parallel")]
+use crate::query::view::ParViews;
 use crate::{
     entities,
     entities::Entities,
     entity,
     entity::Entity,
     internal::{archetype, archetypes::Archetypes, entity_allocator::EntityAllocator},
-    query,
-    query::{filter::Filter, view::Views},
+    query::{filter::Filter, result, view::Views},
     registry::Registry,
 };
 use alloc::{vec, vec::Vec};
@@ -87,12 +88,21 @@ where
         }
     }
 
-    pub fn query<'a, V, F>(&'a mut self) -> query::Results<'a, R, F, V>
+    pub fn query<'a, V, F>(&'a mut self) -> result::Iter<'a, R, F, V>
     where
         V: Views<'a>,
         F: Filter,
     {
-        query::Results::new(self.archetypes.iter_mut(), &self.component_map)
+        result::Iter::new(self.archetypes.iter_mut(), &self.component_map)
+    }
+
+    #[cfg(feature = "parallel")]
+    pub fn par_query<'a, V, F>(&'a mut self) -> result::ParIter<'a, R, F, V>
+    where
+        V: ParViews<'a>,
+        F: Filter,
+    {
+        result::ParIter::new(self.archetypes.par_iter_mut(), &self.component_map)
     }
 
     pub fn entry(&mut self, entity_identifier: entity::Identifier) -> Option<Entry<R>> {


### PR DESCRIPTION
Implements parallel iteration using the `rayon` crate. This closes #19. 

The outer implementation (of query::result::ParIter) is based on the implementations of `rayon::iter::Filter` and `rayon::iter::FlatMap`. I believe everything is implemented correctly.

Benchmarks put this up to par with other ECS libraries for outer parallelism.