### PR TITLE
Rename archetype identifier types to better represent their relationships

### DIFF
--- a/src/internal/archetype/identifier/impl_serde.rs
+++ b/src/internal/archetype/identifier/impl_serde.rs
@@ -1,4 +1,4 @@
-use crate::{internal::archetype::IdentifierBuffer, registry::Registry};
+use crate::{internal::archetype::Identifier, registry::Registry};
 use alloc::vec::Vec;
 use core::{fmt, marker::PhantomData, mem::ManuallyDrop};
 use serde::{
@@ -8,7 +8,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-impl<R> Serialize for IdentifierBuffer<R>
+impl<R> Serialize for Identifier<R>
 where
     R: Registry,
 {
@@ -26,7 +26,7 @@ where
     }
 }
 
-impl<'de, R> Deserialize<'de> for IdentifierBuffer<R>
+impl<'de, R> Deserialize<'de> for Identifier<R>
 where
     R: Registry,
 {
@@ -34,18 +34,18 @@ where
     where
         D: Deserializer<'de>,
     {
-        struct IdentifierBufferVisitor<R>
+        struct IdentifierVisitor<R>
         where
             R: Registry,
         {
             registry: PhantomData<R>,
         }
 
-        impl<'de, R> Visitor<'de> for IdentifierBufferVisitor<R>
+        impl<'de, R> Visitor<'de> for IdentifierVisitor<R>
         where
             R: Registry,
         {
-            type Value = IdentifierBuffer<R>;
+            type Value = Identifier<R>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 write!(formatter, "{} bits corresponding to components, with prefixed 0s padded on the last byte to round up to {} bytes", R::LEN, (R::LEN + 7) / 8)
@@ -89,7 +89,7 @@ where
 
         deserializer.deserialize_tuple(
             (R::LEN + 7) / 8,
-            IdentifierBufferVisitor {
+            IdentifierVisitor {
                 registry: PhantomData,
             },
         )

--- a/src/internal/archetype/identifier/iter.rs
+++ b/src/internal/archetype/identifier/iter.rs
@@ -64,7 +64,7 @@ unsafe impl<R> IdentifierIterator<R> for IdentifierIter<R> where R: Registry {}
 #[cfg(test)]
 mod tests {
     use crate::{
-        internal::archetype::{IdentifierBuffer, IdentifierIterator},
+        internal::archetype::{Identifier, IdentifierIterator},
         registry,
     };
     use alloc::{vec, vec::Vec};
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn none_set() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![0; 4]) };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![0; 4]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
@@ -96,7 +96,7 @@ mod tests {
 
     #[test]
     fn all_set() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![255, 255, 255, 63]) };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![255, 255, 255, 63]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn every_other_set() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![170, 170, 170, 42]) };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![170, 170, 170, 42]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn one_set() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![0, 128, 0, 0]) };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![0, 128, 0, 0]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
@@ -134,14 +134,14 @@ mod tests {
 
     #[test]
     fn no_components() {
-        let buffer = unsafe { IdentifierBuffer::<registry!()>::new(Vec::new()) };
+        let buffer = unsafe { Identifier::<registry!()>::new(Vec::new()) };
 
         assert_eq!(unsafe { buffer.iter() }.collect::<Vec<bool>>(), Vec::new());
     }
 
     #[test]
     fn seven_components() {
-        let buffer = unsafe { IdentifierBuffer::<registry!(A, B, C, D, E, F, G)>::new(vec![0]) };
+        let buffer = unsafe { Identifier::<registry!(A, B, C, D, E, F, G)>::new(vec![0]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn eight_components() {
-        let buffer = unsafe { IdentifierBuffer::<registry!(A, B, C, D, E, F, G, H)>::new(vec![0]) };
+        let buffer = unsafe { Identifier::<registry!(A, B, C, D, E, F, G, H)>::new(vec![0]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
@@ -162,7 +162,7 @@ mod tests {
     #[test]
     fn nine_components() {
         let buffer =
-            unsafe { IdentifierBuffer::<registry!(A, B, C, D, E, F, G, H, I)>::new(vec![0, 0]) };
+            unsafe { Identifier::<registry!(A, B, C, D, E, F, G, H, I)>::new(vec![0, 0]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
@@ -174,7 +174,7 @@ mod tests {
     fn impl_identifier_iterator() {
         fn assert_impls_identifier_iterator(_iter: impl IdentifierIterator<Registry>) {}
 
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![0, 0, 0, 0]) };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![0, 0, 0, 0]) };
 
         assert_impls_identifier_iterator(unsafe { buffer.iter() });
     }

--- a/src/internal/archetype/identifier/iter.rs
+++ b/src/internal/archetype/identifier/iter.rs
@@ -161,8 +161,7 @@ mod tests {
 
     #[test]
     fn nine_components() {
-        let buffer =
-            unsafe { Identifier::<registry!(A, B, C, D, E, F, G, H, I)>::new(vec![0, 0]) };
+        let buffer = unsafe { Identifier::<registry!(A, B, C, D, E, F, G, H, I)>::new(vec![0, 0]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),

--- a/src/internal/archetype/identifier/mod.rs
+++ b/src/internal/archetype/identifier/mod.rs
@@ -44,8 +44,8 @@ where
         slice::from_raw_parts(self.pointer, (R::LEN + 7) / 8)
     }
 
-    pub(crate) unsafe fn as_identifier(&self) -> Identifier<R> {
-        Identifier::<R> {
+    pub(crate) unsafe fn as_ref(&self) -> IdentifierRef<R> {
+        IdentifierRef::<R> {
             registry: self.registry,
 
             pointer: self.pointer,
@@ -96,7 +96,7 @@ where
     }
 }
 
-pub(crate) struct Identifier<R>
+pub(crate) struct IdentifierRef<R>
 where
     R: Registry,
 {
@@ -105,7 +105,7 @@ where
     pointer: *const u8,
 }
 
-impl<R> Identifier<R>
+impl<R> IdentifierRef<R>
 where
     R: Registry,
 {
@@ -126,7 +126,7 @@ where
     }
 }
 
-impl<R> Clone for Identifier<R>
+impl<R> Clone for IdentifierRef<R>
 where
     R: Registry,
 {
@@ -139,9 +139,9 @@ where
     }
 }
 
-impl<R> Copy for Identifier<R> where R: Registry {}
+impl<R> Copy for IdentifierRef<R> where R: Registry {}
 
-impl<R> Hash for Identifier<R>
+impl<R> Hash for IdentifierRef<R>
 where
     R: Registry,
 {
@@ -153,7 +153,7 @@ where
     }
 }
 
-impl<R> PartialEq for Identifier<R>
+impl<R> PartialEq for IdentifierRef<R>
 where
     R: Registry,
 {
@@ -162,9 +162,9 @@ where
     }
 }
 
-impl<R> Eq for Identifier<R> where R: Registry {}
+impl<R> Eq for IdentifierRef<R> where R: Registry {}
 
-impl<R> Debug for Identifier<R>
+impl<R> Debug for IdentifierRef<R>
 where
     R: Registry,
 {

--- a/src/internal/archetype/identifier/mod.rs
+++ b/src/internal/archetype/identifier/mod.rs
@@ -181,7 +181,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{internal::archetype::IdentifierBuffer, registry};
+    use crate::{internal::archetype::Identifier, registry};
     use alloc::{vec, vec::Vec};
     use core::ptr;
     use hashbrown::HashSet;
@@ -203,29 +203,29 @@ mod tests {
 
     #[test]
     fn buffer_as_slice() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
 
         assert_eq!(unsafe { buffer.as_slice() }, &[1, 2, 3, 0]);
     }
 
     #[test]
     fn empty_buffer_as_slice() {
-        let buffer = unsafe { IdentifierBuffer::<registry!()>::new(Vec::new()) };
+        let buffer = unsafe { Identifier::<registry!()>::new(Vec::new()) };
 
         assert_eq!(unsafe { buffer.as_slice() }, &[]);
     }
 
     #[test]
     fn buffer_as_identifier() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let identifier = unsafe { buffer.as_identifier() };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let identifier = unsafe { buffer.as_ref() };
 
         assert!(ptr::eq(buffer.pointer, identifier.pointer));
     }
 
     #[test]
     fn buffer_iter() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
@@ -239,31 +239,31 @@ mod tests {
 
     #[test]
     fn buffer_size_of_components() {
-        let buffer = unsafe { IdentifierBuffer::<registry!(bool, u64, f32)>::new(vec![7]) };
+        let buffer = unsafe { Identifier::<registry!(bool, u64, f32)>::new(vec![7]) };
 
         assert_eq!(buffer.size_of_components(), 13);
     }
 
     #[test]
     fn buffer_eq() {
-        let buffer_a = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let buffer_b = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
+        let buffer_a = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let buffer_b = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
 
         assert_eq!(buffer_a, buffer_b);
     }
 
     #[test]
     fn identifier_as_slice() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let identifier = unsafe { buffer.as_identifier() };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let identifier = unsafe { buffer.as_ref() };
 
         assert_eq!(unsafe { identifier.as_slice() }, &[1, 2, 3, 0]);
     }
 
     #[test]
     fn identifier_iter() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let identifier = unsafe { buffer.as_identifier() };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let identifier = unsafe { buffer.as_ref() };
 
         assert_eq!(
             unsafe { identifier.iter() }.collect::<Vec<bool>>(),
@@ -277,16 +277,16 @@ mod tests {
 
     #[test]
     fn identifier_as_vec() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let identifier = unsafe { buffer.as_identifier() };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let identifier = unsafe { buffer.as_ref() };
 
         assert_eq!(identifier.as_vec(), vec![1, 2, 3, 0]);
     }
 
     #[test]
     fn identifier_get_unchecked() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let identifier = unsafe { buffer.as_identifier() };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let identifier = unsafe { buffer.as_ref() };
 
         assert!(unsafe { identifier.get_unchecked(9) });
         assert!(!unsafe { identifier.get_unchecked(10) });
@@ -294,24 +294,24 @@ mod tests {
 
     #[test]
     fn identifier_get_unchecked_first_element() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let identifier = unsafe { buffer.as_identifier() };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let identifier = unsafe { buffer.as_ref() };
 
         assert!(unsafe { identifier.get_unchecked(0) });
     }
 
     #[test]
     fn identifier_get_unchecked_last_element() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let identifier = unsafe { buffer.as_identifier() };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let identifier = unsafe { buffer.as_ref() };
 
         assert!(!unsafe { identifier.get_unchecked(25) });
     }
 
     #[test]
     fn identifier_clone() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let identifier = unsafe { buffer.as_identifier() };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let identifier = unsafe { buffer.as_ref() };
         let identifier_clone = identifier.clone();
 
         assert_eq!(identifier, identifier_clone);
@@ -319,8 +319,8 @@ mod tests {
 
     #[test]
     fn identifier_copy() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let identifier = unsafe { buffer.as_identifier() };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let identifier = unsafe { buffer.as_ref() };
         let identifier_copy = identifier;
 
         assert_eq!(identifier, identifier_copy);
@@ -328,9 +328,9 @@ mod tests {
 
     #[test]
     fn identifier_in_hashset() {
-        let buffer = unsafe { IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let identifier_a = unsafe { buffer.as_identifier() };
-        let identifier_b = unsafe { buffer.as_identifier() };
+        let buffer = unsafe { Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let identifier_a = unsafe { buffer.as_ref() };
+        let identifier_b = unsafe { buffer.as_ref() };
 
         let mut hashset = HashSet::new();
         hashset.insert(identifier_a);

--- a/src/internal/archetype/identifier/mod.rs
+++ b/src/internal/archetype/identifier/mod.rs
@@ -16,7 +16,7 @@ use core::{
 };
 use iter::IdentifierIter;
 
-pub(crate) struct IdentifierBuffer<R>
+pub(crate) struct Identifier<R>
 where
     R: Registry,
 {
@@ -26,7 +26,7 @@ where
     capacity: usize,
 }
 
-impl<R> IdentifierBuffer<R>
+impl<R> Identifier<R>
 where
     R: Registry,
 {
@@ -61,7 +61,7 @@ where
     }
 }
 
-impl<R> PartialEq for IdentifierBuffer<R>
+impl<R> PartialEq for Identifier<R>
 where
     R: Registry,
 {
@@ -70,7 +70,7 @@ where
     }
 }
 
-impl<R> Drop for IdentifierBuffer<R>
+impl<R> Drop for Identifier<R>
 where
     R: Registry,
 {
@@ -81,7 +81,7 @@ where
     }
 }
 
-impl<R> Debug for IdentifierBuffer<R>
+impl<R> Debug for Identifier<R>
 where
     R: Registry,
 {

--- a/src/internal/archetype/impl_debug.rs
+++ b/src/internal/archetype/impl_debug.rs
@@ -13,7 +13,7 @@ where
     R: RegistryDebug,
 {
     pointers: Vec<*const u8>,
-    identifier: archetype::Identifier<R>,
+    identifier: archetype::IdentifierRef<R>,
 }
 
 impl<R> Debug for Components<R>
@@ -80,7 +80,7 @@ where
                     identifier: *unsafe { entity_identifiers.get_unchecked(i) },
                     components: Components {
                         pointers: component_pointers,
-                        identifier: unsafe { self.identifier_buffer.as_identifier() },
+                        identifier: unsafe { self.identifier_buffer.as_ref() },
                     },
                 },
             );

--- a/src/internal/archetype/impl_serde.rs
+++ b/src/internal/archetype/impl_serde.rs
@@ -3,7 +3,7 @@ use crate::{
     entity,
     internal::{
         archetype,
-        archetype::{Archetype, IdentifierBuffer},
+        archetype::Archetype,
         registry::{RegistryDeserialize, RegistrySerialize},
     },
 };
@@ -305,7 +305,7 @@ where
 {
     lifetime: PhantomData<&'de ()>,
 
-    identifier: archetype::IdentifierBuffer<R>,
+    identifier: archetype::Identifier<R>,
     length: usize,
 }
 
@@ -497,7 +497,7 @@ where
 {
     lifetime: PhantomData<&'de ()>,
 
-    identifier: archetype::IdentifierBuffer<R>,
+    identifier: archetype::Identifier<R>,
     length: usize,
 }
 
@@ -610,7 +610,7 @@ where
             where
                 V: SeqAccess<'de>,
             {
-                let identifier: IdentifierBuffer<R> = seq
+                let identifier: archetype::Identifier<R> = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
 
@@ -649,7 +649,7 @@ where
             where
                 V: SeqAccess<'de>,
             {
-                let identifier: IdentifierBuffer<R> = seq
+                let identifier: archetype::Identifier<R> = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
 

--- a/src/internal/archetype/impl_serde.rs
+++ b/src/internal/archetype/impl_serde.rs
@@ -199,14 +199,13 @@ where
     }
 }
 
-// The deserialization should be done in-place. How can that be done?
 struct DeserializeRow<'a, 'de, R>
 where
     R: RegistryDeserialize<'de>,
 {
     lifetime: PhantomData<&'de ()>,
 
-    identifier: archetype::Identifier<R>,
+    identifier: archetype::IdentifierRef<R>,
 
     entity_identifiers: &'a mut (*mut entity::Identifier, usize),
     components: &'a mut [(*mut u8, usize)],
@@ -218,7 +217,7 @@ where
     R: RegistryDeserialize<'de>,
 {
     unsafe fn new(
-        identifier: archetype::Identifier<R>,
+        identifier: archetype::IdentifierRef<R>,
         entity_identifiers: &'a mut (*mut entity::Identifier, usize),
         components: &'a mut [(*mut u8, usize)],
         length: usize,
@@ -363,7 +362,7 @@ where
                 for i in 0..self.0.length {
                     let result = seq.next_element_seed(unsafe {
                         DeserializeRow::new(
-                            self.0.identifier.as_identifier(),
+                            self.0.identifier.as_ref(),
                             &mut entity_identifiers,
                             &mut components,
                             vec_length,

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -6,7 +6,7 @@ mod impl_send;
 #[cfg(feature = "serde")]
 mod impl_serde;
 
-pub(crate) use identifier::{Identifier, IdentifierBuffer, IdentifierIterator};
+pub(crate) use identifier::{IdentifierRef, IdentifierBuffer, IdentifierIterator};
 #[cfg(feature = "serde")]
 pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
 
@@ -100,7 +100,7 @@ where
         entity.push_components(&self.component_map, &mut self.components, self.length);
 
         let entity_identifier = entity_allocator.allocate(Location {
-            identifier: self.identifier_buffer.as_identifier(),
+            identifier: self.identifier_buffer.as_ref(),
             index: self.length,
         });
 
@@ -136,7 +136,7 @@ where
 
         let entity_identifiers = entity_allocator.allocate_batch(
             (self.length..(self.length + component_len)).map(|index| Location {
-                identifier: self.identifier_buffer.as_identifier(),
+                identifier: self.identifier_buffer.as_ref(),
                 index,
             }),
         );
@@ -333,8 +333,8 @@ where
         self.length - 1
     }
 
-    pub(crate) unsafe fn identifier(&self) -> Identifier<R> {
-        self.identifier_buffer.as_identifier()
+    pub(crate) unsafe fn identifier(&self) -> IdentifierRef<R> {
+        self.identifier_buffer.as_ref()
     }
 
     #[cfg(feature = "serde")]

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -6,7 +6,7 @@ mod impl_send;
 #[cfg(feature = "serde")]
 mod impl_serde;
 
-pub(crate) use identifier::{IdentifierRef, Identifier, IdentifierIterator};
+pub(crate) use identifier::{Identifier, IdentifierIterator, IdentifierRef};
 #[cfg(feature = "serde")]
 pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
 

--- a/src/internal/archetype/mod.rs
+++ b/src/internal/archetype/mod.rs
@@ -6,7 +6,7 @@ mod impl_send;
 #[cfg(feature = "serde")]
 mod impl_serde;
 
-pub(crate) use identifier::{IdentifierRef, IdentifierBuffer, IdentifierIterator};
+pub(crate) use identifier::{IdentifierRef, Identifier, IdentifierIterator};
 #[cfg(feature = "serde")]
 pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
 
@@ -35,7 +35,7 @@ pub(crate) struct Archetype<R>
 where
     R: Registry,
 {
-    identifier_buffer: IdentifierBuffer<R>,
+    identifier_buffer: Identifier<R>,
 
     entity_identifiers: (*mut entity::Identifier, usize),
     components: Vec<(*mut u8, usize)>,
@@ -49,7 +49,7 @@ where
     R: Registry,
 {
     pub(crate) unsafe fn from_raw_parts(
-        identifier_buffer: IdentifierBuffer<R>,
+        identifier_buffer: Identifier<R>,
         entity_identifiers: (*mut entity::Identifier, usize),
         components: Vec<(*mut u8, usize)>,
         length: usize,
@@ -68,7 +68,7 @@ where
         }
     }
 
-    pub(crate) unsafe fn new(identifier_buffer: IdentifierBuffer<R>) -> Self {
+    pub(crate) unsafe fn new(identifier_buffer: Identifier<R>) -> Self {
         let mut entity_identifiers = ManuallyDrop::new(Vec::new());
 
         let entity_len = identifier_buffer.iter().filter(|b| *b).count();

--- a/src/internal/archetypes/iter.rs
+++ b/src/internal/archetypes/iter.rs
@@ -31,7 +31,7 @@ impl<'a, R> Iterator for Iter<'a, R>
 where
     R: Registry + 'a,
 {
-    type Item = (archetype::Identifier<R>, &'a Archetype<R>);
+    type Item = (archetype::IdentifierRef<R>, &'a Archetype<R>);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.raw_iter.next().map(|archetype_bucket| {
@@ -71,7 +71,7 @@ impl<'a, R> Iterator for IterMut<'a, R>
 where
     R: Registry + 'a,
 {
-    type Item = (archetype::Identifier<R>, &'a mut Archetype<R>);
+    type Item = (archetype::IdentifierRef<R>, &'a mut Archetype<R>);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.raw_iter.next().map(|archetype_bucket| {

--- a/src/internal/archetypes/mod.rs
+++ b/src/internal/archetypes/mod.rs
@@ -70,7 +70,7 @@ where
 
     pub(crate) fn get_mut_or_insert_new(
         &mut self,
-        identifier_buffer: archetype::IdentifierBuffer<R>,
+        identifier_buffer: archetype::Identifier<R>,
     ) -> &mut Archetype<R> {
         let hash = Self::make_hash(
             unsafe { identifier_buffer.as_ref() },
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn get_mut_or_insert_new_insertion() {
         let mut archetypes = Archetypes::<Registry>::new();
-        let buffer = unsafe { archetype::IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
+        let buffer = unsafe { archetype::Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
 
         let archetype = archetypes.get_mut_or_insert_new(buffer);
     }
@@ -160,8 +160,8 @@ mod tests {
     #[test]
     fn get_mut_or_insert_new_already_inserted() {
         let mut archetypes = Archetypes::<Registry>::new();
-        let buffer_a = unsafe { archetype::IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
-        let buffer_b = unsafe { archetype::IdentifierBuffer::<Registry>::new(vec![1, 2, 3, 0]) };
+        let buffer_a = unsafe { archetype::Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
+        let buffer_b = unsafe { archetype::Identifier::<Registry>::new(vec![1, 2, 3, 0]) };
         archetypes.get_mut_or_insert_new(buffer_a);
 
         let archetype = archetypes.get_mut_or_insert_new(buffer_b);

--- a/src/internal/archetypes/mod.rs
+++ b/src/internal/archetypes/mod.rs
@@ -45,7 +45,10 @@ where
         }
     }
 
-    fn make_hash(identifier: archetype::IdentifierRef<R>, hash_builder: &ahash::RandomState) -> u64 {
+    fn make_hash(
+        identifier: archetype::IdentifierRef<R>,
+        hash_builder: &ahash::RandomState,
+    ) -> u64 {
         let mut state = hash_builder.build_hasher();
         identifier.hash(&mut state);
         state.finish()
@@ -72,10 +75,7 @@ where
         &mut self,
         identifier_buffer: archetype::Identifier<R>,
     ) -> &mut Archetype<R> {
-        let hash = Self::make_hash(
-            unsafe { identifier_buffer.as_ref() },
-            &self.hash_builder,
-        );
+        let hash = Self::make_hash(unsafe { identifier_buffer.as_ref() }, &self.hash_builder);
 
         match self.raw_archetypes.find(
             hash,

--- a/src/internal/archetypes/mod.rs
+++ b/src/internal/archetypes/mod.rs
@@ -45,7 +45,7 @@ where
         }
     }
 
-    fn make_hash(identifier: archetype::Identifier<R>, hash_builder: &ahash::RandomState) -> u64 {
+    fn make_hash(identifier: archetype::IdentifierRef<R>, hash_builder: &ahash::RandomState) -> u64 {
         let mut state = hash_builder.build_hasher();
         identifier.hash(&mut state);
         state.finish()
@@ -56,12 +56,12 @@ where
     }
 
     fn equivalent_identifier(
-        identifier: archetype::Identifier<R>,
+        identifier: archetype::IdentifierRef<R>,
     ) -> impl Fn(&Archetype<R>) -> bool {
         move |archetype: &Archetype<R>| unsafe { archetype.identifier() } == identifier
     }
 
-    pub(crate) fn get(&self, identifier: archetype::Identifier<R>) -> Option<&Archetype<R>> {
+    pub(crate) fn get(&self, identifier: archetype::IdentifierRef<R>) -> Option<&Archetype<R>> {
         self.raw_archetypes.get(
             Self::make_hash(identifier, &self.hash_builder),
             Self::equivalent_identifier(identifier),
@@ -73,13 +73,13 @@ where
         identifier_buffer: archetype::IdentifierBuffer<R>,
     ) -> &mut Archetype<R> {
         let hash = Self::make_hash(
-            unsafe { identifier_buffer.as_identifier() },
+            unsafe { identifier_buffer.as_ref() },
             &self.hash_builder,
         );
 
         match self.raw_archetypes.find(
             hash,
-            Self::equivalent_identifier(unsafe { identifier_buffer.as_identifier() }),
+            Self::equivalent_identifier(unsafe { identifier_buffer.as_ref() }),
         ) {
             Some(archetype_bucket) => unsafe { archetype_bucket.as_mut() },
             None => self.raw_archetypes.insert_entry(
@@ -92,7 +92,7 @@ where
 
     pub(crate) unsafe fn get_unchecked_mut(
         &mut self,
-        identifier: archetype::Identifier<R>,
+        identifier: archetype::IdentifierRef<R>,
     ) -> &mut Archetype<R> {
         self.raw_archetypes
             .get_mut(

--- a/src/internal/entity_allocator/mod.rs
+++ b/src/internal/entity_allocator/mod.rs
@@ -12,7 +12,7 @@ pub(crate) struct Location<R>
 where
     R: Registry,
 {
-    pub(crate) identifier: archetype::Identifier<R>,
+    pub(crate) identifier: archetype::IdentifierRef<R>,
     pub(crate) index: usize,
 }
 
@@ -20,7 +20,7 @@ impl<R> Location<R>
 where
     R: Registry,
 {
-    pub(crate) fn new(identifier: archetype::Identifier<R>, index: usize) -> Self {
+    pub(crate) fn new(identifier: archetype::IdentifierRef<R>, index: usize) -> Self {
         Self { identifier, index }
     }
 }

--- a/src/public/world/entry.rs
+++ b/src/public/world/entry.rs
@@ -55,7 +55,7 @@ where
             *unsafe { raw_identifier_buffer.get_unchecked_mut(component_index / 8) } |=
                 1 << (component_index % 8);
             let identifier_buffer =
-                unsafe { archetype::IdentifierBuffer::<R>::new(raw_identifier_buffer) };
+                unsafe { archetype::Identifier::<R>::new(raw_identifier_buffer) };
 
             // Insert to the corresponding archetype using the bytes and the new component.
             let archetype = self
@@ -105,7 +105,7 @@ where
             *unsafe { raw_identifier_buffer.get_unchecked_mut(component_index / 8) } ^=
                 1 << (component_index % 8);
             let identifier_buffer =
-                unsafe { archetype::IdentifierBuffer::<R>::new(raw_identifier_buffer) };
+                unsafe { archetype::Identifier::<R>::new(raw_identifier_buffer) };
 
             // Insert to the corresponding archetype using the bytes, skipping the removed
             // component.

--- a/src/public/world/mod.rs
+++ b/src/public/world/mod.rs
@@ -65,7 +65,7 @@ where
         unsafe {
             E::to_key(&mut key, &self.component_map);
         }
-        let identifier_buffer = unsafe { archetype::IdentifierBuffer::new(key) };
+        let identifier_buffer = unsafe { archetype::Identifier::new(key) };
 
         unsafe {
             self.archetypes
@@ -82,7 +82,7 @@ where
         unsafe {
             E::to_key(&mut key, &self.component_map);
         }
-        let identifier_buffer = unsafe { archetype::IdentifierBuffer::new(key) };
+        let identifier_buffer = unsafe { archetype::Identifier::new(key) };
 
         unsafe {
             self.archetypes


### PR DESCRIPTION
Renames `archetype::Identifier` to `archetype::IdentifierRef` and `archetype::IdentifierBuffer` to `archetype::Identifier`. This better clarifies which type is the owned value, and which type is the borrowed, as before it wasn't clear that `archetype::Identifier` was borrowed.