### PR TITLE
Remove allowances of ptr_arg clippy lint.

### DIFF
--- a/src/registry/debug.rs
+++ b/src/registry/debug.rs
@@ -11,9 +11,6 @@ use core::{
 };
 
 pub trait RegistryDebug: Registry {
-    // TODO: Remove attribute when https://github.com/rust-lang/rust-clippy/issues/8366 is
-    // resolved.
-    #[allow(clippy::ptr_arg)]
     unsafe fn extract_component_pointers<R>(
         index: usize,
         components: &[(*mut u8, usize)],

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -23,9 +23,6 @@ pub trait Storage {
     ) where
         R: Registry;
 
-    // TODO: Remove attribute when https://github.com/rust-lang/rust-clippy/issues/8366 is
-    // resolved.
-    #[allow(clippy::ptr_arg)]
     unsafe fn new_components_with_capacity<R>(
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,

--- a/src/registry/serde.rs
+++ b/src/registry/serde.rs
@@ -123,9 +123,6 @@ where
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
 pub trait RegistryDeserialize<'de>: Registry + 'de {
-    // TODO: Remove attribute when https://github.com/rust-lang/rust-clippy/issues/8366 is
-    // resolved.
-    #[allow(clippy::ptr_arg)]
     unsafe fn deserialize_components_by_column<R, V>(
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,


### PR DESCRIPTION
Fixes #48. The false-positive seems to be resolved on nightly now.