### PR TITLE
Assert `Views` are sound in queries

### DIFF
--- a/src/query/view/assertion_buffer.rs
+++ b/src/query/view/assertion_buffer.rs
@@ -7,7 +7,7 @@
 //! [`Views`]: crate::query::view::Views
 
 use crate::component::Component;
-use core::any::{TypeId, type_name};
+use core::any::{type_name, TypeId};
 use hashbrown::HashSet;
 
 /// A buffer for performing assertions on [`Views`].
@@ -17,7 +17,7 @@ use hashbrown::HashSet;
 /// each component is either only borrowed once mutably, or is borrowed multiple times immutably.
 /// If any claim run through the buffer breaks these rules, a panic will occur.
 ///
-/// It is recommended to create a single buffer with the capacity of a registry and reuse it for 
+/// It is recommended to create a single buffer with the capacity of a registry and reuse it for
 /// every check to avoid unnecessary allocations.
 ///
 /// In the future, it would be ideal to move this check to compile time. However, running a check
@@ -60,9 +60,15 @@ impl AssertionBuffer {
     ///
     /// # Panics
     /// This method will panic if the component is already claimed, either mutably or immutably.
-    pub(crate) fn claim_mutable<C>(&mut self) where C: Component {
+    pub(crate) fn claim_mutable<C>(&mut self)
+    where
+        C: Component,
+    {
         if self.mutable_claims.contains(&TypeId::of::<C>()) {
-            panic!("the component {} cannot be viewed as mutable when it is already viewed as mutable", type_name::<C>());
+            panic!(
+                "the component {} cannot be viewed as mutable when it is already viewed as mutable",
+                type_name::<C>()
+            );
         } else if self.immutable_claims.contains(&TypeId::of::<C>()) {
             panic!("the component {} cannot be viewed as mutable when it is already viewed as immutable", type_name::<C>());
         }
@@ -75,7 +81,10 @@ impl AssertionBuffer {
     /// # Panics
     /// This method will panic if the component is already claimed mutably. Note that components
     /// may be claimed immutably more than once.
-    pub(crate) fn claim_immutable<C>(&mut self) where C: Component {
+    pub(crate) fn claim_immutable<C>(&mut self)
+    where
+        C: Component,
+    {
         if self.mutable_claims.contains(&TypeId::of::<C>()) {
             panic!("the component {} cannot be viewed as immutable when it is already viewed as mutable", type_name::<C>());
         }
@@ -156,7 +165,7 @@ mod tests {
         buffer.claim_mutable::<A>();
         buffer.claim_immutable::<A>();
     }
-    
+
     #[test]
     #[should_panic]
     fn claim_immutable_than_mutable() {

--- a/src/query/view/assertion_buffer.rs
+++ b/src/query/view/assertion_buffer.rs
@@ -33,6 +33,13 @@ pub struct AssertionBuffer {
 }
 
 impl AssertionBuffer {
+    /// Create a new empty buffer.
+    ///
+    /// It is recommended to use [`with_capacity`] if possible, as it will save allocations.
+    pub(crate) fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
     /// Create a new buffer with the given capacity.
     ///
     /// A buffer created this way will have the capacity to ensure this number of components are
@@ -93,6 +100,14 @@ mod tests {
     // Test components.
     struct A;
     struct B;
+
+    #[test]
+    fn new() {
+        let buffer = AssertionBuffer::new();
+
+        assert!(buffer.mutable_claims.is_empty());
+        assert!(buffer.immutable_claims.is_empty());
+    }
 
     #[test]
     fn with_capacity() {

--- a/src/query/view/assertion_buffer.rs
+++ b/src/query/view/assertion_buffer.rs
@@ -36,6 +36,7 @@ impl AssertionBuffer {
     /// Create a new empty buffer.
     ///
     /// It is recommended to use [`with_capacity`] if possible, as it will save allocations.
+    #[cfg(feature = "parallel")]
     pub(crate) fn new() -> Self {
         Self::with_capacity(0)
     }
@@ -110,6 +111,7 @@ mod tests {
     struct A;
     struct B;
 
+    #[cfg(feature = "parallel")]
     #[test]
     fn new() {
         let buffer = AssertionBuffer::new();

--- a/src/query/view/assertion_buffer.rs
+++ b/src/query/view/assertion_buffer.rs
@@ -25,7 +25,7 @@ use hashbrown::HashSet;
 /// large amount of unstable nightly features.
 ///
 /// [`Views`]: crate::query::view::Views
-pub(crate) struct AssertionBuffer {
+pub struct AssertionBuffer {
     /// Components that are viewed mutably.
     mutable_claims: HashSet<TypeId>,
     /// Components that are viewed immutably.

--- a/src/query/view/assertion_buffer.rs
+++ b/src/query/view/assertion_buffer.rs
@@ -1,0 +1,216 @@
+//! A buffer for performing assertions on [`Views`].
+//!
+//! This module provides a reusable bufer for performing assertions on views. This buffer should be
+//! used any time `Views` are used to query data from a [`World`], as not performing the assertion
+//! is not sound.
+//!
+//! [`Views`]: crate::query::view::Views
+
+use crate::component::Component;
+use core::any::{TypeId, type_name};
+use hashbrown::HashSet;
+
+/// A buffer for performing assertions on [`Views`].
+///
+/// This struct is intended to be used as a reusable buffer for ensuring that `Views` don't attempt
+/// to borrow components in a way that will cause undefined behavior. Specifically, it ensures that
+/// each component is either only borrowed once mutably, or is borrowed multiple times immutably.
+/// If any claim run through the buffer breaks these rules, a panic will occur.
+///
+/// It is recommended to create a single buffer with the capacity of a registry and reuse it for 
+/// every check to avoid unnecessary allocations.
+///
+/// In the future, it would be ideal to move this check to compile time. However, running a check
+/// like this using const functions on a heterogeneous list is just not possible yet without a
+/// large amount of unstable nightly features.
+///
+/// [`Views`]: crate::query::view::Views
+pub(crate) struct AssertionBuffer {
+    /// Components that are viewed mutably.
+    mutable_claims: HashSet<TypeId>,
+    /// Components that are viewed immutably.
+    immutable_claims: HashSet<TypeId>,
+}
+
+impl AssertionBuffer {
+    /// Create a new buffer with the given capacity.
+    ///
+    /// A buffer created this way will have the capacity to ensure this number of components are
+    /// viewed correctly without creating any extra allocations. It is recommended to call this
+    /// method with the size of the [`World`]'s [`Registry`] to enable storing all components of
+    /// the `Registry`.
+    ///
+    /// [`Registry`]: crate::registry::Registry
+    /// [`World`]: crate::world::World
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            mutable_claims: HashSet::with_capacity(capacity),
+            immutable_claims: HashSet::with_capacity(capacity),
+        }
+    }
+
+    /// Claim a component as being viewed mutably.
+    ///
+    /// # Panics
+    /// This method will panic if the component is already claimed, either mutably or immutably.
+    pub(crate) fn claim_mutable<C>(&mut self) where C: Component {
+        if self.mutable_claims.contains(&TypeId::of::<C>()) {
+            panic!("the component {} cannot be viewed as mutable when it is already viewed as mutable", type_name::<C>());
+        } else if self.immutable_claims.contains(&TypeId::of::<C>()) {
+            panic!("the component {} cannot be viewed as mutable when it is already viewed as immutable", type_name::<C>());
+        }
+
+        self.mutable_claims.insert(TypeId::of::<C>());
+    }
+
+    /// Claim a component as being viewed immutably.
+    ///
+    /// # Panics
+    /// This method will panic if the component is already claimed mutably. Note that components
+    /// may be claimed immutably more than once.
+    pub(crate) fn claim_immutable<C>(&mut self) where C: Component {
+        if self.mutable_claims.contains(&TypeId::of::<C>()) {
+            panic!("the component {} cannot be viewed as immutable when it is already viewed as mutable", type_name::<C>());
+        }
+
+        self.immutable_claims.insert(TypeId::of::<C>());
+    }
+
+    /// Clear the buffer, allowing it to be reused.
+    ///
+    /// It is recommended to clear the buffer and reuse it instead of creating a new one, as this
+    /// will prevent unnecessary allocations.
+    pub(crate) fn clear(&mut self) {
+        self.mutable_claims.clear();
+        self.immutable_claims.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AssertionBuffer;
+
+    // Test components.
+    struct A;
+    struct B;
+
+    #[test]
+    fn with_capacity() {
+        let buffer = AssertionBuffer::with_capacity(42);
+
+        assert!(buffer.mutable_claims.capacity() >= 42);
+        assert!(buffer.immutable_claims.capacity() >= 42);
+    }
+
+    #[test]
+    fn claim_mutable() {
+        let mut buffer = AssertionBuffer::with_capacity(1);
+
+        buffer.claim_mutable::<A>();
+    }
+
+    #[test]
+    fn claim_immutable() {
+        let mut buffer = AssertionBuffer::with_capacity(1);
+
+        buffer.claim_immutable::<A>();
+    }
+
+    #[test]
+    fn claim_immutable_multiple_times() {
+        let mut buffer = AssertionBuffer::with_capacity(1);
+
+        buffer.claim_immutable::<A>();
+        buffer.claim_immutable::<A>();
+    }
+
+    #[test]
+    #[should_panic]
+    fn claim_mutable_multiple_times() {
+        let mut buffer = AssertionBuffer::with_capacity(1);
+
+        buffer.claim_mutable::<A>();
+        buffer.claim_mutable::<A>();
+    }
+
+    #[test]
+    #[should_panic]
+    fn claim_mutable_than_immutable() {
+        let mut buffer = AssertionBuffer::with_capacity(1);
+
+        buffer.claim_mutable::<A>();
+        buffer.claim_immutable::<A>();
+    }
+    
+    #[test]
+    #[should_panic]
+    fn claim_immutable_than_mutable() {
+        let mut buffer = AssertionBuffer::with_capacity(1);
+
+        buffer.claim_immutable::<A>();
+        buffer.claim_mutable::<A>();
+    }
+
+    #[test]
+    fn claim_multiple_components_mutable() {
+        let mut buffer = AssertionBuffer::with_capacity(2);
+
+        buffer.claim_mutable::<A>();
+        buffer.claim_mutable::<B>();
+    }
+
+    #[test]
+    fn claim_multiple_components_immutable() {
+        let mut buffer = AssertionBuffer::with_capacity(2);
+
+        buffer.claim_immutable::<A>();
+        buffer.claim_immutable::<B>();
+    }
+
+    #[test]
+    fn claim_multiple_components_mutable_and_immutable() {
+        let mut buffer = AssertionBuffer::with_capacity(2);
+
+        buffer.claim_mutable::<A>();
+        buffer.claim_immutable::<B>();
+    }
+
+    #[test]
+    fn clear_empty() {
+        let mut buffer = AssertionBuffer::with_capacity(0);
+
+        buffer.clear();
+    }
+
+    #[test]
+    fn clear_mutable_claims() {
+        let mut buffer = AssertionBuffer::with_capacity(1);
+        buffer.claim_mutable::<A>();
+
+        buffer.clear();
+
+        buffer.claim_mutable::<A>();
+    }
+
+    #[test]
+    fn clear_immutable_claims() {
+        let mut buffer = AssertionBuffer::with_capacity(1);
+        buffer.claim_immutable::<A>();
+
+        buffer.clear();
+
+        buffer.claim_mutable::<A>();
+    }
+
+    #[test]
+    fn clear_mutable_and_immutable_claims() {
+        let mut buffer = AssertionBuffer::with_capacity(2);
+        buffer.claim_immutable::<A>();
+        buffer.claim_mutable::<B>();
+
+        buffer.clear();
+
+        buffer.claim_mutable::<A>();
+        buffer.claim_immutable::<B>();
+    }
+}

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -47,7 +47,8 @@
 mod assertion_buffer;
 #[cfg(feature = "parallel")]
 mod par;
-mod seal;
+
+pub(crate) mod seal;
 
 #[cfg(feature = "parallel")]
 pub use par::{ParView, ParViews};

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -44,12 +44,15 @@
 //! [`views!`]: crate::query::views!
 //! [`World`]: crate::world::World.
 
+mod assertion_buffer;
 #[cfg(feature = "parallel")]
 mod par;
 mod seal;
 
 #[cfg(feature = "parallel")]
 pub use par::{ParView, ParViews};
+
+pub(crate) use assertion_buffer::AssertionBuffer;
 
 use crate::{component::Component, doc, entity, hlist::define_null, query::filter::Filter};
 use seal::{ViewSeal, ViewsSeal};

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -1,7 +1,11 @@
 use crate::{
     component::Component,
     entity,
-    query::{claim::Claim, result, view::{AssertionBuffer, Null}},
+    query::{
+        claim::Claim,
+        result,
+        view::{AssertionBuffer, Null},
+    },
 };
 use core::{any::TypeId, iter, slice};
 use either::Either;
@@ -17,9 +21,7 @@ pub trait ViewSeal<'a>: Claim {
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result;
 
-    fn assert_claim(
-        buffer: &mut AssertionBuffer,
-    );
+    fn assert_claim(buffer: &mut AssertionBuffer);
 }
 
 impl<'a, C> ViewSeal<'a> for &C
@@ -43,9 +45,7 @@ where
         .iter()
     }
 
-    fn assert_claim(
-        buffer: &mut AssertionBuffer,
-    ) {
+    fn assert_claim(buffer: &mut AssertionBuffer) {
         buffer.claim_immutable::<C>();
     }
 }
@@ -71,9 +71,7 @@ where
         .iter_mut()
     }
 
-    fn assert_claim(
-        buffer: &mut AssertionBuffer,
-    ) {
+    fn assert_claim(buffer: &mut AssertionBuffer) {
         buffer.claim_mutable::<C>();
     }
 }
@@ -107,9 +105,7 @@ where
         }
     }
 
-    fn assert_claim(
-        buffer: &mut AssertionBuffer,
-    ) {
+    fn assert_claim(buffer: &mut AssertionBuffer) {
         buffer.claim_immutable::<C>();
     }
 }
@@ -143,9 +139,7 @@ where
         }
     }
 
-    fn assert_claim(
-        buffer: &mut AssertionBuffer,
-    ) {
+    fn assert_claim(buffer: &mut AssertionBuffer) {
         buffer.claim_mutable::<C>();
     }
 }
@@ -164,9 +158,7 @@ impl<'a> ViewSeal<'a> for entity::Identifier {
             .cloned()
     }
 
-    fn assert_claim(
-        _buffer: &mut AssertionBuffer,
-    ) {}
+    fn assert_claim(_buffer: &mut AssertionBuffer) {}
 }
 
 pub trait ViewsSeal<'a>: Claim {
@@ -179,9 +171,7 @@ pub trait ViewsSeal<'a>: Claim {
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Results;
 
-    fn assert_claims(
-        buffer: &mut AssertionBuffer,
-    );
+    fn assert_claims(buffer: &mut AssertionBuffer);
 }
 
 impl<'a> ViewsSeal<'a> for Null {
@@ -196,9 +186,7 @@ impl<'a> ViewsSeal<'a> for Null {
         iter::repeat(result::Null)
     }
 
-    fn assert_claims(
-        _buffer: &mut AssertionBuffer,
-    ) {}
+    fn assert_claims(_buffer: &mut AssertionBuffer) {}
 }
 
 impl<'a, V, W> ViewsSeal<'a> for (V, W)
@@ -222,9 +210,7 @@ where
         ))
     }
 
-    fn assert_claims(
-        buffer: &mut AssertionBuffer,
-    ) {
+    fn assert_claims(buffer: &mut AssertionBuffer) {
         V::assert_claim(buffer);
         W::assert_claims(buffer);
     }

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -1,7 +1,7 @@
 use crate::{
     component::Component,
     entity,
-    query::{claim::Claim, result, view::Null},
+    query::{claim::Claim, result, view::{AssertionBuffer, Null}},
 };
 use core::{any::TypeId, iter, slice};
 use either::Either;
@@ -16,6 +16,10 @@ pub trait ViewSeal<'a>: Claim {
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result;
+
+    fn assert_claim(
+        buffer: &mut AssertionBuffer,
+    );
 }
 
 impl<'a, C> ViewSeal<'a> for &C
@@ -38,6 +42,12 @@ where
         )
         .iter()
     }
+
+    fn assert_claim(
+        buffer: &mut AssertionBuffer,
+    ) {
+        buffer.claim_immutable::<C>();
+    }
 }
 
 impl<'a, C> ViewSeal<'a> for &mut C
@@ -59,6 +69,12 @@ where
             length,
         )
         .iter_mut()
+    }
+
+    fn assert_claim(
+        buffer: &mut AssertionBuffer,
+    ) {
+        buffer.claim_mutable::<C>();
     }
 }
 
@@ -90,6 +106,12 @@ where
             None => Either::Left(iter::repeat(None).take(length)),
         }
     }
+
+    fn assert_claim(
+        buffer: &mut AssertionBuffer,
+    ) {
+        buffer.claim_immutable::<C>();
+    }
 }
 
 impl<'a, C> ViewSeal<'a> for Option<&mut C>
@@ -120,6 +142,12 @@ where
             None => Either::Left(iter::repeat_with(none as fn() -> Option<&'a mut C>).take(length)),
         }
     }
+
+    fn assert_claim(
+        buffer: &mut AssertionBuffer,
+    ) {
+        buffer.claim_mutable::<C>();
+    }
 }
 
 impl<'a> ViewSeal<'a> for entity::Identifier {
@@ -135,6 +163,10 @@ impl<'a> ViewSeal<'a> for entity::Identifier {
             .iter()
             .cloned()
     }
+
+    fn assert_claim(
+        _buffer: &mut AssertionBuffer,
+    ) {}
 }
 
 pub trait ViewsSeal<'a>: Claim {
@@ -146,6 +178,10 @@ pub trait ViewsSeal<'a>: Claim {
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Results;
+
+    fn assert_claims(
+        buffer: &mut AssertionBuffer,
+    );
 }
 
 impl<'a> ViewsSeal<'a> for Null {
@@ -159,6 +195,10 @@ impl<'a> ViewsSeal<'a> for Null {
     ) -> Self::Results {
         iter::repeat(result::Null)
     }
+
+    fn assert_claims(
+        _buffer: &mut AssertionBuffer,
+    ) {}
 }
 
 impl<'a, V, W> ViewsSeal<'a> for (V, W)
@@ -180,5 +220,12 @@ where
             length,
             component_map,
         ))
+    }
+
+    fn assert_claims(
+        buffer: &mut AssertionBuffer,
+    ) {
+        V::assert_claim(buffer);
+        W::assert_claims(buffer);
     }
 }

--- a/src/system/schedule/builder.rs
+++ b/src/system/schedule/builder.rs
@@ -1,4 +1,5 @@
 use crate::{
+    query::view,
     system,
     system::{
         schedule::{
@@ -130,6 +131,7 @@ where
                 &mut HashSet::new(),
                 &mut HashSet::new(),
                 &mut HashSet::new(),
+                &mut view::AssertionBuffer::new(),
             ),
         }
     }

--- a/src/system/schedule/task.rs
+++ b/src/system/schedule/task.rs
@@ -21,13 +21,13 @@ where
         match self {
             Task::Seq(system) => {
                 // Query world using system.
-                let result = unsafe { (*world.0).query::<S::Views, S::Filter>() };
+                let result = unsafe { (*world.0).query_unchecked::<S::Views, S::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }
             Task::Par(system) => {
                 // Query world using system.
-                let result = unsafe { (*world.0).par_query::<P::Views, P::Filter>() };
+                let result = unsafe { (*world.0).par_query_unchecked::<P::Views, P::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }

--- a/src/system/schedule/task.rs
+++ b/src/system/schedule/task.rs
@@ -21,13 +21,13 @@ where
         match self {
             Task::Seq(system) => {
                 // Query world using system.
-                let result = unsafe { (*world.0).query_unchecked::<S::Views, S::Filter>() };
+                let result = unsafe { (*world.0).query::<S::Views, S::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }
             Task::Par(system) => {
                 // Query world using system.
-                let result = unsafe { (*world.0).par_query_unchecked::<P::Views, P::Filter>() };
+                let result = unsafe { (*world.0).par_query::<P::Views, P::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -283,10 +283,11 @@ where
     {
         self.view_assertion_buffer.clear();
         V::assert_claims(&mut self.view_assertion_buffer);
-        
+
         result::ParIter::new(self.archetypes.par_iter_mut(), &self.component_map)
     }
 
+    /// Performs a query, skipping checks on views.
     #[cfg(feature = "parallel")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub(crate) unsafe fn query_unchecked<'a, V, F>(&'a mut self) -> result::Iter<'a, R, F, V>
@@ -297,6 +298,7 @@ where
         result::Iter::new(self.archetypes.iter_mut(), &self.component_map)
     }
 
+    /// Performs a parallel query, skipping checks on views.
     #[cfg(feature = "parallel")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub(crate) unsafe fn par_query_unchecked<'a, V, F>(&'a mut self) -> result::ParIter<'a, R, F, V>

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -289,6 +289,26 @@ where
 
     #[cfg(feature = "parallel")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+    pub(crate) unsafe fn query_unchecked<'a, V, F>(&'a mut self) -> result::Iter<'a, R, F, V>
+    where
+        V: Views<'a>,
+        F: Filter,
+    {
+        result::Iter::new(self.archetypes.iter_mut(), &self.component_map)
+    }
+
+    #[cfg(feature = "parallel")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+    pub(crate) unsafe fn par_query_unchecked<'a, V, F>(&'a mut self) -> result::ParIter<'a, R, F, V>
+    where
+        V: ParViews<'a>,
+        F: Filter,
+    {
+        result::ParIter::new(self.archetypes.par_iter_mut(), &self.component_map)
+    }
+
+    #[cfg(feature = "parallel")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub fn run<'a, S>(&'a mut self, schedule: &'a mut Schedule<S>)
     where
         S: Stages<'a>,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     entities::Entities,
     entity,
     entity::Entity,
-    query::{filter::Filter, result, view::Views},
+    query::{filter::Filter, result, view, view::Views},
     registry::Registry,
 };
 #[cfg(feature = "parallel")]
@@ -74,6 +74,8 @@ where
     entity_allocator: entity::Allocator<R>,
 
     component_map: HashMap<TypeId, usize>,
+
+    view_assertion_buffer: view::AssertionBuffer,
 }
 
 impl<R> World<R>
@@ -89,6 +91,8 @@ where
             entity_allocator,
 
             component_map,
+
+            view_assertion_buffer: view::AssertionBuffer::with_capacity(R::LEN),
         }
     }
 
@@ -227,6 +231,9 @@ where
         V: Views<'a>,
         F: Filter,
     {
+        self.view_assertion_buffer.clear();
+        V::assert_claims(&mut self.view_assertion_buffer);
+
         result::Iter::new(self.archetypes.iter_mut(), &self.component_map)
     }
 
@@ -274,6 +281,9 @@ where
         V: ParViews<'a>,
         F: Filter,
     {
+        self.view_assertion_buffer.clear();
+        V::assert_claims(&mut self.view_assertion_buffer);
+        
         result::ParIter::new(self.archetypes.par_iter_mut(), &self.component_map)
     }
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -279,26 +279,6 @@ where
 
     #[cfg(feature = "parallel")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
-    pub(crate) unsafe fn query_unchecked<'a, V, F>(&'a mut self) -> result::Iter<'a, R, F, V>
-    where
-        V: Views<'a>,
-        F: Filter,
-    {
-        result::Iter::new(self.archetypes.iter_mut(), &self.component_map)
-    }
-
-    #[cfg(feature = "parallel")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
-    pub(crate) unsafe fn par_query_unchecked<'a, V, F>(&'a mut self) -> result::ParIter<'a, R, F, V>
-    where
-        V: ParViews<'a>,
-        F: Filter,
-    {
-        result::ParIter::new(self.archetypes.par_iter_mut(), &self.component_map)
-    }
-
-    #[cfg(feature = "parallel")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub fn run<'a, S>(&'a mut self, schedule: &'a mut Schedule<S>)
     where
         S: Stages<'a>,


### PR DESCRIPTION
Fixes #27.

This ensures that all components viewed on a query are sound, meaning they follow Rust's borrowing rules.

The solution here is the naive run-time approach. Ideally, this check could be done at compile-time, since the components are always known at compile time anyway. Having this check at run-time is bad for both developer velocity (not knowing something is incorrect until the program hits it) and adds a run-time cost. However, it is not currently possible to move this check to compile time, and won't be until there is much more work done on `const fn`s in traits and `const` `TypeId`s are stabilized. In fact, as it stands now, I don't think it's technically possible to force this check to compile-time, even with unstable nightly features, due to it not currently being possible to require a supertrait be `~const`. See #27's comments for the notes on what could be possible later.