### PR TITLE
Fix undefined behavior with reading and writing to buffers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,12 +113,12 @@ jobs:
     - uses: actions-rs/install@v0.1
       with:
         crate: cargo-hack
-    - env:
-      MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks
     - uses: actions-rs/cargo@v1
       with:
         command: hack
         args: miri test --feature-powerset --optional-deps
+      env:
+        MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks
 
   valgrind:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,6 +113,8 @@ jobs:
     - uses: actions-rs/install@v0.1
       with:
         crate: cargo-hack
+    - env:
+      MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks
     - uses: actions-rs/cargo@v1
       with:
         command: hack

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -284,7 +284,7 @@ where
                 component_column.1,
             ));
 
-            ptr::write(buffer as *mut C, v.swap_remove(index));
+            ptr::write_unaligned(buffer as *mut C, v.swap_remove(index));
             buffer = buffer.add(size_of::<C>());
 
             components = components.get_unchecked(1..);
@@ -324,7 +324,7 @@ where
                     length,
                     component_column.1,
                 ));
-                v.push(buffer.cast::<C>().read());
+                v.push(buffer.cast::<C>().read_unaligned());
                 buffer = buffer.add(size_of::<C>());
 
                 *component_column = (v.as_mut_ptr() as *mut u8, v.capacity());
@@ -365,7 +365,7 @@ where
                 length,
                 component_column.1,
             ));
-            v.push(buffer.cast::<C>().read());
+            v.push(buffer.cast::<C>().read_unaligned());
             *component_column = (v.as_mut_ptr() as *mut u8, v.capacity());
 
             components = components.get_unchecked_mut(1..);


### PR DESCRIPTION
This fixes the undefined behavior `miri` has been complaining about with reading and writing values to a buffer. The values were being written to and read from the buffer using `ptr::write` and `ptr::read`, which is incorrect because those methods assume the locations will be correctly aligned. The fix is to use `ptr::write_unaligned` and `ptr::read_unaligned`.