### PR TITLE
Run `clippy` in continuous integration workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,6 +93,7 @@ jobs:
       with:
         toolchain: nightly
         override: true
+        components: clippy
     - uses: actions-rs/install@v0.1
       with:
         crate: cargo-hack

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,6 +85,22 @@ jobs:
         command: hack
         args: check --feature-powerset --optional-deps
 
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - uses: actions-rs/install@v0.1
+      with:
+        crate: cargo-hack
+    - uses: actions-rs/cargo@v1
+      with:
+        command: hack
+        args: clippy --feature-powerset --optional-deps
+
   msrv:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: hack
-        args: clippy --feature-powerset --optional-deps
+        args: clippy --feature-powerset --optional-deps -- --deny warnings
 
   msrv:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: nightly
         override: true
     - uses: actions-rs/install@v0.1
       with:

--- a/src/archetype/identifier/iter.rs
+++ b/src/archetype/identifier/iter.rs
@@ -1,13 +1,7 @@
 use crate::registry::Registry;
 use core::marker::PhantomData;
 
-pub unsafe trait IdentifierIterator<R>: Iterator<Item = bool>
-where
-    R: Registry,
-{
-}
-
-pub(crate) struct IdentifierIter<R>
+pub struct IdentifierIter<R>
 where
     R: Registry,
 {
@@ -59,12 +53,10 @@ where
     }
 }
 
-unsafe impl<R> IdentifierIterator<R> for IdentifierIter<R> where R: Registry {}
-
 #[cfg(test)]
 mod tests {
     use crate::{
-        archetype::{Identifier, IdentifierIterator},
+        archetype::Identifier,
         registry,
     };
     use alloc::{vec, vec::Vec};
@@ -167,14 +159,5 @@ mod tests {
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
             vec![false, false, false, false, false, false, false, false, false]
         );
-    }
-
-    #[test]
-    fn impl_identifier_iterator() {
-        fn assert_impls_identifier_iterator(_iter: impl IdentifierIterator<Registry>) {}
-
-        let buffer = unsafe { Identifier::<Registry>::new(vec![0, 0, 0, 0]) };
-
-        assert_impls_identifier_iterator(unsafe { buffer.iter() });
     }
 }

--- a/src/archetype/identifier/iter.rs
+++ b/src/archetype/identifier/iter.rs
@@ -55,10 +55,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        archetype::Identifier,
-        registry,
-    };
+    use crate::{archetype::Identifier, registry};
     use alloc::{vec, vec::Vec};
 
     macro_rules! create_components {

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -3,7 +3,7 @@
 mod impl_serde;
 mod iter;
 
-pub use iter::IdentifierIterator;
+pub(crate) use iter::IdentifierIter;
 
 use crate::registry::Registry;
 use alloc::vec::Vec;
@@ -15,7 +15,6 @@ use core::{
     mem::ManuallyDrop,
     slice,
 };
-use iter::IdentifierIter;
 
 pub(crate) struct Identifier<R>
 where

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -7,7 +7,7 @@ mod impl_send;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod impl_serde;
 
-pub(crate) use identifier::{Identifier, IdentifierIterator, IdentifierRef};
+pub(crate) use identifier::{Identifier, IdentifierIter, IdentifierRef};
 #[cfg(feature = "serde")]
 pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
 

--- a/src/entity/allocator/mod.rs
+++ b/src/entity/allocator/mod.rs
@@ -216,7 +216,9 @@ where
         identifier: entity::Identifier,
         index: usize,
     ) {
-        self.slots.get_unchecked_mut(identifier.index).location
+        self.slots
+            .get_unchecked_mut(identifier.index)
+            .location
             .as_mut()
             .unwrap_unchecked()
             .index = index;

--- a/src/entity/allocator/mod.rs
+++ b/src/entity/allocator/mod.rs
@@ -216,7 +216,7 @@ where
         identifier: entity::Identifier,
         index: usize,
     ) {
-        (&mut self.slots.get_unchecked_mut(identifier.index).location)
+        self.slots.get_unchecked_mut(identifier.index).location
             .as_mut()
             .unwrap_unchecked()
             .index = index;

--- a/src/registry/debug.rs
+++ b/src/registry/debug.rs
@@ -11,6 +11,9 @@ use core::{
 };
 
 pub trait RegistryDebug: Registry {
+    // TODO: Remove attribute when https://github.com/rust-lang/rust-clippy/issues/8366 is
+    // resolved.
+    #[allow(clippy::ptr_arg)]
     unsafe fn extract_component_pointers<R>(
         index: usize,
         components: &[(*mut u8, usize)],

--- a/src/registry/debug.rs
+++ b/src/registry/debug.rs
@@ -15,14 +15,14 @@ pub trait RegistryDebug: Registry {
         index: usize,
         components: &[(*mut u8, usize)],
         pointers: &mut Vec<*const u8>,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry;
 
     unsafe fn debug_components<'a, 'b, R>(
         pointers: &[*const u8],
         debug_map: &mut DebugMap<'a, 'b>,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry;
 }
@@ -32,7 +32,7 @@ impl RegistryDebug for Null {
         _index: usize,
         _components: &[(*mut u8, usize)],
         _pointers: &mut Vec<*const u8>,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry,
     {
@@ -41,7 +41,7 @@ impl RegistryDebug for Null {
     unsafe fn debug_components<'a, 'b, R>(
         _pointers: &[*const u8],
         _debug_map: &mut DebugMap<'a, 'b>,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry,
     {
@@ -57,7 +57,7 @@ where
         index: usize,
         mut components: &[(*mut u8, usize)],
         pointers: &mut Vec<*const u8>,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         R_: Registry,
     {
@@ -72,7 +72,7 @@ where
     unsafe fn debug_components<'a, 'b, R_>(
         mut pointers: &[*const u8],
         debug_map: &mut DebugMap<'a, 'b>,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         R_: Registry,
     {

--- a/src/registry/eq.rs
+++ b/src/registry/eq.rs
@@ -11,7 +11,7 @@ pub trait RegistryPartialEq: Registry {
         components_a: &[(*mut u8, usize)],
         components_b: &[(*mut u8, usize)],
         length: usize,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) -> bool
     where
         R: Registry;
@@ -22,7 +22,7 @@ impl RegistryPartialEq for Null {
         _components_a: &[(*mut u8, usize)],
         _components_b: &[(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) -> bool
     where
         R: Registry,
@@ -40,7 +40,7 @@ where
         mut components_a: &[(*mut u8, usize)],
         mut components_b: &[(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) -> bool
     where
         R_: Registry,

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -23,6 +23,9 @@ pub trait Storage {
     ) where
         R: Registry;
 
+    // TODO: Remove attribute when https://github.com/rust-lang/rust-clippy/issues/8366 is
+    // resolved.
+    #[allow(clippy::ptr_arg)]
     unsafe fn new_components_with_capacity<R>(
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -19,19 +19,19 @@ pub trait Storage {
     unsafe fn create_component_map_for_key<R>(
         component_map: &mut HashMap<TypeId, usize>,
         index: usize,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry;
 
     unsafe fn new_components_with_capacity<R>(
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry;
 
     unsafe fn size_of_components_for_identifier<R>(
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) -> usize
     where
         R: Registry;
@@ -40,7 +40,7 @@ pub trait Storage {
         index: usize,
         components: &[(*mut u8, usize)],
         length: usize,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry;
 
@@ -49,7 +49,7 @@ pub trait Storage {
         buffer: *mut u8,
         components: &[(*mut u8, usize)],
         length: usize,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry;
 
@@ -58,7 +58,7 @@ pub trait Storage {
         component: MaybeUninit<C>,
         components: &mut [(*mut u8, usize)],
         length: usize,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         C: Component,
         R: Registry;
@@ -68,7 +68,7 @@ pub trait Storage {
         component: PhantomData<C>,
         components: &mut [(*mut u8, usize)],
         length: usize,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         C: Component,
         R: Registry;
@@ -76,20 +76,20 @@ pub trait Storage {
     unsafe fn free_components<R>(
         components: &[(*mut u8, usize)],
         length: usize,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry;
 
     unsafe fn try_free_components<R>(
         components: &[(*mut u8, usize)],
         length: usize,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry;
 
     unsafe fn debug_identifier<R>(
         debug_list: &mut DebugList,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry;
 }
@@ -100,7 +100,7 @@ impl Storage for Null {
     unsafe fn create_component_map_for_key<R>(
         _component_map: &mut HashMap<TypeId, usize>,
         _index: usize,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry,
     {
@@ -109,14 +109,14 @@ impl Storage for Null {
     unsafe fn new_components_with_capacity<R>(
         _components: &mut Vec<(*mut u8, usize)>,
         _length: usize,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry,
     {
     }
 
     unsafe fn size_of_components_for_identifier<R>(
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) -> usize
     where
         R: Registry,
@@ -128,7 +128,7 @@ impl Storage for Null {
         _index: usize,
         _components: &[(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry,
     {
@@ -139,7 +139,7 @@ impl Storage for Null {
         _buffer: *mut u8,
         _components: &[(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry,
     {
@@ -150,7 +150,7 @@ impl Storage for Null {
         _component: MaybeUninit<C>,
         _components: &mut [(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         C: Component,
         R: Registry,
@@ -162,7 +162,7 @@ impl Storage for Null {
         _component: PhantomData<C>,
         _components: &mut [(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         C: Component,
         R: Registry,
@@ -172,7 +172,7 @@ impl Storage for Null {
     unsafe fn free_components<R>(
         _components: &[(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry,
     {
@@ -181,7 +181,7 @@ impl Storage for Null {
     unsafe fn try_free_components<R>(
         _components: &[(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry,
     {
@@ -189,7 +189,7 @@ impl Storage for Null {
 
     unsafe fn debug_identifier<R>(
         _debug_list: &mut DebugList,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) where
         R: Registry,
     {
@@ -209,7 +209,7 @@ where
     unsafe fn create_component_map_for_key<R_>(
         component_map: &mut HashMap<TypeId, usize>,
         mut index: usize,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         R_: Registry,
     {
@@ -223,7 +223,7 @@ where
     unsafe fn new_components_with_capacity<R_>(
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         R_: Registry,
     {
@@ -236,7 +236,7 @@ where
     }
 
     unsafe fn size_of_components_for_identifier<R_>(
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) -> usize
     where
         R_: Registry,
@@ -249,7 +249,7 @@ where
         index: usize,
         mut components: &[(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         R_: Registry,
     {
@@ -272,7 +272,7 @@ where
         mut buffer: *mut u8,
         mut components: &[(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         R_: Registry,
     {
@@ -297,7 +297,7 @@ where
         mut component: MaybeUninit<C_>,
         mut components: &mut [(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         C_: Component,
         R_: Registry,
@@ -347,7 +347,7 @@ where
         component: PhantomData<C_>,
         mut components: &mut [(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         C_: Component,
         R_: Registry,
@@ -384,7 +384,7 @@ where
     unsafe fn free_components<R_>(
         mut components: &[(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         R_: Registry,
     {
@@ -403,7 +403,7 @@ where
     unsafe fn try_free_components<R_>(
         mut components: &[(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         R_: Registry,
     {
@@ -431,7 +431,7 @@ where
 
     unsafe fn debug_identifier<R_>(
         debug_list: &mut DebugList,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) where
         R_: Registry,
     {

--- a/src/registry/serde.rs
+++ b/src/registry/serde.rs
@@ -123,6 +123,9 @@ where
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub trait RegistryDeserialize<'de>: Registry + 'de {
+    // TODO: Remove attribute when https://github.com/rust-lang/rust-clippy/issues/8366 is
+    // resolved.
+    #[allow(clippy::ptr_arg)]
     unsafe fn deserialize_components_by_column<R, V>(
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,

--- a/src/registry/serde.rs
+++ b/src/registry/serde.rs
@@ -14,7 +14,7 @@ pub trait RegistrySerialize: Registry {
         components: &[(*mut u8, usize)],
         length: usize,
         tuple: &mut S,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) -> Result<(), S::Error>
     where
         R: Registry,
@@ -25,7 +25,7 @@ pub trait RegistrySerialize: Registry {
         length: usize,
         index: usize,
         tuple: &mut S,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) -> Result<(), S::Error>
     where
         R: Registry,
@@ -37,7 +37,7 @@ impl RegistrySerialize for Null {
         _components: &[(*mut u8, usize)],
         _length: usize,
         _tuple: &mut S,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) -> Result<(), S::Error>
     where
         R: Registry,
@@ -51,7 +51,7 @@ impl RegistrySerialize for Null {
         _length: usize,
         _index: usize,
         _tuple: &mut S,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) -> Result<(), S::Error>
     where
         R: Registry,
@@ -70,7 +70,7 @@ where
         mut components: &[(*mut u8, usize)],
         length: usize,
         tuple: &mut S,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) -> Result<(), S::Error>
     where
         R_: Registry,
@@ -97,7 +97,7 @@ where
         length: usize,
         index: usize,
         tuple: &mut S,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) -> Result<(), S::Error>
     where
         R_: Registry,
@@ -127,7 +127,7 @@ pub trait RegistryDeserialize<'de>: Registry + 'de {
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,
         seq: &mut V,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) -> Result<(), V::Error>
     where
         R: Registry,
@@ -137,7 +137,7 @@ pub trait RegistryDeserialize<'de>: Registry + 'de {
         components: &mut [(*mut u8, usize)],
         length: usize,
         seq: &mut V,
-        identifier_iter: impl archetype::IdentifierIterator<R>,
+        identifier_iter: archetype::IdentifierIter<R>,
     ) -> Result<(), V::Error>
     where
         R: Registry,
@@ -149,7 +149,7 @@ impl<'de> RegistryDeserialize<'de> for Null {
         _components: &mut Vec<(*mut u8, usize)>,
         _length: usize,
         _seq: &mut V,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) -> Result<(), V::Error>
     where
         R: Registry,
@@ -162,7 +162,7 @@ impl<'de> RegistryDeserialize<'de> for Null {
         _components: &mut [(*mut u8, usize)],
         _length: usize,
         _seq: &mut V,
-        _identifier_iter: impl archetype::IdentifierIterator<R>,
+        _identifier_iter: archetype::IdentifierIter<R>,
     ) -> Result<(), V::Error>
     where
         R: Registry,
@@ -181,7 +181,7 @@ where
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,
         seq: &mut V,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) -> Result<(), V::Error>
     where
         R_: Registry,
@@ -204,7 +204,7 @@ where
         mut components: &mut [(*mut u8, usize)],
         length: usize,
         seq: &mut V,
-        mut identifier_iter: impl archetype::IdentifierIterator<R_>,
+        mut identifier_iter: archetype::IdentifierIter<R_>,
     ) -> Result<(), V::Error>
     where
         R_: Registry,

--- a/src/system/schedule/sendable.rs
+++ b/src/system/schedule/sendable.rs
@@ -9,7 +9,7 @@ where
     R: Registry,
 {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self(<&World<R>>::clone(&self.0))
     }
 }
 

--- a/src/system/schedule/sendable.rs
+++ b/src/system/schedule/sendable.rs
@@ -1,20 +1,20 @@
 use crate::{registry::Registry, world::World};
 
-pub struct SendableWorld<'a, R>(pub(crate) &'a World<R>)
+pub struct SendableWorld<R>(pub(crate) *mut World<R>)
 where
     R: Registry;
 
-impl<R> Clone for SendableWorld<'_, R>
+impl<R> Clone for SendableWorld<R>
 where
     R: Registry,
 {
     fn clone(&self) -> Self {
-        Self(<&World<R>>::clone(&self.0))
+        Self(self.0)
     }
 }
 
-impl<R> Copy for SendableWorld<'_, R> where R: Registry {}
+impl<R> Copy for SendableWorld<R> where R: Registry {}
 
-unsafe impl<R> Send for SendableWorld<'_, R> where R: Registry {}
+unsafe impl<R> Send for SendableWorld<R> where R: Registry {}
 
-unsafe impl<R> Sync for SendableWorld<'_, R> where R: Registry {}
+unsafe impl<R> Sync for SendableWorld<R> where R: Registry {}

--- a/src/system/schedule/stage/seal.rs
+++ b/src/system/schedule/stage/seal.rs
@@ -10,53 +10,53 @@ use crate::{
 };
 
 pub trait Seal<'a>: Send {
-    fn run<R>(&mut self, world: SendableWorld<'a, R>)
+    fn run<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry + 'a;
 
-    fn defer<R>(&mut self, world: SendableWorld<'a, R>)
+    fn defer<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry + 'a;
 
-    fn run_current<R>(&mut self, world: SendableWorld<'a, R>)
+    fn run_current<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry + 'a;
 
-    fn run_continuing<R>(&mut self, world: SendableWorld<'a, R>)
+    fn run_continuing<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry + 'a;
 
-    fn flush<R>(&mut self, world: SendableWorld<'a, R>)
+    fn flush<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry + 'a;
 }
 
 impl<'a> Seal<'a> for Null {
-    fn run<R>(&mut self, _world: SendableWorld<'a, R>)
+    fn run<R>(&mut self, _world: SendableWorld<R>)
     where
         R: Registry + 'a,
     {
     }
 
-    fn defer<R>(&mut self, _world: SendableWorld<'a, R>)
+    fn defer<R>(&mut self, _world: SendableWorld<R>)
     where
         R: Registry + 'a,
     {
     }
 
-    fn run_current<R>(&mut self, _world: SendableWorld<'a, R>)
+    fn run_current<R>(&mut self, _world: SendableWorld<R>)
     where
         R: Registry + 'a,
     {
     }
 
-    fn run_continuing<R>(&mut self, _world: SendableWorld<'a, R>)
+    fn run_continuing<R>(&mut self, _world: SendableWorld<R>)
     where
         R: Registry + 'a,
     {
     }
 
-    fn flush<R>(&mut self, _world: SendableWorld<'a, R>)
+    fn flush<R>(&mut self, _world: SendableWorld<R>)
     where
         R: Registry + 'a,
     {
@@ -69,7 +69,7 @@ where
     P: ParSystem<'a> + Send,
     L: Seal<'a>,
 {
-    fn run<R>(&mut self, world: SendableWorld<'a, R>)
+    fn run<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry + 'a,
     {
@@ -77,7 +77,7 @@ where
         self.run_current(world);
     }
 
-    fn defer<R>(&mut self, world: SendableWorld<'a, R>)
+    fn defer<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry + 'a,
     {
@@ -91,7 +91,7 @@ where
         }
     }
 
-    fn run_current<R>(&mut self, world: SendableWorld<'a, R>)
+    fn run_current<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry + 'a,
     {
@@ -115,7 +115,7 @@ where
         }
     }
 
-    fn run_continuing<R>(&mut self, world: SendableWorld<'a, R>)
+    fn run_continuing<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry + 'a,
     {
@@ -137,7 +137,7 @@ where
         }
     }
 
-    fn flush<R>(&mut self, world: SendableWorld<'a, R>)
+    fn flush<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry + 'a,
     {

--- a/src/system/schedule/task.rs
+++ b/src/system/schedule/task.rs
@@ -21,14 +21,14 @@ where
         match self {
             Task::Seq(system) => {
                 // Query world using system.
-                let result = unsafe { (&mut *world.0).query_unchecked::<S::Views, S::Filter>() };
+                let result = unsafe { (*world.0).query_unchecked::<S::Views, S::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }
             Task::Par(system) => {
                 // Query world using system.
                 let result =
-                    unsafe { (&mut *world.0).par_query_unchecked::<P::Views, P::Filter>() };
+                    unsafe { (*world.0).par_query_unchecked::<P::Views, P::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }

--- a/src/system/schedule/task.rs
+++ b/src/system/schedule/task.rs
@@ -27,8 +27,7 @@ where
             }
             Task::Par(system) => {
                 // Query world using system.
-                let result =
-                    unsafe { (*world.0).par_query_unchecked::<P::Views, P::Filter>() };
+                let result = unsafe { (*world.0).par_query_unchecked::<P::Views, P::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }

--- a/src/system/schedule/task.rs
+++ b/src/system/schedule/task.rs
@@ -14,27 +14,27 @@ where
     S: System<'a>,
     P: ParSystem<'a>,
 {
-    pub(crate) fn run<R>(&mut self, world: SendableWorld<'a, R>)
+    pub(crate) fn run<R>(&mut self, world: SendableWorld<R>)
     where
-        R: Registry,
+        R: Registry + 'a,
     {
         match self {
             Task::Seq(system) => {
                 // Query world using system.
-                let result = unsafe { world.0.query_unchecked::<S::Views, S::Filter>() };
+                let result = unsafe { (&mut *world.0).query_unchecked::<S::Views, S::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }
             Task::Par(system) => {
                 // Query world using system.
-                let result = unsafe { world.0.par_query_unchecked::<P::Views, P::Filter>() };
+                let result = unsafe { (&mut *world.0).par_query_unchecked::<P::Views, P::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }
         }
     }
 
-    pub(crate) fn flush<R>(&mut self, world: SendableWorld<'a, R>)
+    pub(crate) fn flush<R>(&mut self, world: SendableWorld<R>)
     where
         R: Registry,
     {

--- a/src/system/schedule/task.rs
+++ b/src/system/schedule/task.rs
@@ -27,7 +27,8 @@ where
             }
             Task::Par(system) => {
                 // Query world using system.
-                let result = unsafe { (&mut *world.0).par_query_unchecked::<P::Views, P::Filter>() };
+                let result =
+                    unsafe { (&mut *world.0).par_query_unchecked::<P::Views, P::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -279,24 +279,22 @@ where
 
     #[cfg(feature = "parallel")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
-    pub(crate) unsafe fn query_unchecked<'a, V, F>(&'a self) -> result::Iter<'a, R, F, V>
+    pub(crate) unsafe fn query_unchecked<'a, V, F>(&'a mut self) -> result::Iter<'a, R, F, V>
     where
         V: Views<'a>,
         F: Filter,
     {
-        let mut_self = &mut *(self as *const World<R> as *mut World<R>);
-        result::Iter::new(mut_self.archetypes.iter_mut(), &self.component_map)
+        result::Iter::new(self.archetypes.iter_mut(), &self.component_map)
     }
 
     #[cfg(feature = "parallel")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
-    pub(crate) unsafe fn par_query_unchecked<'a, V, F>(&'a self) -> result::ParIter<'a, R, F, V>
+    pub(crate) unsafe fn par_query_unchecked<'a, V, F>(&'a mut self) -> result::ParIter<'a, R, F, V>
     where
         V: ParViews<'a>,
         F: Filter,
     {
-        let mut_self = &mut *(self as *const World<R> as *mut World<R>);
-        result::ParIter::new(mut_self.archetypes.par_iter_mut(), &self.component_map)
+        result::ParIter::new(self.archetypes.par_iter_mut(), &self.component_map)
     }
 
     #[cfg(feature = "parallel")]


### PR DESCRIPTION
Fixes some `clippy` lints and enables `clippy` in CI. This is the last step of #9.