### PR TITLE
Documentation for public API

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -1,11 +1,11 @@
 //! Types defining a single aspect of an entity.
 //!
 //! Components are defined as any type that implements the [`Component`] trait. This trait is
-//! implemented automatically for any type that can be a component (which is any type that 
+//! implemented automatically for any type that can be a component (which is any type that
 //! implements the [`Any`] trait), so users will be unable to implement it manually.
 //!
 //! A set of unique components forms an entity. A unique component is a component with a unique
-//! type, meaning entities cannot be created using the same component type multiple times. 
+//! type, meaning entities cannot be created using the same component type multiple times.
 //! Therefore, the
 //! [newtype idiom](https://doc.rust-lang.org/rust-by-example/generics/new_types.html) is useful
 //! when defining component types. For example, suppose we are defining an entity made up of two

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -17,7 +17,6 @@ macro_rules! non_root_macro {
         }
     ) => (
         $(#[$m])*
-        #[doc(hidden)]
         #[cfg(not(doc_cfg))]
         #[macro_export]
         macro_rules! $name {

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -1,0 +1,43 @@
+//! Documentation-specific tools.
+//!
+//! These are items specific to this crate's documentation. Nothing contained in this module should
+//! affect how this crate works logically; things included here should only affect how the crate is
+//! documented.
+
+/// Defines a macro that is not documented at the crate's root.
+///
+/// This changes the way the macro is defined only when the `doc_cfg` cfg flag is passed. It
+/// utilizes the unstable `decl_macro` nightly feature to define the macro in-place, rather than
+/// defining it at the root level of the crate.
+macro_rules! non_root_macro {
+    (
+        $(#[$m:meta])*
+        macro_rules! $name:ident {
+            $(($($token:tt)*) => ($($expansion:tt)*));* $(;)?
+        }
+    ) => (
+        $(#[$m])*
+        #[doc(hidden)]
+        #[cfg(not(doc_cfg))]
+        #[macro_export]
+        macro_rules! $name {
+            $(
+                ($($token)*) => ($($expansion)*)
+            );*
+        }
+
+        $(#[$m])*
+        #[cfg(not(doc_cfg))]
+        pub use $name;
+
+        $(#[$m])*
+        #[cfg(doc_cfg)]
+        pub macro $name {
+            $(
+                ($($token)*) => ($($expansion)*)
+            ),*
+        }
+    )
+}
+
+pub(crate) use non_root_macro;

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -1,3 +1,39 @@
+//! A heterogeneous list of batches of [`Component`]s stored within a [`World`].
+//!
+//! A [`Batch`] of [`Entities`] is a container of entities all made of the same combination of
+//! `Component`s. Inserting a `Batch` of `Entities` is much more efficient than storing them one at
+//! a time.
+//!
+//! `Batch`es of entities are most often defined using the [`entities!`] macro. The items
+//! contained within this module should rarely be needed in user code.
+//!
+//! `Entity`s are stored within [`World`]s to allow efficient querying and iteration with other
+//! entities of similar components. Since entities are defined as heterogeneous lists, they can be
+//! made of an arbitrary number of components. `World`s can store entities made up of any
+//! combination of components, so long as those components are stored in the `World`'s
+//! [`Registry`].
+//!
+//! # Example
+//! ``` rust
+//! use brood::{entities, registry, World};
+//!
+//! // Define components.
+//! struct Foo(usize);
+//! struct Bar(bool);
+//!
+//! type Registry = registry!(Foo, Bar);
+//!
+//! let mut world = World::<Registry>::new();
+//!
+//! world.extend(entities!((Foo(42), Bar(false)), (Foo(100), Bar(true))));
+//! ```
+//!
+//! [`Batch`]: crate::entities::Batch
+//! [`Component`]: crate::component::Component
+//! [`Entities`]: crate::entities::Entities
+//! [`entities!`]: crate::entities!
+//! [`World`]: crate::world::World
+
 mod seal;
 
 use crate::{component::Component, hlist::define_null};

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -53,7 +53,7 @@ define_null!();
 ///
 /// Note that entities must consist of unique component types. Duplicate components are not
 /// supported. When multiple components of the same type are included in an entity, a `World` will
-/// only store one of those components. 
+/// only store one of those components.
 ///
 /// # Example
 /// ``` rust
@@ -121,7 +121,7 @@ where
     ///
     /// Note that this method can only be called using a raw heterogeneous list of entity columns.
     /// There is currently no macro that can make the call simpler. It is recommended to use the
-    /// [`entities!`] macro instead of this method. 
+    /// [`entities!`] macro instead of this method.
     ///
     /// # Example
     /// ``` rust
@@ -143,7 +143,7 @@ where
 
     /// Creates a new `Batch`, wrapping the given [`Entities`] heterogeneous list, skipping any
     /// run-time checks for column length.
-    /// 
+    ///
     /// Note that this method can only be called using a raw heterogeneous list of entity columns.
     /// There is currently no macro that can make the call simpler. It is recommended to use the
     /// [`entities!`] macro instead of this method.

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -32,6 +32,7 @@
 //! [`Component`]: crate::component::Component
 //! [`Entities`]: crate::entities::Entities
 //! [`entities!`]: crate::entities!
+//! [`Registry`]: crate::registry::Registry
 //! [`World`]: crate::world::World
 
 mod seal;
@@ -42,6 +43,34 @@ use seal::Seal;
 
 define_null!();
 
+/// A heterogeneous list of columns of [`Component`]s.
+///
+/// In order for `Entities` to be able to be used, it must be contained within a [`Batch`]. This
+/// guarnatees that the length of all columns within the heterogeneous list are equal.
+///
+/// Entities are stored within [`World`]s. In order for an entity to be able to be stored within a
+/// `World`, that `World`'s [`Registry`] must include the `Component`s that make up an entity.
+///
+/// Note that entities must consist of unique component types. Duplicate components are not
+/// supported. When multiple components of the same type are included in an entity, a `World` will
+/// only store one of those components. 
+///
+/// # Example
+/// ``` rust
+/// use brood::entities;
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+///
+/// // Creates `Entities` wrapped in a `Batch` struct.
+/// let entities = entities!((Foo(42), Bar(true)), (Foo(100), Bar(false)));
+/// ```
+///
+/// [`Batch`]: crate::entities::Batch
+/// [`Component`]: crate::component::Component
+/// [`Registry`]: crate::registry::Registry
+/// [`World`]: crate::world::World
 pub trait Entities: Seal {}
 
 impl Entities for Null {}

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -38,6 +38,56 @@ where
     }
 }
 
+/// Creates a batch of entities made from the same components.
+///
+/// This macro allows multiple entities to be defined for efficient storage within a [`World`]. The
+/// syntax is similar to an array expression or the [`vec!`] macro. There are two forms of this
+/// macro:
+///
+/// # Create entities given a list of tuples of components
+///
+/// ``` rust
+/// use brood::entities;
+///
+/// // Define components `Foo` and `Bar`.
+/// struct Foo(u16);
+/// struct Bar(f32);
+///
+/// let my_entities = entities![(Foo(42), Bar(1.5)), (Foo(4), Bar(1.0))];
+/// ```
+///
+/// Note that all tuples must be made from the same components in the same order.
+///
+/// # Create entities from a tuple of components and a size
+///
+/// ``` rust
+/// use brood::entities;
+///
+/// // Define components `Foo` and `Bar`.
+/// #[derive(Clone)]
+/// struct Foo(u16);
+///
+/// #[derive(Clone)]
+/// struct Bar(f32);
+///
+/// let my_entities = entities![(Foo(42), Bar(1.5)); 3];
+/// ```
+///
+/// This syntax only supports entities made from components that implement [`Clone`], and the size
+/// does not have to be a constant value.
+///
+/// This will call `clone()` to duplicate each component, so one should be careful with types that
+/// have a nonstandard `Clone` implementation. For example, using `Rc` as a component value in this
+/// context will create multiple entities with references to the same boxed value, not multiple
+/// references to independently boxed values.
+///
+/// Using `0` as a size is allowed, and produces a container of no entities. This will still
+/// evaluate all expressions passed as components, however, and immediately drop the resulting
+/// values, so be mindful of side effects.
+///
+/// [`Clone`]: core::clone::Clone
+/// [`World`]: crate::World
+/// [`vec!`]: alloc::vec!
 #[macro_export]
 macro_rules! entities {
     (($component:expr $(,$components:expr)* $(,)?); $n:expr) => {

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -53,6 +53,28 @@ where
 {
 }
 
+/// A batch of entity columns of unified length.
+///
+/// This is a wrapper for an [`Entities`] heterogeneous list of columns of components, with the
+/// guarantee that all columns are of the same length. In other words, this is a collection of
+/// entities separated column-wise into their components.
+///
+/// A `Batch` is most often created using the [`entities!`] macro.
+///
+/// # Example
+/// ``` rust
+/// use brood::entities;
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+///
+/// // This defines a `Batch` of entities, with guaranteed equal column length.
+/// let entities = entities!((Foo(42), Bar(false)), (Foo(100), Bar(true)));
+/// ```
+///
+/// [`Entities`]: crate::entities::Entities
+/// [`entities!`]: crate::entities!
 pub struct Batch<E>
 where
     E: Entities,
@@ -64,11 +86,54 @@ impl<E> Batch<E>
 where
     E: Entities,
 {
+    /// Creates a new `Batch`, wrapping the given [`Entities`] heterogeneous list.
+    ///
+    /// This method performs a run-time check to ensure the columns are all the same length.
+    ///
+    /// Note that this method can only be called using a raw heterogeneous list of entity columns.
+    /// There is currently no macro that can make the call simpler. It is recommended to use the
+    /// [`entities!`] macro instead of this method. 
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entities, entities::Batch};
+    ///
+    /// // Define components.
+    /// struct Foo(usize);
+    /// struct Bar(bool);
+    ///
+    /// let batch = Batch::new((vec![42; 10], (vec![true; 10] ,entities::Null)));
+    /// ```
+    ///
+    /// [`Entities`]: crate::entities::Entities
+    /// [`entities!]: crate::entities!
     pub fn new(entities: E) -> Self {
         assert!(entities.check_len());
         unsafe { Self::new_unchecked(entities) }
     }
 
+    /// Creates a new `Batch`, wrapping the given [`Entities`] heterogeneous list, skipping any
+    /// run-time checks for column length.
+    /// 
+    /// Note that this method can only be called using a raw heterogeneous list of entity columns.
+    /// There is currently no macro that can make the call simpler. It is recommended to use the
+    /// [`entities!`] macro instead of this method.
+    ///
+    /// # Safety
+    /// The caller must guarantee that the lengths of all columns within `entities` are equal.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entities, entities::Batch};
+    ///
+    /// // Define components.
+    /// struct Foo(usize);
+    /// struct Bar(bool);
+    ///
+    /// let batch = unsafe { Batch::new_unchecked((vec![42; 10], (vec![true; 10] ,entities::Null))) };
+    /// ```
+    /// [`Entities`]: crate::entities::Entities
+    /// [`entities!]: crate::entities!
     pub unsafe fn new_unchecked(entities: E) -> Self {
         Self { entities }
     }

--- a/src/entity/identifier/mod.rs
+++ b/src/entity/identifier/mod.rs
@@ -2,6 +2,31 @@
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod impl_serde;
 
+/// A unique identifier for an entity.
+///
+/// An `Identifier` can be used to reference an entity that is stored within a [`World`].
+/// `Identifier`s are normally obtained when inserting an entity into a `World`, although they can
+/// also be obtained through a [`query`] on a `World` by providing `Identifier` as a [`View`].
+///
+/// # Example
+/// ``` rust
+/// use brood::{entity, registry, World};
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+///
+/// type Registry = registry!(Foo, Bar);
+///
+/// let mut world = World::<Registry>::new();
+///
+/// // An identifier is returned on insertion.
+/// let entity_identifier = world.push(entity!(Foo(42), Bar(false)));
+/// ```
+///
+/// [`query`]: crate::world::World::query()
+/// [`View`]: crate::query::view::View
+/// [`World`]: crate::world::World
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Identifier {
     pub(crate) index: usize,

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -23,7 +23,7 @@
 //!
 //! // Store an entity containing both `Foo` and `Bar`.
 //! world.push(entity!(Foo(42), Bar(false)));
-//! 
+//!
 //! // Store an entity containing only `Bar`.
 //! world.push(entity!(Bar(true)));
 //!
@@ -58,7 +58,7 @@ define_null!();
 ///
 /// Note that entities must consist of unique component types. Duplicate components are not
 /// supported. When multiple components of the same type are included in an entity, a `World` will
-/// only store one of those components. 
+/// only store one of those components.
 ///
 /// # Example
 /// ``` rust

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -1,4 +1,4 @@
-//! A heterogeneous list of [`Component`]s.
+//! A heterogeneous list of [`Component`]s stored within a [`World`].
 //!
 //! [`Entity`]s are most often defined using the [`entity!`] macro. The items contained within this
 //! module should rarely be needed in user code, apart from [`Identifier`].

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -12,6 +12,29 @@ use seal::Seal;
 
 define_null!();
 
+/// A heterogeneous list of [`Component`]s.
+///
+/// Entities are stored within [`World`]s. In order for an entity to be able to be stored within a
+/// `World`, that `World`'s [`Registry`] must include the `Component`s that make up an entity.
+///
+/// Note that entities must consist of unique component types. Duplicate components are not
+/// supported. When multiple components of the same type are included in an entity, a `World` will
+/// only store one of those components. 
+///
+/// # Example
+/// ``` rust
+/// use brood::entity;
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+///
+/// let entity = entity!(Foo(42), Bar(true));
+/// ```
+///
+/// [`Component`]: crate::component::Component
+/// [`Registry`]: crate::registry::Registry
+/// [`World`]: crate::world::World
 pub trait Entity: Seal {}
 
 impl Entity for Null {}

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -1,3 +1,42 @@
+//! A heterogeneous list of [`Component`]s.
+//!
+//! [`Entity`]s are most often defined using the [`entity!`] macro. The items contained within this
+//! module should rarely be needed in user code, apart from [`Identifier`].
+//!
+//! `Entity`s are stored within [`World`]s to allow efficient querying and iteration with other
+//! entities of similar components. Since entities are defined as heterogeneous lists, they can be
+//! made of an arbitrary number of components. `World`s can store entities made up of any
+//! combination of components, so long as those components are stored in the `World`'s
+//! [`Registry`].
+//!
+//! # Example
+//! ``` rust
+//! use brood::{entity, registry, World};
+//!
+//! // Define components.
+//! struct Foo(usize);
+//! struct Bar(bool);
+//!
+//! type Registry = registry!(Foo, Bar);
+//!
+//! let mut world = World::<Registry>::new();
+//!
+//! // Store an entity containing both `Foo` and `Bar`.
+//! world.push(entity!(Foo(42), Bar(false)));
+//! 
+//! // Store an entity containing only `Bar`.
+//! world.push(entity!(Bar(true)));
+//!
+//! // Store an entity containing zero components.
+//! world.push(entity!());
+//! ```
+//!
+//! [`Entity`]: crate::entity::Entity
+//! [`entity!`]: crate::entity!
+//! [`Identifier`]: crate::entity::Identifier
+//! [`Registry`]: crate::registry::Registry
+//! [`World`]: crate::world::World
+
 pub(crate) mod allocator;
 
 mod identifier;

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -1,5 +1,11 @@
 macro_rules! define_null {
     () => {
+        /// Represents the end of a heterogeneous list.
+        ///
+        /// This struct is used when defining heterogeneous lists. Normally, it will be constructed
+        /// by a macro and the user will not have to interact directly with it. `Null` is placed at
+        /// the inner-most level of the nested tuples that make up a heterogeneous list to denote
+        /// the end of the list.
         #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
         pub struct Null;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![cfg_attr(doc_cfg, feature(doc_cfg, decl_macro))]
 
 extern crate alloc;
 
@@ -16,6 +16,7 @@ pub mod reexports;
 
 mod archetype;
 mod archetypes;
+mod doc;
 mod hlist;
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,5 @@ mod archetype;
 mod archetypes;
 mod hlist;
 
+#[doc(inline)]
 pub use world::World;

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -12,6 +12,21 @@ use crate::{
 };
 use core::marker::PhantomData;
 
+/// A filter for entities.
+///
+/// `Filter`s are used to filter results when querying entities. Along with [`Views`], they are
+/// what make up a query over a [`World`]. They provide the ability to query based on a 
+/// [`Component`] without actually having to borrow the `Component`'s value.
+///
+/// Note that some `Views` provide implicit `Filter`s. Specifically, non-optional views over a
+/// `Component` `C` (`&C` and `&mut C`) both implicitly [`And`] a [`Has<C>`] `Filter` with other
+/// `Filter`s.
+///
+/// [`And`]: crate::query::filter::And
+/// [`Component`]: crate::component::Component
+/// [`Has<C>`]: crate::query::filter::Has
+/// [`Views`]: crate::query::view::Views
+/// [`World`]: crate::world::World
 pub trait Filter: Seal {}
 
 /// An empty filter.

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -1,3 +1,19 @@
+//! Filters for entities.
+//!
+//! `Filter`s are used to filter results when querying entities. Along with [`Views`], they are
+//! what make up a query over a [`World`]. They provide the ability to query based on a 
+//! [`Component`] without actually having to borrow the `Component`'s value.
+//!
+//! Note that some `Views` provide implicit `Filter`s. Specifically, non-optional views over a
+//! `Component` `C` (`&C` and `&mut C`) both implicitly [`And`] a [`Has<C>`] `Filter` with other
+//! `Filter`s.
+//!
+//! [`And`]: crate::query::filter::And
+//! [`Component`]: crate::component::Component
+//! [`Has<C>`]: crate::query::filter::Has
+//! [`Views`]: crate::query::view::Views
+//! [`World`]: crate::world::World
+
 mod seal;
 
 pub(crate) use seal::Seal;

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -20,7 +20,7 @@ impl Filter for None {}
 
 /// Filter based on whether a [`Component`] is present in an entity.
 ///
-/// This filters out any entities which do not have the component `C`. No borrow of the value `C`
+/// This filters out any entities which do not have the `Component` `C`. No borrow of the value `C`
 /// from the entity is required.
 ///
 /// # Example'
@@ -44,6 +44,25 @@ where
 
 impl<C> Filter for Has<C> where C: Component {}
 
+/// Filter using the logical inverse of another [`Filter`].
+///
+/// This filters out any entities which would not have been filtered by the `Filter` `F`.
+///
+/// # Example
+/// ``` rust
+/// use brood::query::filter;
+///
+/// // Define a component.
+/// struct Foo(usize);
+///
+/// // Define a filter for the component above.
+/// type HasFoo = filter::Has<Foo>;
+///
+/// // Define a component that is the inverse of the filter above.
+/// type DoesNotHaveFoo = filter::Not<HasFoo>;
+/// ```
+///
+/// [`Filter`]: crate::query::filter::Filter
 pub struct Not<F>
 where
     F: Filter,

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -18,6 +18,23 @@ pub struct None;
 
 impl Filter for None {}
 
+/// Filter based on whether a [`Component`] is present in an entity.
+///
+/// This filters out any entities which do not have the component `C`. No borrow of the value `C`
+/// from the entity is required.
+///
+/// # Example'
+/// ``` rust
+/// use brood::query::filter;
+///
+/// // Define a component.
+/// struct Foo(usize);
+///
+/// // Define a filter for the component above.
+/// type HasFoo = filter::Has<Foo>;
+/// ```
+///
+/// [`Component`]: crate::component::Component
 pub struct Has<C>
 where
     C: Component,

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -1,7 +1,7 @@
 //! Filters for entities.
 //!
 //! `Filter`s are used to filter results when querying entities. Along with [`Views`], they are
-//! what make up a query over a [`World`]. They provide the ability to query based on a 
+//! what make up a query over a [`World`]. They provide the ability to query based on a
 //! [`Component`] without actually having to borrow the `Component`'s value.
 //!
 //! Note that some `Views` provide implicit `Filter`s. Specifically, non-optional views over a
@@ -31,7 +31,7 @@ use core::marker::PhantomData;
 /// A filter for entities.
 ///
 /// `Filter`s are used to filter results when querying entities. Along with [`Views`], they are
-/// what make up a query over a [`World`]. They provide the ability to query based on a 
+/// what make up a query over a [`World`]. They provide the ability to query based on a
 /// [`Component`] without actually having to borrow the `Component`'s value.
 ///
 /// Note that some `Views` provide implicit `Filter`s. Specifically, non-optional views over a

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -86,6 +86,28 @@ where
 
 impl<F> Filter for Not<F> where F: Filter {}
 
+/// Filter entities which are filtered by two [`Filter`]s.
+///
+/// This filter is a logical `and` between two `Filter`s `F1` and `F2`. Any entity filtered out by
+/// either `Filter` will be filtered out by the `And` filter.
+///
+/// # Example
+/// ``` rust
+/// use brood::query::filter;
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+///
+/// // Define filters based on the above components.
+/// type HasFoo = filter::Has<Foo>;
+/// type HasBar = filter::Has<Bar>;
+///
+/// // Define a filter using a combination of the above filters.
+/// type HasFooAndBar = filter::And<HasFoo, HasBar>;
+/// ```
+///
+/// [`Filter`]: crate::query::filter::Filter
 pub struct And<F1, F2>
 where
     F1: Filter,

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -124,6 +124,28 @@ where
 {
 }
 
+/// Filter entities which are filtered by one of two [`Filter`]s.
+///
+/// This filter is a logical `or` between two `Filter`s `F1` and `F2`. Any entity filtered out by
+/// both `Filter`s will be filtered out by the `Or` filter.
+///
+/// # Example
+/// ``` rust
+/// use brood::query::filter;
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+///
+/// // Define filters based on the above components.
+/// type HasFoo = filter::Has<Foo>;
+/// type HasBar = filter::Has<Bar>;
+///
+/// // Define a filter using a combination of the above filters.
+/// type HasFooOrBar = filter::Or<HasFoo, HasBar>;
+/// ```
+///
+/// [`Filter`]: crate::query::filter::Filter
 pub struct Or<F1, F2>
 where
     F1: Filter,

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -14,6 +14,20 @@ use core::marker::PhantomData;
 
 pub trait Filter: Seal {}
 
+/// An empty filter.
+///
+/// This filter is used when a filter is required but nothing is needed to be filtered. For
+/// example, some queries don't need any additional filtering beyond the filtering already provided
+/// by their [`Views`]. This filter can be provided in those cases.
+///
+/// # Example
+/// ``` rust
+/// use brood::query::filter;
+///
+/// type NoFilter = filter::None;
+/// ```
+///
+/// [`Views`]: crate::query::view::Views
 pub struct None;
 
 impl Filter for None {}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -43,6 +43,6 @@ pub mod view;
 pub(crate) mod claim;
 
 #[doc(inline)]
-pub use view::views;
-#[doc(inline)]
 pub use result::result;
+#[doc(inline)]
+pub use view::views;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -5,6 +5,6 @@ pub mod view;
 pub(crate) mod claim;
 
 #[doc(inline)]
-pub use crate::views;
+pub use view::views;
 #[doc(inline)]
 pub use result::result;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -5,4 +5,6 @@ pub mod view;
 pub(crate) mod claim;
 
 #[doc(inline)]
+pub use crate::views;
+#[doc(inline)]
 pub use crate::result;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,3 +1,41 @@
+//! Queries over [`World`]s.
+//!
+//! Entities within a `World` are difficult to interact with directly due to being made of
+//! heterogeneous lists of [`Component`]s. Therefore, queries can be executed to give [`Views`] of
+//! `Component`s within the entities stored in a `World`.
+//!
+//! Queries are made up of `Views`, giving access to `Component`s, and [`Filter`]s which can filter
+//! which entities are viewed. Query results are returned as heterogeneous lists, so the
+//! [`result!`] macro is provided to unpack the results.
+//!
+//! # Example
+//! The below example queries mutably for the component `Foo`, immutably for the component `Bar`,
+//! and filters out entities that do not have the component `Baz`.
+//!
+//! ``` rust
+//! use brood::{entity, query::{filter, result, views}, registry, World};
+//!
+//! // Define components.
+//! struct Foo(u32);
+//! struct Bar(bool);
+//! struct Baz(f64);
+//!
+//! type Registry = registry!(Foo, Bar, Baz);
+//!
+//! let mut world = World::<Registry>::new();
+//! world.push(entity!(Foo(42), Bar(true), Baz(1.5)));
+//!
+//! for result!(foo, bar) in world.query::<views!(&mut Foo, &Bar), filter::Has<Baz>>() {
+//!     // Do something.
+//! }
+//! ```
+//!
+//! [`Component`]: crate::component::Component
+//! [`Filter`]: crate::query::filter::Filter
+//! [`result!`]: crate::query::result!
+//! [`Views`]: crate::query::view::Views
+//! [`World`]: crate::world::World
+
 pub mod filter;
 pub mod result;
 pub mod view;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -7,4 +7,4 @@ pub(crate) mod claim;
 #[doc(inline)]
 pub use crate::views;
 #[doc(inline)]
-pub use crate::result;
+pub use result::result;

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -12,7 +12,9 @@ use hashbrown::HashMap;
 /// An [`Iterator`] over the results of a query.
 ///
 /// Yields results based on the specified [`Views`] `V` and [`Filter`] `F`, returning the
-/// [`Component`]s viewed. The entities iterated are not in any specified order.
+/// [`Component`]s viewed. The entities iterated are not in any specified order. The yielded views
+/// will be heterogeneous lists, so the [`result!`] macro is recommended to create identifiers for
+/// them.
 ///
 /// This `struct` is created by the [`query`] method on [`World`].
 ///
@@ -38,6 +40,7 @@ use hashbrown::HashMap;
 /// [`Component`]: crate::component::Component
 /// [`Filter`]: crate::query::filter::Filter
 /// [`query`]: crate::world::World::query()
+/// [`result!`]: crate::query::result!
 /// [`Views`]: crate::query::view::Views
 /// [`World`]: crate::world::World
 pub struct Iter<'a, R, F, V>

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -9,6 +9,37 @@ use crate::{
 use core::{any::TypeId, iter::FusedIterator, marker::PhantomData};
 use hashbrown::HashMap;
 
+/// An [`Iterator`] over the results of a query.
+///
+/// Yields results based on the specified [`Views`] `V` and [`Filter`] `F`, returning the
+/// [`Component`]s viewed. The entities iterated are not in any specified order.
+///
+/// This `struct` is created by the [`query`] method on [`World`].
+///
+/// # Example
+/// ``` rust
+/// use brood::{entity, query::{filter, result, views}, registry, World};
+///
+/// struct Foo(u32);
+/// struct Bar(bool);
+///
+/// type Registry = registry!(Foo, Bar);
+///
+/// let mut world = World::<Registry>::new();
+/// world.push(entity!(Foo(42), Bar(true)));
+///
+/// for result!(foo, bar) in world.query::<views!(&mut Foo, &Bar), filter::None>() {
+///     if bar.0 {
+///         foo.0 += 1;
+///     }
+/// }
+/// ```
+///
+/// [`Component`]: crate::component::Component
+/// [`Filter`]: crate::query::filter::Filter
+/// [`query`]: crate::world::World::query()
+/// [`Views`]: crate::query::view::Views
+/// [`World`]: crate::world::World
 pub struct Iter<'a, R, F, V>
 where
     R: Registry,

--- a/src/query/result/mod.rs
+++ b/src/query/result/mod.rs
@@ -1,3 +1,44 @@
+//! Results of queries.
+//!
+//! The primary way to interact with entities stored within a [`World`] is to query their
+//! [`Component`]s using [`Views`] and [`Filter`]s. This module handles interaction with the
+//! results of those queries.
+//!
+//! As `Component`s should be allowed to be queried arbitrarily, with any amount of `Component`s
+//! and any amount of `Filter`s being requested at once, the returned results of queries must be
+//! just as flexible. Therefore, the returned results are in the form of heterogeneous lists. In
+//! order to unpack these values into usable identifiers, a [`result!`] macro is provided to remove
+//! the unpleasant boilerplate.
+//!
+//! # Example
+//! The following example queries a `World` for all entities containing two `Component`s, giving
+//! `View`s over both `Component`s. One of these `View`s is mutable, allowing the component to be
+//! modified during iteration.
+//!
+//! ``` rust
+//! use brood::{entity, query::{filter, result, views}, registry, World};
+//!
+//! struct Foo(u32);
+//! struct Bar(bool);
+//!
+//! type Registry = registry!(Foo, Bar);
+//!
+//! let mut world = World::<Registry>::new();
+//! world.push(entity!(Foo(42), Bar(true)));
+//!
+//! for result!(foo, bar) in world.query::<views!(&mut Foo, &Bar), filter::None>() {
+//!     if bar.0 {
+//!         foo.0 += 1;
+//!     }
+//! }
+//! ```
+//!
+//! [`Component`]: crate::component::Component
+//! [`Filter`]: crate::query::filter::Filter
+//! [`result!`]: crate::query::result!
+//! [`Views`]: crate::query::view::Views
+//! [`World`]: crate::world::World
+
 mod iter;
 #[cfg(feature = "parallel")]
 mod par_iter;

--- a/src/query/result/mod.rs
+++ b/src/query/result/mod.rs
@@ -6,39 +6,40 @@ pub use iter::Iter;
 #[cfg(feature = "parallel")]
 pub use par_iter::ParIter;
 
-use crate::hlist::define_null;
+use crate::{doc, hlist::define_null};
 
 define_null!();
 
-/// Defines identifiers to match items returned by a [`result::Iter`] iterator.
-///
-/// This allows matching identifiers with the heterogeneous lists iterated by the `result::Iter`
-/// iterator.
-///
-/// # Example
-/// ``` rust
-/// use brood::{entity, query::{filter, result, views}, registry, World};
-///
-/// struct Foo(u32);
-/// struct Bar(bool);
-///
-/// type Registry = registry!(Foo, Bar);
-///
-/// let mut world = World::<Registry>::new();
-/// world.push(entity!(Foo(42), Bar(true)));
-///
-/// for result!(foo, bar) in world.query::<views!(&mut Foo, &Bar), filter::None>() {
-///     // ...
-/// }
-/// ```
-///
-/// [`result::Iter`]: crate::query::result::Iter
-#[macro_export]
-macro_rules! result {
-    () => {
-        _
-    };
-    ($component:ident $(,$components:ident)* $(,)?) => {
-        ($component, $crate::result!($($components,)*))
-    };
+doc::non_root_macro! {
+    /// Defines identifiers to match items returned by a [`result::Iter`] iterator.
+    ///
+    /// This allows matching identifiers with the heterogeneous lists iterated by the `result::Iter`
+    /// iterator.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entity, query::{filter, result, views}, registry, World};
+    ///
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    ///
+    /// type Registry = registry!(Foo, Bar);
+    ///
+    /// let mut world = World::<Registry>::new();
+    /// world.push(entity!(Foo(42), Bar(true)));
+    ///
+    /// for result!(foo, bar) in world.query::<views!(&mut Foo, &Bar), filter::None>() {
+    ///     // ...
+    /// }
+    /// ```
+    ///
+    /// [`result::Iter`]: crate::query::result::Iter
+    macro_rules! result {
+        () => (
+            _
+        );
+        ($component:ident $(,$components:ident)* $(,)?) => (
+            ($component, $crate::query::result!($($components,)*))
+        );
+    }
 }

--- a/src/query/result/mod.rs
+++ b/src/query/result/mod.rs
@@ -10,6 +10,29 @@ use crate::hlist::define_null;
 
 define_null!();
 
+/// Defines identifiers to match items returned by a [`result::Iter`] iterator.
+///
+/// This allows matching identifiers with the heterogeneous lists iterated by the `result::Iter`
+/// iterator.
+///
+/// # Example
+/// ``` rust
+/// use brood::{entity, query::{filter, result, views}, registry, World};
+///
+/// struct Foo(u32);
+/// struct Bar(bool);
+///
+/// type Registry = registry!(Foo, Bar);
+///
+/// let mut world = World::<Registry>::new();
+/// world.push(entity!(Foo(42), Bar(true)));
+///
+/// for result!(foo, bar) in world.query::<views!(&mut Foo, &Bar), filter::None>() {
+///     // ...
+/// }
+/// ```
+///
+/// [`result::Iter`]: crate::query::result::Iter
 #[macro_export]
 macro_rules! result {
     () => {

--- a/src/query/result/par_iter.rs
+++ b/src/query/result/par_iter.rs
@@ -14,6 +14,41 @@ use rayon::iter::{
     ParallelIterator,
 };
 
+/// A [`ParallelIterator`] over the results of a query.
+///
+/// Yields results based on the specified [`ParViews`] `V` and [`Filter`] `F`, return the
+/// [`Component`]s viewed. The yielded views will be heterogeneous lists, so the [`result!`] macro
+/// is recommended to create identifiers for them.
+///
+/// This `struct` is created by the [`par_query`] method on [`World`].
+///
+/// # Example
+/// ``` rust
+/// use brood::{entity, query::{filter, result, views}, registry, World};
+/// use rayon::iter::ParallelIterator;
+///
+/// struct Foo(u32);
+/// struct Bar(bool);
+///
+/// type Registry = registry!(Foo, Bar);
+///
+/// let mut world = World::<Registry>::new();
+/// world.push(entity!(Foo(42), Bar(true)));
+///
+/// world.par_query::<views!(&mut Foo, &Bar), filter::None>().for_each(|result!(foo, bar)| {
+///     if bar.0 {
+///         foo.0 += 1;
+///     }
+/// });
+/// ```
+///
+/// [`Component`]: crate::component::Component
+/// [`Filter`]: crate::query::filter::Filter
+/// [`ParallelIterator`]: rayon::iter::ParallelIterator
+/// [`par_query`]: crate::world::World::par_query()
+/// [`ParViews`]: crate::query::view::ParViews
+/// [`result!`]: crate::query::result!
+/// [`World`]: crate::world::World
 #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub struct ParIter<'a, R, F, V>
 where

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -112,6 +112,35 @@ impl<'a> View<'a> for entity::Identifier {}
 
 define_null!();
 
+/// A heterogeneous list of [`View`]s.
+///
+/// Along with [`Filter`]s, `Views` are what make up a query over entities stored wihin a
+/// [`World`]. `Views` are how queries specify what [`Component`]s should be borrowed within query
+/// results.
+///
+/// Note that while multiple immutable borrows of `Component`s are allowed within a `Views`, if a
+/// component is borrowed mutably in a `Views` it cannot be borrowed again within the same `Views`.
+/// In other words, borrows in `Views` must follow Rust's
+/// [borrowing rules](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html).
+///
+/// As `Views` is a heterogeneous list, it is most easily constructed using the [`views!`] macro.
+///
+/// # Example
+/// ``` rust
+/// use brood::query::views;
+///
+/// // Define components.
+/// struct Foo(u32);
+/// struct Bar(bool);
+///
+/// type Views<'a> = views!(&'a mut Foo, &'a Bar);
+/// ```
+///
+/// [`Component`]: crate::component::Component
+/// [`Filter`]: crate::query::filter::Filter
+/// [`View`]: crate::query::view::View
+/// [`views!`]: crate::query::views!
+/// [`World`]: crate::world::World
 pub trait Views<'a>: Filter + ViewsSeal<'a> {}
 
 impl<'a> Views<'a> for Null {}

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -59,7 +59,6 @@ doc::non_root_macro! {
     /// [`System`]: crate::system::System
     /// [`View`]: crate::query::view::View
     /// [`World`]: crate::world::World
-    #[macro_export]
     macro_rules! views {
         ($view:ty $(,$views:ty)* $(,)?) => (
             ($view, $crate::views!($($views,)*))

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -1,3 +1,49 @@
+//! Views over entities.
+//!
+//! Along with [`Filter`]s, [`Views`] are what make up a query over entities stored wihin a
+//! [`World`]. `Views` are how queries specify what [`Component`]s should be borrowed within query
+//! results.
+//!
+//! There are five types of [`View`]s that can be used when defining a query:
+//! - **`&C`** - Borrows the `Component` `C` immutably, filtering out any entities that do not
+//! contain `C`.
+//! - **`&mut C`** - Borrows the `Component` `C` mutably, filtering out any entities that do not
+//! contain `C`.
+//! - **`Option<&C>`** - Borrows the `Component` `C` immutably if present in the entity. Returns
+//! [`None`] otherwise.
+//! - **`Option<&mut C>`** - Borrows the `Component` `C` mutably if present in the entity. Returns
+//! [`None`] otherwise.
+//! - **[`entity::Identifier`]** - Returns the `entity::Identifier` of each entity in the query
+//! results.
+//!
+//! `Views` is a heterogeneous list of individual `View`s. Therefore, it is easiest to define them
+//! using the [`views!`] macro.
+//!
+//! # Example
+//! ``` rust
+//! use brood::{entity, query::views};
+//!
+//! // Define components.
+//! struct Foo(u32);
+//! struct Bar(bool);
+//! struct Baz(f64);
+//!
+//! type Views<'a> = views!(&'a mut Foo, &'a Bar, Option<&'a Baz>, entity::Identifier);
+//! ```
+//!
+//! Note that the lifetime `'a` can often be omitted when [`query`]ing a [`World`], but is required
+//! when defining a [`System`].
+//!
+//! [`Component`]: crate::component::Component
+//! [`entity::Identifier`]: crate::entity::Identifier
+//! [`Filter`]: crate::query::filter::Filter
+//! [`query`]: crate::world::World::query()
+//! [`System`]: crate::system::System
+//! [`View`]: crate::query::view::View
+//! [`Views`]: crate::query::view::Views
+//! [`views!`]: crate::query::views!
+//! [`World`]: crate::world::World.
+
 #[cfg(feature = "parallel")]
 mod par;
 mod seal;

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -33,6 +33,31 @@ where
 {
 }
 
+/// Creates a set of [`View`]s over components.
+///
+/// These views can be used to [`query`] the components stored within a [`World`]. They can also be
+/// used when defining [`System`]s to be run over components stored in a [`World`].
+///
+/// See the documentation for [`View`] to learn more about what kinds of `View`s can be created.
+///
+/// # Example
+/// ``` rust
+/// use brood::query::views;
+///
+/// // Define components.
+/// struct Foo(u32);
+/// struct Bar(bool);
+///
+/// type Views<'a> = views!(&'a mut Foo, &'a Bar);
+/// ```
+///
+/// Note that the lifetime `'a` can often be omitted when [`query`]ing a [`World`], but is required
+/// when defining a [`System`].
+///
+/// [`query`]: crate::world::World::query()
+/// [`System`]: crate::system::System
+/// [`View`]: crate::query::view::View
+/// [`World`]: crate::world::World
 #[macro_export]
 macro_rules! views {
     ($view:ty $(,$views:ty)* $(,)?) => {

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -54,6 +54,50 @@ pub use par::{ParView, ParViews};
 use crate::{component::Component, doc, entity, hlist::define_null, query::filter::Filter};
 use seal::{ViewSeal, ViewsSeal};
 
+/// A view over a single aspect of an entity.
+///
+/// Here, the world "aspect" means either a [`Component`] or the entity's [`Identifier`].
+/// Specifically, `View` is implemented for each of the following five types, providing the
+/// specified view into the entity:
+/// - **`&C`** - Borrows the `Component` `C` immutably, filtering out any entities that do not
+/// contain `C`.
+/// - **`&mut C`** - Borrows the `Component` `C` mutably, filtering out any entities that do not
+/// contain `C`.
+/// - **`Option<&C>`** - Borrows the `Component` `C` immutably if present in the entity. Returns
+/// [`None`] otherwise.
+/// - **`Option<&mut C>`** - Borrows the `Component` `C` mutably if present in the entity. Returns
+/// [`None`] otherwise.
+/// - **[`entity::Identifier`]** - Returns the `entity::Identifier` of each entity in the query
+/// results.
+///
+/// # Example
+/// ``` rust
+/// // Define a component.
+/// struct Foo(usize);
+///
+/// // Define a view over that component.
+/// type FooView<'a> = &'a Foo;
+/// ```
+///
+/// Note that a single `View` by itself isn't very useful. To be usable in querying a [`World`],
+/// a [`Views`] heterogeneous list must be used. It is recommended to use the [`views!`] macro to
+/// construct this heterogeneous list.
+///
+/// ``` rust
+/// use brood::query::views;
+///
+/// // Define components.
+/// struct Foo(u32);
+/// struct Bar(bool);
+///
+/// type Views<'a> = views!(&'a mut Foo, &'a Bar);
+/// ```
+///
+/// [`Component`]: crate::component::Component
+/// [`Identifier`]: crate::entity::Identifier
+/// [`Views`]: crate::query::view::Views
+/// [`views!`]: crate::query::views!
+/// [`World`]: crate::world::World
 pub trait View<'a>: Filter + ViewSeal<'a> {}
 
 impl<'a, C> View<'a> for &C where C: Component {}

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -5,7 +5,7 @@ mod seal;
 #[cfg(feature = "parallel")]
 pub use par::{ParView, ParViews};
 
-use crate::{component::Component, entity, hlist::define_null, query::filter::Filter};
+use crate::{component::Component, doc, entity, hlist::define_null, query::filter::Filter};
 use seal::{ViewSeal, ViewsSeal};
 
 pub trait View<'a>: Filter + ViewSeal<'a> {}
@@ -33,37 +33,39 @@ where
 {
 }
 
-/// Creates a set of [`View`]s over components.
-///
-/// These views can be used to [`query`] the components stored within a [`World`]. They can also be
-/// used when defining [`System`]s to be run over components stored in a [`World`].
-///
-/// See the documentation for [`View`] to learn more about what kinds of `View`s can be created.
-///
-/// # Example
-/// ``` rust
-/// use brood::query::views;
-///
-/// // Define components.
-/// struct Foo(u32);
-/// struct Bar(bool);
-///
-/// type Views<'a> = views!(&'a mut Foo, &'a Bar);
-/// ```
-///
-/// Note that the lifetime `'a` can often be omitted when [`query`]ing a [`World`], but is required
-/// when defining a [`System`].
-///
-/// [`query`]: crate::world::World::query()
-/// [`System`]: crate::system::System
-/// [`View`]: crate::query::view::View
-/// [`World`]: crate::world::World
-#[macro_export]
-macro_rules! views {
-    ($view:ty $(,$views:ty)* $(,)?) => {
-        ($view, $crate::views!($($views,)*))
-    };
-    () => {
-        $crate::query::view::Null
-    };
+doc::non_root_macro! {
+    /// Creates a set of [`View`]s over components.
+    ///
+    /// These views can be used to [`query`] the components stored within a [`World`]. They can also be
+    /// used when defining [`System`]s to be run over components stored in a [`World`].
+    ///
+    /// See the documentation for [`View`] to learn more about what kinds of `View`s can be created.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::query::views;
+    ///
+    /// // Define components.
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    ///
+    /// type Views<'a> = views!(&'a mut Foo, &'a Bar);
+    /// ```
+    ///
+    /// Note that the lifetime `'a` can often be omitted when [`query`]ing a [`World`], but is required
+    /// when defining a [`System`].
+    ///
+    /// [`query`]: crate::world::World::query()
+    /// [`System`]: crate::system::System
+    /// [`View`]: crate::query::view::View
+    /// [`World`]: crate::world::World
+    #[macro_export]
+    macro_rules! views {
+        ($view:ty $(,$views:ty)* $(,)?) => (
+            ($view, $crate::views!($($views,)*))
+        );
+        () => (
+            $crate::query::view::Null
+        );
+    }
 }

--- a/src/query/view/par/mod.rs
+++ b/src/query/view/par/mod.rs
@@ -28,6 +28,7 @@ use seal::{ParViewSeal, ParViewsSeal};
 /// Because the `Component` viewed in the above example implements `Sync`, the view created above
 /// implements `ParView`.
 ///
+/// [`Component`]: crate::component::Component
 /// [`ParSystem`]: crate::system::ParSystem
 /// [`par_query`]: crate::world::World::par_query()
 /// [`View`]: crate::query::view::View
@@ -44,6 +45,35 @@ impl<'a, C> ParView<'a> for Option<&mut C> where C: Component + Send {}
 
 impl<'a> ParView<'a> for entity::Identifier {}
 
+/// A heterogeneous list of [`ParView`]s.
+///
+/// The main difference between this trait and the standard [`Views`] trait is that these views can
+/// be shared between threads, allowing them to be used within parallel iteration in either a
+/// [`ParSystem`] or a [`par_query`].
+///
+/// All types that implement `Views` also implement `ParViews`, so long as any [`Component`]s `C`
+/// they view are [`Send`] when viewed mutably or [`Sync`] when viewed immutably.
+///
+/// # Example
+/// ``` rust
+/// use brood::query::views;
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+///
+/// // Define views over those components.
+/// type Views<'a> = views!(&'a Foo, &'a mut Bar);
+/// ```
+///
+/// Because the `Component`s viewed above implement both [`Send`] and [`Sync`], the views created
+/// above implement `ParViews`.
+///
+/// [`Component`]: crate::component::Component
+/// [`ParSystem`]: crate::system::ParSystem
+/// [`ParView`]: crate::query::view::ParView
+/// [`par_query`]: crate::world::World::par_query()
+/// [`Views`]: crate::query::view::Views
 #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub trait ParViews<'a>: Filter + ParViewsSeal<'a> {}
 

--- a/src/query/view/par/mod.rs
+++ b/src/query/view/par/mod.rs
@@ -7,6 +7,30 @@ use crate::{
 };
 use seal::{ParViewSeal, ParViewsSeal};
 
+/// A parallel view over a single aspect of an entity.
+///
+/// The main difference between this trait and the standard [`View`] trait is that this view can be
+/// shared between threads, allowing it to be used within parallel iteration in either a
+/// [`ParSystem`] or a [`par_query`].
+///
+/// All types that implement `View` also implement `ParView`, so long as any [`Component`] `C` they
+/// view is [`Send`] when viewed mutably or [`Sync`] when viewed immutably.
+///
+/// # Example
+/// ``` rust
+/// // Define a component.
+/// struct Foo(usize);
+///
+/// // Define a view over that component.
+/// type FooView<'a> = &'a Foo;
+/// ```
+///
+/// Because the `Component` viewed in the above example implements `Sync`, the view created above
+/// implements `ParView`.
+///
+/// [`ParSystem`]: crate::system::ParSystem
+/// [`par_query`]: crate::world::World::par_query()
+/// [`View`]: crate::query::view::View
 #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub trait ParView<'a>: Filter + ParViewSeal<'a> {}
 

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,3 +1,29 @@
+//! A heterogeneous list of [`Component`]s.
+//!
+//! [`Registry`]s are most often defined using the [`registry!`] macro. The items contained wihtin
+//! this module should rarely be needed in user code.
+//!
+//! Recommended practice is to define a `Registry` as a custom type, and use that type when
+//! defining a [`World`].
+//!
+//! # Example
+//! ``` rust
+//! use brood::{registry, World};
+//!
+//! // Define components.
+//! struct Foo(usize);
+//! struct Bar(bool);
+//!
+//! type Registry = registry!(Foo, Bar);
+//!
+//! let world = World::<Registry>::new();
+//! ```
+//!
+//! [`Component`]: crate::component::Component
+//! [`Registry`]: crate::registry::Registry
+//! [`registry!`]: crate::registry!
+//! [`World`]: crate::world::World
+
 mod debug;
 mod eq;
 mod seal;

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,4 +1,4 @@
-//! A heterogeneous list of [`Component`]s.
+//! A heterogeneous list of registered [`Component`]s.
 //!
 //! [`Registry`]s are most often defined using the [`registry!`] macro. The items contained within
 //! this module should rarely be needed in user code.

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,6 +1,6 @@
 //! A heterogeneous list of [`Component`]s.
 //!
-//! [`Registry`]s are most often defined using the [`registry!`] macro. The items contained wihtin
+//! [`Registry`]s are most often defined using the [`registry!`] macro. The items contained within
 //! this module should rarely be needed in user code.
 //!
 //! Recommended practice is to define a `Registry` as a custom type, and use that type when

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -18,6 +18,30 @@ use seal::Seal;
 
 define_null!();
 
+/// A heterogeneous list of [`Component`]s.
+///
+/// Registries are used when defining [`World`]s. In order for components to be stored within a
+/// `World`, they must be included in the `World`'s registry. However, care should be made to only
+/// include `Component`s that will be used, as unused `Component`s will cause unnecessary heap
+/// allocations.
+///
+/// While duplicate `Component`s can be included within a registry, it is not advised. There are no
+/// benefits to including multiple `Component`s, and the unused components cause higher memory
+/// allocation within a `World`.
+///
+/// # Example
+/// ``` rust
+/// use brood::registry;
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+///
+/// type Registry = registry!(Foo, Bar);
+/// ```
+///
+/// [`Component`]: crate::component::Component
+/// [`World`]: crate::World
 pub trait Registry: Seal {}
 
 impl Registry for Null {}

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -29,6 +29,31 @@ where
 {
 }
 
+/// Creates a registry from the provided components.
+///
+/// This macro allows a registry to be defined without needing to manually create a heterogeneous
+/// list of components. Given an arbitrary number of components, this macro will arrange them into
+/// nested tuples forming a heterogeneous list.
+///
+/// A registry is not normally instantiated. Its main purpose is to be used as a generic in the
+/// definition of a [`World`].
+///
+/// # Example
+/// ``` rust
+/// use brood::{registry, World};
+///
+/// // Define components `Foo` and `Bar`.
+/// struct Foo(u16);
+/// struct Bar(f32);
+///
+/// // Define a registry containing those components.
+/// type Registry = registry!(Foo, Bar);
+///
+/// // Define a world using the registry.
+/// let world = World::<Registry>::new();
+/// ```
+///
+/// [`World`]: crate::World
 #[macro_export]
 macro_rules! registry {
     ($component:ty $(,$components:ty)* $(,)?) => {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1,3 +1,40 @@
+//! Executable types which operate over entities within a [`World`].
+//!
+//! [`System`]s are executable types which query a `World` and operate on the query results.
+//! Multiple `System`s can be combined within a [`Schedule`] to execute `System`s in parallel.
+//!
+//! # Example
+//! ``` rust
+//! use brood::{query::{filter, result, views}, registry::Registry, system::System};
+//!
+//! // Define components.
+//! struct Foo(usize);
+//! struct Bar(bool);
+//!
+//! // Define system to operate on those components.
+//! struct MySystem;
+//!
+//! impl<'a> System<'a> for MySystem {
+//!     type Views = views!(&'a mut Foo, &'a Bar);
+//!     type Filter = filter::None;
+//!
+//!     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+//!         for result!(foo, bar) in query_results {
+//!             if bar.0 {
+//!                 foo.0 += 1;
+//!             }
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Defining `System`s allows for reuse of querying logic in multiple places, as well as combining
+//! `System`s together within a `Schedule` to allow them to be run in parallel.
+//!
+//! [`Schedule`]: crate::system::schedule::Schedule
+//! [`System`]: crate::system::System
+//! [`World`]: crate::world::World
+
 #[cfg(feature = "parallel")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub mod schedule;

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -56,14 +56,134 @@ use crate::{
     world::World,
 };
 
+/// An executable type which operates over the entities within a [`World`].
+///
+/// `System`s can be passed to a `World` to be executed. When executed, the query specified by the
+/// `Filter` and `Views` associated types is performed and the result is passed to the [`run`]
+/// method. After execution, the [`world_post_processing`] method will be run.
+///
+/// It is advised to define a new struct for each `System` you wish to write. Logic to be done
+/// using the query result should be included in the `run` method, and any logic that must be done
+/// after the query (such as insertion/removal of entities or components) should be included in the
+/// `world_post_processing` method.
+///
+/// # Example
+/// ``` rust
+/// use brood::{query::{filter, result, views}, registry::Registry, system::System};
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+///
+/// // Define system to operate on those components.
+/// struct MySystem;
+///
+/// impl<'a> System<'a> for MySystem {
+///     type Views = views!(&'a mut Foo, &'a Bar);
+///     type Filter = filter::None;
+///
+///     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+///         for result!(foo, bar) in query_results {
+///             if bar.0 {
+///                 foo.0 += 1;
+///             }
+///         }
+///     }
+/// }
+/// ```
+///
+/// [`run`]: crate::system::System::run()
+/// [`World`]: crate::world::World
+/// [`world_post_processing`]: crate::system::System::world_post_processing()
 pub trait System<'a> {
     type Filter: Filter;
     type Views: Views<'a>;
 
+    /// Logic to be run over the query result.
+    ///
+    /// Any action performed using the query result should be performed here. If any modifications
+    /// to the [`World`] itself are desired based on the query result, those should be performed in
+    /// the [`world_post_processing`] method.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{query::{filter, result, views}, registry::Registry, system::System};
+    ///
+    /// // Define components.
+    /// struct Foo(usize);
+    /// struct Bar(bool);
+    ///
+    /// // Define system to operate on those components.
+    /// struct MySystem;
+    ///
+    /// impl<'a> System<'a> for MySystem {
+    ///     type Views = views!(&'a mut Foo, &'a Bar);
+    ///     type Filter = filter::None;
+    ///
+    ///     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+    ///         for result!(foo, bar) in query_results {
+    ///             if bar.0 {
+    ///                 foo.0 += 1;
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// [`World`]: crate::world::World
+    /// [`world_post_processing`]: crate::system::System::world_post_processing()
     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>)
     where
         R: Registry + 'a;
 
+    /// Logic to be run after processing.
+    ///
+    /// This is an optional method that can be defined if any changes are desired to be made to the
+    /// [`World`] after querying. Changes can be stored using fields of the type implementing
+    /// `System` during the [`run`] method so that they can be accessed by this method.
+    ///
+    /// # Example
+    /// The following example creates a list of entities to remove during evaluation, and then
+    /// executes the removal during post processing.
+    ///
+    /// ``` rust
+    /// use brood::{entity, query::{filter, result, views}, registry::Registry, system::System, World};
+    ///
+    /// // Define components.
+    /// struct Foo(usize);
+    /// struct Bar(bool);
+    ///
+    /// // Define system to operate on those components.
+    /// struct MySystem {
+    ///     // A list of entity identifiers to remove during post processing.
+    ///     entities_to_remove: Vec<entity::Identifier>,     
+    /// }
+    ///
+    /// impl<'a> System<'a> for MySystem {
+    ///     type Views = views!(&'a mut Foo, &'a Bar, entity::Identifier);
+    ///     type Filter = filter::None;
+    ///
+    ///     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+    ///         for result!(foo, bar, entity_identifier) in query_results {
+    ///             // If `bar` is true, increment `foo`. Otherwise, remove the entity in post proessing.
+    ///             if bar.0 {
+    ///                 foo.0 += 1;
+    ///             } else {
+    ///                 self.entities_to_remove.push(entity_identifier);
+    ///             }
+    ///         }
+    ///     }
+    ///
+    ///     fn world_post_processing<R>(&mut self, world: &mut World<R>) where R: Registry {
+    ///         for entity_identifier in &self.entities_to_remove {
+    ///             world.remove(*entity_identifier);
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// [`run`]: crate::system::System::run()
+    /// [`World`]: crate::world::World
     #[inline]
     #[allow(unused_variables)]
     fn world_post_processing<R>(&mut self, world: &mut World<R>)

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -165,7 +165,7 @@ pub trait System<'a> {
     ///
     ///     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
     ///         for result!(foo, bar, entity_identifier) in query_results {
-    ///             // If `bar` is true, increment `foo`. Otherwise, remove the entity in post proessing.
+    ///             // If `bar` is true, increment `foo`. Otherwise, remove the entity in post processing.
     ///             if bar.0 {
     ///                 foo.0 += 1;
     ///             } else {

--- a/src/system/null.rs
+++ b/src/system/null.rs
@@ -8,6 +8,13 @@ use crate::{
 };
 use core::hint::unreachable_unchecked;
 
+/// A null system.
+///
+/// As this is an empty `enum`, it can never be instantiated. Its main use is as a generic argument
+/// for [`Schedule`]s for the unused generic parameters of [`Stage`]s.
+///
+/// [`Schedule`]: crate::system::Schedule
+/// [`Stage`]: crate::system::schedule::stage::Stage
 pub enum Null {}
 
 impl<'a> System<'a> for Null {

--- a/src/system/par.rs
+++ b/src/system/par.rs
@@ -47,6 +47,40 @@ pub trait ParSystem<'a> {
     type Filter: Filter;
     type Views: ParViews<'a>;
 
+    /// Logic to be run over the parallel query result.
+    ///
+    /// Any action performed using the query result should be performed here. If any modifications
+    /// to the [`World`] itself are desired based on the query result, those should be performed in
+    /// the [`world_post_processing`] method.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{query::{filter, result, views}, registry::Registry, system::ParSystem};
+    /// use rayon::iter::ParallelIterator;
+    ///
+    /// // Define components.
+    /// struct Foo(usize);
+    /// struct Bar(bool);
+    ///
+    /// // Define parallel system to operate on those components.
+    /// struct MySystem;
+    ///
+    /// impl<'a> ParSystem<'a> for MySystem {
+    ///     type Views = views!(&'a mut Foo, &'a Bar);
+    ///     type Filter = filter::None;
+    ///
+    ///     fn run<R>(&mut self, query_results: result::ParIter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+    ///         query_results.for_each(|result!(foo, bar)| {
+    ///             if bar.0 {
+    ///                 foo.0 += 1;
+    ///             }
+    ///         });
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// [`World`]: crate::world::World
+    /// [`world_post_processing`]: crate::system::System::world_post_processing()
     fn run<R>(&mut self, query_results: result::ParIter<'a, R, Self::Filter, Self::Views>)
     where
         R: Registry + 'a;

--- a/src/system/par.rs
+++ b/src/system/par.rs
@@ -4,6 +4,44 @@ use crate::{
     world::World,
 };
 
+/// An executable type which operates over the entities within a [`World`] in parallel.
+///
+/// This trait is very similar to the [`System`] trait. The main difference is that the [`run`]
+/// method takes a [`result::ParIter`] instead of a [`result::Iter`]. Note that the `Views`
+/// associated type must also implement [`ParViews`].
+///
+/// # Example
+/// ``` rust
+/// use brood::{query::{filter, result, views}, registry::Registry, system::ParSystem};
+/// use rayon::iter::ParallelIterator;
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+///
+/// // Define parallel system to operate on those components.
+/// struct MySystem;
+///
+/// impl<'a> ParSystem<'a> for MySystem {
+///     type Views = views!(&'a mut Foo, &'a Bar);
+///     type Filter = filter::None;
+///
+///     fn run<R>(&mut self, query_results: result::ParIter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+///         query_results.for_each(|result!(foo, bar)| {
+///             if bar.0 {
+///                 foo.0 += 1;
+///             }
+///         });
+///     }
+/// }
+/// ```
+///
+/// [`ParViews`]: crate::query::view::ParViews
+/// [`result::Iter`]: crate::query::result::Iter
+/// [`result::ParIter`]: crate::query::result::ParIter
+/// [`run`]: crate::system::ParSystem::run()
+/// [`System`]: crate::system::System
+/// [`World`]: crate::world::World
 #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub trait ParSystem<'a> {
     type Filter: Filter;
@@ -13,6 +51,56 @@ pub trait ParSystem<'a> {
     where
         R: Registry + 'a;
 
+    /// Logic to be run after processing.
+    ///
+    /// This is an optional method that can be defined if any changes are desired to be made to the
+    /// [`World`] after querying. Changes can be stored using fields of the type implementing
+    /// `ParSystem` during the [`run`] method so that they can be accessed by this method.
+    ///
+    /// # Example
+    /// The following example creates a list of entities to remove during evaluation, and then
+    /// executes the removal during post processing.
+    ///
+    /// ``` rust
+    /// use brood::{entity, query::{filter, result, views}, registry::Registry, system::ParSystem, World};
+    /// use rayon::iter::ParallelIterator;
+    ///
+    /// // Define components.
+    /// struct Foo(usize);
+    /// struct Bar(bool);
+    ///
+    /// // Define system to operate on those components.
+    /// struct MySystem {
+    ///     // A list of entity identifiers to remove during post processing.
+    ///     entities_to_remove: Vec<entity::Identifier>,     
+    /// }
+    ///
+    /// impl<'a> ParSystem<'a> for MySystem {
+    ///     type Views = views!(&'a mut Foo, &'a Bar, entity::Identifier);
+    ///     type Filter = filter::None;
+    ///
+    ///     fn run<R>(&mut self, query_results: result::ParIter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+    ///         self.entities_to_remove = query_results.filter_map(|result!(foo, bar, entity_identifier)| {
+    ///             // If `bar` is true, increment `foo`. Otherwise, remove the entity in post processing.
+    ///             if bar.0 {
+    ///                 foo.0 += 1;
+    ///                 None
+    ///             } else {
+    ///                 Some(entity_identifier)
+    ///             }
+    ///         }).collect::<Vec<_>>();
+    ///     }
+    ///
+    ///     fn world_post_processing<R>(&mut self, world: &mut World<R>) where R: Registry {
+    ///         for entity_identifier in &self.entities_to_remove {
+    ///             world.remove(*entity_identifier);
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// [`run`]: crate::system::ParSystem::run()
+    /// [`World`]: crate::world::World
     #[inline]
     #[allow(unused_variables)]
     fn world_post_processing<R>(&mut self, world: &mut World<R>)

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -1,3 +1,56 @@
+//! A list of [`System`]s to be run in stages.
+//!
+//! [`Schedule`]s are created using a builder pattern. `System`s are provided in the desired order
+//! they are to be run, and the stages in which those `System`s are run is automatically derived.
+//!
+//! The advantage of defining a `Schedule` is that `System`s are allowed to be run in parallel as
+//! long as their [`Views`] can be borrowed simultaneously.
+//!
+//! # Example
+//! The below example will execute both `SystemA` and `SystemB` in parallel, since their views can
+//! be borrowed simultaneously.
+//!
+//! ``` rust
+//! use brood::{query::{filter, result, views}, registry::Registry, system::{Schedule, System}};
+//!
+//! // Define components.
+//! struct Foo(usize);
+//! struct Bar(bool);
+//! struct Baz(f64);
+//!
+//! struct SystemA;
+//!
+//! impl<'a> System<'a> for SystemA {
+//!     type Views = views!(&'a mut Foo, &'a Bar);
+//!     type Filter = filter::None;
+//!
+//!     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+//!         for result!(foo, bar) in query_results {
+//!             // Do something...
+//!         }
+//!     }
+//! }
+//!
+//! struct SystemB;
+//!
+//! impl<'a> System<'a> for SystemB {
+//!     type Views = views!(&'a mut Baz, &'a Bar);
+//!     type Filter = filter::None;
+//!
+//!     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+//!         for result!(baz, bar) in query_results {
+//!             // Do something...
+//!         }
+//!     }
+//! }
+//!
+//! let schedule = Schedule::builder().system(SystemA).system(SystemB).build();
+//! ```
+//!
+//! [`Schedule`]: crate::system::schedule::Schedule
+//! [`System`]: crate::system::System
+//! [`Views`]: crate::query::view::Views
+
 pub mod raw_task;
 pub mod stage;
 

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -8,6 +8,7 @@ mod sendable;
 mod builder;
 
 pub use builder::Builder;
+pub use stage::stages;
 
 use crate::{registry::Registry, world::World};
 use sendable::SendableWorld;

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -14,12 +14,74 @@ use crate::{registry::Registry, world::World};
 use sendable::SendableWorld;
 use stage::Stages;
 
+/// A list of [`System`]s to be run in stages.
+///
+/// The `System`s that make up a `Schedule` are organized into [`Stages`] on creation. `System`s
+/// that can be run in parallel are done so. See the documentation for the [`schedule::Builder`]
+/// for more information about creating a `Schedule`.
+///
+/// # Example
+/// The below example will execute both `SystemA` and `SystemB` in parallel, since their views can
+/// be borrowed simultaneously.
+///
+/// ``` rust
+/// use brood::{query::{filter, result, views}, registry::Registry, system::{Schedule, System}};
+///
+/// // Define components.
+/// struct Foo(usize);
+/// struct Bar(bool);
+/// struct Baz(f64);
+///
+/// struct SystemA;
+///
+/// impl<'a> System<'a> for SystemA {
+///     type Views = views!(&'a mut Foo, &'a Bar);
+///     type Filter = filter::None;
+///
+///     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+///         for result!(foo, bar) in query_results {
+///             // Do something...
+///         }
+///     }
+/// }
+///
+/// struct SystemB;
+///
+/// impl<'a> System<'a> for SystemB {
+///     type Views = views!(&'a mut Baz, &'a Bar);
+///     type Filter = filter::None;
+///
+///     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {
+///         for result!(baz, bar) in query_results {
+///             // Do something...
+///         }
+///     }
+/// }
+///
+/// let schedule = Schedule::builder().system(SystemA).system(SystemB).build();
+/// ```
+///
+/// [`schedule::Builder`]: crate::system::schedule::Builder
+/// [`Stages`]: crate::system::schedule::stage::Stages
+/// [`System`]: crate::system::System
 #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub struct Schedule<S> {
     stages: S,
 }
 
 impl Schedule<stage::Null> {
+    /// Creates a [`schedule::Builder`] to construct a new `Schedule`.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::system::Schedule;
+    ///
+    /// let builder = Schedule::builder();
+    /// // Add systems to the builder.
+    /// let schedule = builder.build();
+    /// ```
+    ///
+    /// [`schedule::Builder`]: crate::system::schedule::Builder
     pub fn builder() -> Builder<raw_task::Null> {
         Builder::new()
     }

--- a/src/system/schedule/raw_task/mod.rs
+++ b/src/system/schedule/raw_task/mod.rs
@@ -8,7 +8,10 @@
 
 mod seal;
 
-use crate::{hlist::define_null, system::{schedule::task::Task, ParSystem, System}};
+use crate::{
+    hlist::define_null,
+    system::{schedule::task::Task, ParSystem, System},
+};
 use seal::Seal;
 
 /// A single task waiting to be scheduled.

--- a/src/system/schedule/raw_task/mod.rs
+++ b/src/system/schedule/raw_task/mod.rs
@@ -1,6 +1,6 @@
 mod seal;
 
-use crate::system::{schedule::task::Task, ParSystem, System};
+use crate::{hlist::define_null, system::{schedule::task::Task, ParSystem, System}};
 use seal::Seal;
 
 pub enum RawTask<S, P> {
@@ -8,7 +8,7 @@ pub enum RawTask<S, P> {
     Flush,
 }
 
-pub struct Null;
+define_null!();
 
 pub trait RawTasks<'a>: Seal<'a> {}
 

--- a/src/system/schedule/raw_task/mod.rs
+++ b/src/system/schedule/raw_task/mod.rs
@@ -1,8 +1,22 @@
+//! Tasks awaiting assignment to [`Stages`].
+//!
+//! [`RawTasks`] are created during the build process of a [`Schedule`]. The items in this module
+//! are not normally directly required for user-facing code.
+//!
+//! [`Schedule`]: crate::system::schedule::Schedule
+//! [`Stages`]: crate::system::schedule::stage::Stages
+
 mod seal;
 
 use crate::{hlist::define_null, system::{schedule::task::Task, ParSystem, System}};
 use seal::Seal;
 
+/// A single task waiting to be scheduled.
+///
+/// Tasks are either a [`System`], [`ParSystem`], or a `flush` command.
+///
+/// [`ParSystem`]: crate::system::ParSystem
+/// [`System`]: crate::system::System
 pub enum RawTask<S, P> {
     Task(Task<S, P>),
     Flush,
@@ -10,6 +24,7 @@ pub enum RawTask<S, P> {
 
 define_null!();
 
+/// A heterogeneous list of [`RawTask`]s.
 pub trait RawTasks<'a>: Seal<'a> {}
 
 impl<'a> RawTasks<'a> for Null {}

--- a/src/system/schedule/stage/mod.rs
+++ b/src/system/schedule/stage/mod.rs
@@ -12,7 +12,11 @@
 
 mod seal;
 
-use crate::{doc, hlist::define_null, system::{schedule::task::Task, ParSystem, System}};
+use crate::{
+    doc,
+    hlist::define_null,
+    system::{schedule::task::Task, ParSystem, System},
+};
 use seal::Seal;
 
 /// A single step in a stage.
@@ -81,7 +85,7 @@ doc::non_root_macro! {
     ///         // Operate on result here.
     ///     }
     /// }
-    /// 
+    ///
     /// // Define a Parallel System.
     /// struct Bar;
     /// impl<'a> ParSystem<'a> for Bar {
@@ -103,7 +107,7 @@ doc::non_root_macro! {
     /// };
     /// ```
     ///
-    /// The above example will create stages operating the system `Foo`, followed by performing 
+    /// The above example will create stages operating the system `Foo`, followed by performing
     /// post-processing, and then run the parallel system `Bar`.
     ///
     /// [`ParSystem`]: crate::system::ParSystem

--- a/src/system/schedule/stage/mod.rs
+++ b/src/system/schedule/stage/mod.rs
@@ -24,7 +24,71 @@ where
 }
 
 doc::non_root_macro! {
-#[macro_export]
+    /// Define type annotations for stages wihtin a [`Schedule`].
+    ///
+    /// This macro removes all the boilerplate involved in creating a type annotation for a
+    /// `Schedule` by allowing an easy definition of stages the `Schedule` is generic over.
+    ///
+    /// There are three different types of commands that can be given to a `stages!` definition.
+    /// These match with the commands that can be used to create a `Schedule` using a
+    /// [`schedule::Builder`]. They are:
+    ///
+    /// - `system: <system>`: runs a [`System`].
+    /// - `par_system: <par_system>`: runs a [`ParSystem`].
+    /// - `flush`: waits for completion of current stage and runs post-processing before proceeding.
+    ///
+    /// These can be provided to the macro to generate the correct type annotations, like so:
+    ///
+    /// ``` rust
+    /// use brood::{query::{filter, result, views}, registry::Registry, system::{schedule::stages, System, ParSystem}};
+    ///
+    /// // Define components.
+    /// struct A;
+    /// struct B;
+    /// struct C;
+    ///
+    /// // Define a System.
+    /// struct Foo;
+    /// impl<'a> System<'a> for Foo {
+    ///     type Filter = filter::None;
+    ///     type Views = views!(&'a mut A, &'a B);
+    ///
+    ///     fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>)
+    ///     where
+    ///         R: Registry + 'a,
+    ///     {
+    ///         // Operate on result here.
+    ///     }
+    /// }
+    /// 
+    /// // Define a Parallel System.
+    /// struct Bar;
+    /// impl<'a> ParSystem<'a> for Bar {
+    ///     type Filter = filter::None;
+    ///     type Views = views!(&'a B, &'a mut C);
+    ///
+    ///     fn run<R>(&mut self, query_results: result::ParIter<'a, R, Self::Filter, Self::Views>)
+    ///     where
+    ///         R: Registry + 'a
+    ///     {
+    ///         // Operate on result here.
+    ///     }
+    /// }
+    ///
+    /// type Stages = stages!{
+    ///     system: Foo,
+    ///     flush,
+    ///     par_system: Bar,
+    /// };
+    /// ```
+    ///
+    /// The above example will create stages operating the system `Foo`, followed by performing 
+    /// post-processing, and then run the parallel system `Bar`.
+    ///
+    /// [`ParSystem`]: crate::system::ParSystem
+    /// [`Schedule`]: crate::system::Schedule
+    /// [`schedule::Builder`]: crate::system::schedule::Builder
+    /// [`System`]: crate::system::System
     macro_rules! stages {
         ($($idents:tt $(: $systems:tt)?),* $(,)?) => (
             stages!(internal @ $crate::system::schedule::stage::Null; $($idents $(: $systems)?,)*)
@@ -41,5 +105,5 @@ doc::non_root_macro! {
         (internal @ $processed:ty; $($idents:tt $(: $systems:tt)?),* $(,)?) => (
             $processed
         );
-}
+    }
 }

--- a/src/system/schedule/stage/mod.rs
+++ b/src/system/schedule/stage/mod.rs
@@ -1,14 +1,35 @@
+//! Tasks scheduled in stages.
+//!
+//! [`Stages`] are [`System`]s that are scheduled to run in order, with parallelizable stages
+//! already grouped together. These are created by a [`schedule::Builder`]. User-facing code will
+//! not normally need to create `Stages` outside of the `schedule::Builder`. However, if a defined
+//! type of a `Stages` is needed, a [`stages!`] macro is provided to easily define the type.
+//!
+//! [`schedule::Builder`]: crate::system::schedule::Builder
+//! [`Stages`]: crate::system::schedule::stage::Stages
+//! [`stages!`]: crate::system::schedule::stages!
+//! [`System`]: crate::system::System
+
 mod seal;
 
 use crate::{doc, hlist::define_null, system::{schedule::task::Task, ParSystem, System}};
 use seal::Seal;
 
+/// A single step in a stage.
+///
+/// A step is a single task in a stage, along with information about whether this task is the
+/// beginning of a new stage or if it is a continuation of the current stage.
 pub enum Stage<S, P> {
     Start(Task<S, P>),
     Continue(Task<S, P>),
     Flush,
 }
 
+/// A heterogeneous list of [`Stage`]s.
+///
+/// The ordered `Stage`s provided here define the actual stages of the schedule. Note that the
+/// stages are defined inside-out, with the last of the heterogeneous list being the beginning of
+/// the list of stages.
 pub trait Stages<'a>: Seal<'a> {}
 
 define_null!();

--- a/src/system/schedule/stage/mod.rs
+++ b/src/system/schedule/stage/mod.rs
@@ -1,6 +1,6 @@
 mod seal;
 
-use crate::{hlist::define_null, system::{schedule::task::Task, ParSystem, System}};
+use crate::{doc, hlist::define_null, system::{schedule::task::Task, ParSystem, System}};
 use seal::Seal;
 
 pub enum Stage<S, P> {
@@ -23,21 +23,23 @@ where
 {
 }
 
+doc::non_root_macro! {
 #[macro_export]
-macro_rules! stages {
-    ($($idents:tt $(: $systems:tt)?),* $(,)?) => {
-        stages!(internal @ $crate::system::schedule::stage::Null; $($idents $(: $systems)?,)*)
-    };
-    (internal @ $processed:ty; system: $system:ty, $($idents:tt $(: $systems:tt)?),* $(,)?) => {
-        stages!(internal @ ($crate::system::schedule::stage::Stage<$system, $crate::system::Null>, $processed); $($idents $(: $systems)?,)*)
-    };
-    (internal @ $processed:ty; par_system: $par_system:ty, $($idents:tt $(: $systems:tt)?),* $(,)?) => {
-        stages!(internal @ ($crate::system::schedule::stage::Stage<$crate::system::Null, $par_system>, $processed); $($idents $(: $systems)?,)*)
-    };
-    (internal @ $processed:ty; flush, $($idents:tt $(: $systems:tt)?),* $(,)?) => {
-        stages!(internal @ ($crate::system::schedule::stage::Stage<$crate::system::Null, $crate::system::Null>, $processed); $($idents $(: $systems)?,)*)
-    };
-    (internal @ $processed:ty; $($idents:tt $(: $systems:tt)?),* $(,)?) => {
-        $processed
-    };
+    macro_rules! stages {
+        ($($idents:tt $(: $systems:tt)?),* $(,)?) => (
+            stages!(internal @ $crate::system::schedule::stage::Null; $($idents $(: $systems)?,)*)
+        );
+        (internal @ $processed:ty; system: $system:ty, $($idents:tt $(: $systems:tt)?),* $(,)?) => (
+            stages!(internal @ ($crate::system::schedule::stage::Stage<$system, $crate::system::Null>, $processed); $($idents $(: $systems)?,)*)
+        );
+        (internal @ $processed:ty; par_system: $par_system:ty, $($idents:tt $(: $systems:tt)?),* $(,)?) => (
+            stages!(internal @ ($crate::system::schedule::stage::Stage<$crate::system::Null, $par_system>, $processed); $($idents $(: $systems)?,)*)
+        );
+        (internal @ $processed:ty; flush, $($idents:tt $(: $systems:tt)?),* $(,)?) => (
+            stages!(internal @ ($crate::system::schedule::stage::Stage<$crate::system::Null, $crate::system::Null>, $processed); $($idents $(: $systems)?,)*)
+        );
+        (internal @ $processed:ty; $($idents:tt $(: $systems:tt)?),* $(,)?) => (
+            $processed
+        );
+}
 }

--- a/src/system/schedule/stage/mod.rs
+++ b/src/system/schedule/stage/mod.rs
@@ -1,6 +1,6 @@
 mod seal;
 
-use crate::system::{schedule::task::Task, ParSystem, System};
+use crate::{hlist::define_null, system::{schedule::task::Task, ParSystem, System}};
 use seal::Seal;
 
 pub enum Stage<S, P> {
@@ -11,7 +11,7 @@ pub enum Stage<S, P> {
 
 pub trait Stages<'a>: Seal<'a> {}
 
-pub struct Null;
+define_null!();
 
 impl<'a> Stages<'a> for Null {}
 

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -121,6 +121,25 @@ where
         }
     }
 
+    /// Remove a component from the entity.
+    ///
+    /// If the component is not present within the entity, nothing happens.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entity, registry, World};
+    ///
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    ///
+    /// type Registry = registry!(Foo, Bar);
+    ///
+    /// let mut world = World::<Registry>::new();
+    /// let entity_identifier = world.push(entity!(Foo(42), Bar(true)));
+    /// let mut entry = world.entry(entity_identifier).unwrap();
+    ///
+    /// entry.remove::<Foo>();
+    /// ```
     pub fn remove<C>(&mut self)
     where
         C: Component,

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -3,6 +3,30 @@ use crate::{
 };
 use core::any::TypeId;
 
+/// A view into a single entity in a [`World`].
+///
+/// This struct is constructed by the [`entry`] method on `World`.
+///
+/// # Example
+/// An entry for an entity can be obtained from an [`entity::Identifier`] as follows:
+///
+/// ``` rust
+/// use brood::{entity, registry, World};
+///
+/// struct Foo(u32);
+/// struct Bar(bool);
+///
+/// type Registry = registry!(Foo, Bar);
+///
+/// let mut world = World::<Registry>::new();
+/// let entity_identifier = world.push(entity!(Foo(42), Bar(true)));
+///
+/// let mut entry = world.entry(entity_identifier).unwrap();
+/// ```
+///
+/// [`entity::Identifier`]: crate::entity::Identifier
+/// [`entry`]: crate::World::entry()
+/// [`World`]: crate::World
 pub struct Entry<'a, R>
 where
     R: Registry,

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -43,6 +43,26 @@ where
         Self { world, location }
     }
 
+    /// Add a component to the entity.
+    ///
+    /// If the component already exists, it is updated to the new value.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entity, registry, World};
+    ///
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    /// struct Baz(f64);
+    ///
+    /// type Registry = registry!(Foo, Bar, Baz);
+    ///
+    /// let mut world = World::<Registry>::new();
+    /// let entity_identifier = world.push(entity!(Foo(42), Bar(true)));
+    /// let mut entry = world.entry(entity_identifier).unwrap();
+    ///
+    /// entry.add(Baz(1.5));
+    /// ```
     pub fn add<C>(&mut self, component: C)
     where
         C: Component,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1,7 +1,7 @@
 //! A container of entities.
 //!
 //! Entities are primarily stored and interacted with through a [`World`] container. A `World`
-//! stores entities made with a combination of components contained in the `World`'s component 
+//! stores entities made with a combination of components contained in the `World`'s component
 //! `Registry`.
 
 mod entry;
@@ -189,7 +189,7 @@ where
     }
 
     /// Query for components contained within the `World` using the given [`Views`] `V` and
-    /// [`Filter`] `F`, returning an [`Iterator`] over all components of entities matching the 
+    /// [`Filter`] `F`, returning an [`Iterator`] over all components of entities matching the
     /// query.
     ///
     /// Note that the order of the entities returned by a query is not specified.

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -237,6 +237,24 @@ where
             .map(|location| Entry::new(self, location))
     }
 
+    /// Remove the entity associated with an [`entity::Identifier`].
+    ///
+    /// If the entity has already been removed, this method will do nothing.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entity, registry, World};
+    ///
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    ///
+    /// type Registry = registry!(Foo, Bar);
+    ///
+    /// let mut world = World::<Registry>::new();
+    /// let entity_identifier = world.push(entity!(Foo(42), Bar(true)));
+    ///
+    /// world.remove(entity_identifier);
+    /// ```
     pub fn remove(&mut self, entity_identifier: entity::Identifier) {
         // Get location of entity.
         if let Some(location) = self.entity_allocator.get(entity_identifier) {

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -102,10 +102,32 @@ where
     ///
     /// let world = World::<Registry>::new();
     /// ```
+    ///
+    /// [`Registry`]: crate::registry::Registry
     pub fn new() -> Self {
         Self::from_raw_parts(Archetypes::new(), entity::Allocator::new())
     }
 
+    /// Insert an entity, returning an [`entity::Identifier`].
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entity, registry, World};
+    ///
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    ///
+    /// type Registry = registry!(Foo, Bar);
+    ///
+    /// let mut world = World::<Registry>::new();
+    ///
+    /// let entity_identifier = world.push(entity!(Foo(42), Bar(false)));
+    /// ```
+    ///
+    /// # Panics
+    /// Panics if the entity contains any components not included in the `World`'s [`Registry`].
+    ///
+    /// [`Registry`]: crate::registry::Registry
     pub fn push<E>(&mut self, entity: E) -> entity::Identifier
     where
         E: Entity,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1,3 +1,9 @@
+//! A container of entities.
+//!
+//! Entities are primarily stored and interacted with through a [`World`] container. A `World`
+//! stores entities made with a combination of components contained in the `World`'s component 
+//! `Registry`.
+
 mod entry;
 mod impl_debug;
 mod impl_default;

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -29,6 +29,35 @@ use alloc::{vec, vec::Vec};
 use core::any::TypeId;
 use hashbrown::HashMap;
 
+/// A container of entities.
+///
+/// A `World` can contain entities made of any combination of components contained in the
+/// [`Registry`] `R`. These entities are not stored in any defined order, and thier internal
+/// location is subject to change. Therefore, entities stored inside a `World` are uniquely
+/// identified using an `entity::Identifier`.
+///
+/// ``` rust
+/// use brood::{entity, registry, World};
+///
+/// // Define components.
+/// struct Foo(u32);
+/// struct Bar(bool);
+///
+/// // Create a world.
+/// let mut world = World::<registry!(Foo, Bar)>::new();
+///
+/// // Insert a new entity. The returned identifier uniquely identifies the entity.
+/// let entity_identifier = world.push(entity!(Foo(42), Bar(true)));
+/// ```
+///
+/// Note that a `World` can only contain entities made of components defined in the `World`'s
+/// registry. Attempting to insert entities containing components not in the registry will result
+/// in a panic.
+///
+/// Components of entities can be queried using the [`query()`] method. `Schedule`s of `System`s
+/// can also be run over the components stored in the `World` using the [`run()`] method.
+///
+/// [`Registry`]: crate::Registry
 pub struct World<R>
 where
     R: Registry,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -182,6 +182,37 @@ where
         }
     }
 
+    /// Query for components contained within the `World` using the given [`Views`] `V` and
+    /// [`Filter`] `F`, returning an iterator over all components of entities matching the query.
+    ///
+    /// Note that the order of the entities returned by a query is not specified.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entity, query::{filter, result, views}, registry, World};
+    ///
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    ///
+    /// type Registry = registry!(Foo, Bar);
+    ///
+    /// let mut world = World::<Registry>::new();
+    /// let inserted_entity_identifier = world.push(entity!(Foo(42), Bar(true)));
+    ///
+    /// // Note that the views provide implicit filters.
+    /// for result!(foo, entity_identifier) in world.query::<views!(&mut Foo, entity::Identifier), filter::Has<Bar>>() {
+    ///     // Allows immutable or mutable access to queried components.
+    ///     foo.0 = 100;
+    ///     // Also allows access to entity identifiers.
+    ///     assert_eq!(entity_identifier, inserted_entity_identifier);
+    /// }
+    /// ```
+    ///
+    /// For more information about `Views` and `Filter`, see the [`query`] module documentaion.
+    ///
+    /// [`Filter`]: crate::query::filter::Filter
+    /// [`query`]: crate::query
+    /// [`Views`]: crate::query::view::Views
     pub fn query<'a, V, F>(&'a mut self) -> result::Iter<'a, R, F, V>
     where
         V: Views<'a>,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -57,7 +57,9 @@ use hashbrown::HashMap;
 /// Components of entities can be queried using the [`query()`] method. `Schedule`s of `System`s
 /// can also be run over the components stored in the `World` using the [`run()`] method.
 ///
-/// [`Registry`]: crate::Registry
+/// [`query()`]: crate::World::query()
+/// [`Registry`]: crate::registry::Registry
+/// [`run()`]: crate::World::run()
 pub struct World<R>
 where
     R: Registry,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -231,6 +231,30 @@ where
         schedule.run(self);
     }
 
+    /// Gets an [`Entry`] for the entity associated with an [`entity::Identifier`] for
+    /// component-level manipulation.
+    ///
+    /// If no such entity exists, [`None`] is returned.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entity, registry, World};
+    ///
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    ///
+    /// type Registry = registry!(Foo, Bar);
+    ///
+    /// let mut world = World::<Registry>::new();
+    /// let entity_identifier = world.push(entity!(Foo(42), Bar(true)));
+    ///
+    /// let mut entry = world.entry(entity_identifier).unwrap();
+    /// // Remove the `Bar` component.
+    /// entry.remove::<Bar>();
+    /// ```
+    ///
+    /// [`Entry`]: crate::world::Entry
+    /// [`None`]: Option::None
     pub fn entry(&mut self, entity_identifier: entity::Identifier) -> Option<Entry<R>> {
         self.entity_allocator
             .get(entity_identifier)

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -183,7 +183,8 @@ where
     }
 
     /// Query for components contained within the `World` using the given [`Views`] `V` and
-    /// [`Filter`] `F`, returning an iterator over all components of entities matching the query.
+    /// [`Filter`] `F`, returning an [`Iterator`] over all components of entities matching the 
+    /// query.
     ///
     /// Note that the order of the entities returned by a query is not specified.
     ///
@@ -212,6 +213,7 @@ where
     /// For more information about `Views` and `Filter`, see the [`query`] module documentaion.
     ///
     /// [`Filter`]: crate::query::filter::Filter
+    /// [`Iterator`]: core::iter::Iterator
     /// [`query`]: crate::query
     /// [`Views`]: crate::query::view::Views
     pub fn query<'a, V, F>(&'a mut self) -> result::Iter<'a, R, F, V>

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -145,6 +145,26 @@ where
         }
     }
 
+    /// Insert multiple entities made from the same components, returning a [`Vec`] of [`entity::Identifier`]s.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entities, registry, World};
+    ///
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    ///
+    /// type Registry = registry!(Foo, Bar);
+    ///
+    /// let mut world = World::<Registry>::new();
+    ///
+    /// let entity_identiifers = world.extend(entities![(Foo(1), Bar(false)), (Foo(2), Bar(true))]);
+    /// ```
+    ///
+    /// # Panics
+    /// Panics if the entities contain any components not included in the `World`'s [`Registry`].
+    ///
+    /// [`Registry`]: crate::registry::Registry
     pub fn extend<E>(&mut self, entities: entities::Batch<E>) -> Vec<entity::Identifier>
     where
         E: Entities,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -86,6 +86,22 @@ where
         }
     }
 
+    /// Creates an empty `World`.
+    ///
+    /// Often, calls to `new()` are accompanied with a [`Registry`] to tell the compiler what
+    /// components the `World` can contain.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{registry, World};
+    ///
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    ///
+    /// type Registry = registry!(Foo, Bar);
+    ///
+    /// let world = World::<Registry>::new();
+    /// ```
     pub fn new() -> Self {
         Self::from_raw_parts(Archetypes::new(), entity::Allocator::new())
     }


### PR DESCRIPTION
This provides documentation for the entire public API *except* for the `World::run()` method, since this method is going to be changing a lot with the work to be done on #42.

This addresses part of #4, but does not close it completely. The private API should also be documented, although thorough examples are not required.