### PR TITLE
Annotate feature-gated items using `doc_cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.58.0"
 
+[package.metadata.docs.rs]
+# To build locally:
+# RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --no-deps --open
+all-features = true
+rustdoc-args = ["--cfg", "doc_cfg"]
+
 [dependencies]
 ahash = {version = "0.7.6", default-features = false}
 either = {version = "1.6.1", default-features = false}

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "serde")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod impl_serde;
 mod iter;
 

--- a/src/archetype/impl_serde.rs
+++ b/src/archetype/impl_serde.rs
@@ -13,6 +13,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 pub(crate) struct SerializeColumn<'a, C>(pub(crate) &'a Vec<C>)
 where
     C: Component + Serialize;
@@ -413,6 +414,7 @@ where
     }
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 pub(crate) struct DeserializeColumn<'de, C>
 where
     C: Component + Deserialize<'de>,

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -4,6 +4,7 @@ mod impl_drop;
 mod impl_eq;
 mod impl_send;
 #[cfg(feature = "serde")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod impl_serde;
 
 pub(crate) use identifier::{Identifier, IdentifierIterator, IdentifierRef};
@@ -171,6 +172,7 @@ where
     }
 
     #[cfg(feature = "parallel")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub(crate) fn par_view<'a, V>(&mut self) -> V::ParResults
     where
         V: ParViews<'a>,
@@ -337,6 +339,7 @@ where
     }
 
     #[cfg(feature = "serde")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
     pub(crate) fn entity_identifiers(&self) -> impl Iterator<Item = &entity::Identifier> {
         unsafe { slice::from_raw_parts(self.entity_identifiers.0, self.length) }.iter()
     }

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -1,6 +1,7 @@
 mod impl_debug;
 mod impl_eq;
 #[cfg(feature = "serde")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod impl_serde;
 mod iter;
 #[cfg(feature = "parallel")]

--- a/src/archetypes/par_iter.rs
+++ b/src/archetypes/par_iter.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 use hashbrown::raw::rayon::RawParIter;
 use rayon::iter::{plumbing::UnindexedConsumer, ParallelIterator};
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub(crate) struct ParIterMut<'a, R>
 where
     R: Registry,
@@ -45,6 +46,7 @@ impl<R> Archetypes<R>
 where
     R: Registry,
 {
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub(crate) fn par_iter_mut(&mut self) -> ParIterMut<R> {
         ParIterMut::new(unsafe { self.raw_archetypes.par_iter() })
     }

--- a/src/entity/allocator/impl_serde.rs
+++ b/src/entity/allocator/impl_serde.rs
@@ -48,6 +48,7 @@ where
     }
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 pub(crate) struct DeserializeAllocator<'a, R>
 where
     R: Registry,

--- a/src/entity/allocator/mod.rs
+++ b/src/entity/allocator/mod.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "serde")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod impl_serde;
 
 #[cfg(feature = "serde")]

--- a/src/entity/identifier/mod.rs
+++ b/src/entity/identifier/mod.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "serde")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod impl_serde;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -4,6 +4,7 @@ macro_rules! define_null {
         pub struct Null;
 
         #[cfg(feature = "serde")]
+        #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
         mod impl_serde {
             use super::Null;
             use core::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 extern crate alloc;
 

--- a/src/query/result/par_iter.rs
+++ b/src/query/result/par_iter.rs
@@ -14,6 +14,7 @@ use rayon::iter::{
     ParallelIterator,
 };
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub struct ParIter<'a, R, F, V>
 where
     R: Registry,

--- a/src/query/view/par/mod.rs
+++ b/src/query/view/par/mod.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use seal::{ParViewSeal, ParViewsSeal};
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub trait ParView<'a>: Filter + ParViewSeal<'a> {}
 
 impl<'a, C> ParView<'a> for &C where C: Component + Sync {}
@@ -19,6 +20,7 @@ impl<'a, C> ParView<'a> for Option<&mut C> where C: Component + Send {}
 
 impl<'a> ParView<'a> for entity::Identifier {}
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub trait ParViews<'a>: Filter + ParViewsSeal<'a> {}
 
 impl<'a> ParViews<'a> for Null {}

--- a/src/registry/serde.rs
+++ b/src/registry/serde.rs
@@ -8,6 +8,7 @@ use ::serde::{de, de::SeqAccess, ser::SerializeTuple, Deserialize, Serialize};
 use alloc::{format, vec::Vec};
 use core::{any::type_name, mem::ManuallyDrop};
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub trait RegistrySerialize: Registry {
     unsafe fn serialize_components_by_column<R, S>(
         components: &[(*mut u8, usize)],
@@ -120,6 +121,7 @@ where
     }
 }
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub trait RegistryDeserialize<'de>: Registry + 'de {
     unsafe fn deserialize_components_by_column<R, V>(
         components: &mut Vec<(*mut u8, usize)>,

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "parallel")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub mod schedule;
 
 mod null;
@@ -9,6 +10,7 @@ pub use null::Null;
 #[cfg(feature = "parallel")]
 pub use par::ParSystem;
 #[cfg(feature = "parallel")]
+#[doc(inline)]
 pub use schedule::Schedule;
 
 use crate::{

--- a/src/system/par.rs
+++ b/src/system/par.rs
@@ -4,6 +4,7 @@ use crate::{
     world::World,
 };
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub trait ParSystem<'a> {
     type Filter: Filter;
     type Views: ParViews<'a>;

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -13,6 +13,7 @@ use crate::{registry::Registry, world::World};
 use sendable::SendableWorld;
 use stage::Stages;
 
+#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub struct Schedule<S> {
     stages: S,
 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -4,6 +4,7 @@ mod impl_default;
 mod impl_eq;
 mod impl_send;
 #[cfg(feature = "serde")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod impl_serde;
 mod impl_sync;
 
@@ -101,6 +102,7 @@ where
     }
 
     #[cfg(feature = "parallel")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub fn par_query<'a, V, F>(&'a mut self) -> result::ParIter<'a, R, F, V>
     where
         V: ParViews<'a>,
@@ -110,6 +112,7 @@ where
     }
 
     #[cfg(feature = "parallel")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub(crate) unsafe fn query_unchecked<'a, V, F>(&'a self) -> result::Iter<'a, R, F, V>
     where
         V: Views<'a>,
@@ -120,6 +123,7 @@ where
     }
 
     #[cfg(feature = "parallel")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub(crate) unsafe fn par_query_unchecked<'a, V, F>(&'a self) -> result::ParIter<'a, R, F, V>
     where
         V: ParViews<'a>,
@@ -130,6 +134,7 @@ where
     }
 
     #[cfg(feature = "parallel")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub fn run<'a, S>(&'a mut self, schedule: &'a mut Schedule<S>)
     where
         S: Stages<'a>,


### PR DESCRIPTION
This PR uses the unstable `doc_cfg` feature to annotate feature-gated items to display the required features in documentation. It is enabled by a `--cfg` flag passed to rustdoc, which seems to be standard across other crates (at least it is on the ones I looked at, which were `rand` and `syn`).  This fixes #25.