### PR TITLE
Improvements to results iterator

### DIFF
--- a/src/archetypes/impl_debug.rs
+++ b/src/archetypes/impl_debug.rs
@@ -6,6 +6,11 @@ where
     R: RegistryDebug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_map().entries(self.iter().map(|archetype| (unsafe {archetype.identifier()}, archetype))).finish()
+        f.debug_map()
+            .entries(
+                self.iter()
+                    .map(|archetype| (unsafe { archetype.identifier() }, archetype)),
+            )
+            .finish()
     }
 }

--- a/src/archetypes/impl_debug.rs
+++ b/src/archetypes/impl_debug.rs
@@ -6,6 +6,6 @@ where
     R: RegistryDebug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_map().entries(self.iter()).finish()
+        f.debug_map().entries(self.iter().map(|archetype| (unsafe {archetype.identifier()}, archetype))).finish()
     }
 }

--- a/src/archetypes/impl_eq.rs
+++ b/src/archetypes/impl_eq.rs
@@ -14,7 +14,7 @@ where
 
         self.iter().all(|archetype| {
             other
-                .get(unsafe {archetype.identifier()})
+                .get(unsafe { archetype.identifier() })
                 .map_or(false, |other_archetype| archetype == other_archetype)
         })
     }

--- a/src/archetypes/impl_eq.rs
+++ b/src/archetypes/impl_eq.rs
@@ -12,9 +12,9 @@ where
             return false;
         }
 
-        self.iter().all(|(identifier, archetype)| {
+        self.iter().all(|archetype| {
             other
-                .get(identifier)
+                .get(unsafe {archetype.identifier()})
                 .map_or(false, |other_archetype| archetype == other_archetype)
         })
     }

--- a/src/archetypes/impl_serde.rs
+++ b/src/archetypes/impl_serde.rs
@@ -17,7 +17,7 @@ where
     where
         S: Serializer,
     {
-        serializer.collect_seq(self.iter().map(|(_identifier, archetype)| archetype))
+        serializer.collect_seq(self.iter())
     }
 }
 

--- a/src/archetypes/iter.rs
+++ b/src/archetypes/iter.rs
@@ -31,9 +31,9 @@ where
     type Item = &'a Archetype<R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.raw_iter.next().map(|archetype_bucket|
-            unsafe { archetype_bucket.as_ref() }
-        )
+        self.raw_iter
+            .next()
+            .map(|archetype_bucket| unsafe { archetype_bucket.as_ref() })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -70,8 +70,8 @@ where
     type Item = &'a mut Archetype<R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.raw_iter.next().map(|archetype_bucket|
-            unsafe { archetype_bucket.as_mut() }
-        )
+        self.raw_iter
+            .next()
+            .map(|archetype_bucket| unsafe { archetype_bucket.as_mut() })
     }
 }

--- a/src/archetypes/iter.rs
+++ b/src/archetypes/iter.rs
@@ -74,4 +74,8 @@ where
             .next()
             .map(|archetype_bucket| unsafe { archetype_bucket.as_mut() })
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.raw_iter.size_hint()
+    }
 }

--- a/src/archetypes/iter.rs
+++ b/src/archetypes/iter.rs
@@ -28,13 +28,12 @@ impl<'a, R> Iterator for Iter<'a, R>
 where
     R: Registry + 'a,
 {
-    type Item = (archetype::IdentifierRef<R>, &'a Archetype<R>);
+    type Item = &'a Archetype<R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.raw_iter.next().map(|archetype_bucket| {
-            let archetype = unsafe { archetype_bucket.as_ref() };
-            (unsafe { archetype.identifier() }, archetype)
-        })
+        self.raw_iter.next().map(|archetype_bucket|
+            unsafe { archetype_bucket.as_ref() }
+        )
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/archetypes/iter.rs
+++ b/src/archetypes/iter.rs
@@ -1,4 +1,4 @@
-use crate::{archetype, archetype::Archetype, registry::Registry};
+use crate::{archetype::Archetype, registry::Registry};
 use core::marker::PhantomData;
 use hashbrown::raw::RawIter;
 
@@ -67,12 +67,11 @@ impl<'a, R> Iterator for IterMut<'a, R>
 where
     R: Registry + 'a,
 {
-    type Item = (archetype::IdentifierRef<R>, &'a mut Archetype<R>);
+    type Item = &'a mut Archetype<R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.raw_iter.next().map(|archetype_bucket| {
-            let archetype = unsafe { archetype_bucket.as_mut() };
-            (unsafe { archetype.identifier() }, archetype)
-        })
+        self.raw_iter.next().map(|archetype_bucket|
+            unsafe { archetype_bucket.as_mut() }
+        )
     }
 }

--- a/src/entity/allocator/impl_serde.rs
+++ b/src/entity/allocator/impl_serde.rs
@@ -226,7 +226,7 @@ where
                         *slot = Some(Slot {
                             generation: entity_identifier.generation,
                             location: Some(Location {
-                                identifier: unsafe {archetype.identifier()},
+                                identifier: unsafe { archetype.identifier() },
                                 index: i,
                             }),
                         });

--- a/src/entity/allocator/impl_serde.rs
+++ b/src/entity/allocator/impl_serde.rs
@@ -209,7 +209,7 @@ where
         }
 
         // Populate active slots from archetypes.
-        for (archetype_identifier, archetype) in archetypes.iter() {
+        for archetype in archetypes.iter() {
             for (i, entity_identifier) in archetype.entity_identifiers().enumerate() {
                 let slot = slots.get_mut(entity_identifier.index).ok_or_else(|| {
                     de::Error::custom(format!(
@@ -226,7 +226,7 @@ where
                         *slot = Some(Slot {
                             generation: entity_identifier.generation,
                             location: Some(Location {
-                                identifier: archetype_identifier,
+                                identifier: unsafe {archetype.identifier()},
                                 index: i,
                             }),
                         });

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -62,8 +62,8 @@ where
                     return result;
                 }
             }
-            let (_identifier, archetype) = self.archetypes_iter.find(|(identifier, _archetype)| unsafe {
-                And::<V, F>::filter(identifier.as_slice(), self.component_map)
+            let archetype = self.archetypes_iter.find(|archetype| unsafe {
+                And::<V, F>::filter(archetype.identifier().as_slice(), self.component_map)
             })?;
             self.current_results_iter = Some(archetype.view::<V>());
         }

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -68,6 +68,18 @@ where
             self.current_results_iter = Some(archetype.view::<V>());
         }
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (low, high) = self
+            .current_results_iter
+            .as_ref()
+            .map_or((0, Some(0)), V::Results::size_hint);
+        match (self.archetypes_iter.size_hint(), high) {
+            ((0, Some(0)), Some(_)) => (low, high),
+            _ => (low, None),
+        }
+    }
 }
 
 impl<'a, R, F, V> FusedIterator for Iter<'a, R, F, V>

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -70,7 +70,13 @@ where
     }
 }
 
-impl<'a, R, F, V> FusedIterator for Iter<'a, R, F, V> where R: Registry + 'a, F: Filter, V: Views<'a> {}
+impl<'a, R, F, V> FusedIterator for Iter<'a, R, F, V>
+where
+    R: Registry + 'a,
+    F: Filter,
+    V: Views<'a>,
+{
+}
 
 unsafe impl<'a, R, F, V> Send for Iter<'a, R, F, V>
 where

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -80,6 +80,25 @@ where
             _ => (low, None),
         }
     }
+
+    #[inline]
+    fn fold<A, Fold>(self, mut init: A, mut fold: Fold) -> A
+    where
+        Fold: FnMut(A, Self::Item) -> A,
+    {
+        if let Some(results) = self.current_results_iter {
+            init = results.fold(init, &mut fold);
+        }
+
+        self.archetypes_iter.fold(init, |acc, archetype| {
+            if unsafe { And::<V, F>::filter(archetype.identifier().as_slice(), self.component_map) }
+            {
+                archetype.view::<V>().fold(acc, &mut fold)
+            } else {
+                acc
+            }
+        })
+    }
 }
 
 impl<'a, R, F, V> FusedIterator for Iter<'a, R, F, V>

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     registry::Registry,
 };
-use core::{any::TypeId, marker::PhantomData};
+use core::{any::TypeId, iter::FusedIterator, marker::PhantomData};
 use hashbrown::HashMap;
 
 pub struct Iter<'a, R, F, V>
@@ -90,6 +90,8 @@ where
         }
     }
 }
+
+impl<'a, R, F, V> FusedIterator for Iter<'a, R, F, V> where R: Registry + 'a, F: Filter, V: Views<'a> {}
 
 unsafe impl<'a, R, F, V> Send for Iter<'a, R, F, V>
 where


### PR DESCRIPTION
Implements `FusedIterator` for `result::Iter`, as well as implementing `size_hint` and `fold` methods rather than relying on default implementations.

Resolves #36 and #37.