### PR TITLE
Replace potentially unsound private API with sound `Locations`-based API.

### DIFF
--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -18,7 +18,10 @@ use crate::{
     entities,
     entities::Entities,
     entity,
-    entity::{allocator::Location, Entity},
+    entity::{
+        allocator::{Location, Locations},
+        Entity,
+    },
     query::view::Views,
     registry::Registry,
 };
@@ -134,12 +137,10 @@ where
             .entities
             .extend_components(&self.component_map, &mut self.components, self.length);
 
-        let entity_identifiers = entity_allocator.allocate_batch(
-            (self.length..(self.length + component_len)).map(|index| Location {
-                identifier: self.identifier_buffer.as_ref(),
-                index,
-            }),
-        );
+        let entity_identifiers = entity_allocator.allocate_batch(Locations::new(
+            self.length..(self.length + component_len),
+            self.identifier_buffer.as_ref(),
+        ));
 
         let mut entity_identifiers_v = ManuallyDrop::new(Vec::from_raw_parts(
             self.entity_identifiers.0,

--- a/src/entity/allocator/mod.rs
+++ b/src/entity/allocator/mod.rs
@@ -7,7 +7,7 @@ pub(crate) use impl_serde::DeserializeAllocator;
 
 use crate::{archetype, entity, registry::Registry};
 use alloc::{collections::VecDeque, vec::Vec};
-use core::{fmt, fmt::Debug, iter::ExactSizeIterator};
+use core::{fmt, fmt::Debug, ops::Range};
 
 pub(crate) struct Location<R>
 where
@@ -58,6 +58,86 @@ where
 {
     fn eq(&self, other: &Self) -> bool {
         self.identifier == other.identifier && self.index == other.index
+    }
+}
+
+/// A batch of [`Location`]s, all sharing the same [`archetype::Identifier`].
+///
+/// These locations are meant to be iterated over, yielding the appropriate `Location`s defined.
+///
+/// [`archetype::Identifier`]: crate::archetype::Identifier
+/// [`Location`]: crate::entity::allocator::Location
+pub(crate) struct Locations<R>
+where
+    R: Registry,
+{
+    /// The remaining indices to be iterated.
+    indices: Range<usize>,
+    /// The archetype identifier of all contained [`Location`]s.
+    ///
+    /// [`Location`]: crate::entity::allocator::Location
+    identifier: archetype::IdentifierRef<R>,
+}
+
+impl<R> Locations<R>
+where
+    R: Registry,
+{
+    /// Create a new batch of [`Location`]s.
+    ///
+    /// This method takes a range of indices, representing the indices of entities within an
+    /// [`Archetype`], and a single [`archetype::Identifier`] to specify which `Archetype` the
+    /// entities belong to.
+    ///
+    /// Note that a single `Locations` container cannot be used to represent locations from
+    /// multiple `Archetype`s.
+    ///
+    /// Note that it is an error if `end` is less than `start` within `indices` (although not
+    /// technically `unsafe`).
+    ///
+    /// [`Archetype`]: crate::archetype::Archetype
+    /// [`archetype::Identifier`]: crate::archetype::Identifier
+    /// [`Location`]: crate::entity::allocator::Location
+    pub(crate) fn new(indices: Range<usize>, identifier: archetype::IdentifierRef<R>) -> Self {
+        Self {
+            indices,
+            identifier,
+        }
+    }
+
+    /// The remaining number of [`Location`]s yet to be iterated.
+    ///
+    /// [`Location`]: crate::entity::allocator::Location
+    fn len(&self) -> usize {
+        debug_assert!(self.indices.end >= self.indices.start);
+        self.indices.end - self.indices.start
+    }
+
+    /// Returns `true` if there are no more [`Location`]s to be iterated over.
+    ///
+    /// [`Location`]: crate::entity::allocator::Location
+    fn is_empty(&self) -> bool {
+        self.indices.is_empty()
+    }
+}
+
+impl<R> Iterator for Locations<R>
+where
+    R: Registry,
+{
+    type Item = Location<R>;
+
+    /// Returns the next [`Location`], if there are any left to be returned.
+    ///
+    /// Note that `Location`s are returned in sequential order, according to the `indices` provided
+    /// on construction.
+    ///
+    /// [`Location`]: crate::entity::allocator::Location
+    fn next(&mut self) -> Option<Self::Item> {
+        self.indices.next().map(|index| Location {
+            identifier: self.identifier,
+            index,
+        })
     }
 }
 
@@ -160,15 +240,15 @@ where
     }
 
     #[inline]
-    pub(crate) unsafe fn allocate_batch<L>(&mut self, mut locations: L) -> Vec<entity::Identifier>
-    where
-        L: Iterator<Item = Location<R>> + ExactSizeIterator,
-    {
+    pub(crate) unsafe fn allocate_batch(
+        &mut self,
+        mut locations: Locations<R>,
+    ) -> Vec<entity::Identifier> {
         let mut identifiers = Vec::with_capacity(locations.len());
 
         // First activate slots that are already allocated.
         while let Some(index) = self.free.pop_front() {
-            if locations.len() == 0 {
+            if locations.is_empty() {
                 break;
             }
             let slot = self.slots.get_unchecked_mut(index);


### PR DESCRIPTION
This replaces the generic parameter in `entity::Allocator::allocate_batch()` with a `Locations` `Iterator`, which fixes the potential unsoundness discussed in #17.