### PR TITLE
Macro compilation tests.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -136,6 +136,7 @@ jobs:
         args: miri test --feature-powerset --optional-deps
       env:
         MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks
+        RUSTFLAGS: --cfg skip_trybuild
 
   valgrind:
     runs-on: ubuntu-latest
@@ -164,6 +165,8 @@ jobs:
       with:
         command: hack
         args: valgrind test --feature-powerset --optional-deps
+        env:
+          RUSTFLAGS: --cfg skip_trybuild
 
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,7 +143,7 @@ jobs:
     - uses: actions/checkout@v2
     - run: wget https://sourceware.org/pub/valgrind/valgrind-3.18.1.tar.bz2
     - run: tar xvf valgrind-3.18.1.tar.bz2
-    - run: /configure
+    - run: ./configure
       working-directory: ./valgrind-3.18.1
     - run: make
       working-directory: ./valgrind-3.18.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -144,6 +144,7 @@ jobs:
     - run: wget https://sourceware.org/pub/valgrind/valgrind-3.18.1.tar.bz2
     - run: tar xvf valgrind-3.18.1.tar.bz2
     - run: cd valgrind-3.18.1
+    - run: ./configure
     - run: make
     - run: sudo make install
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -149,6 +149,7 @@ jobs:
       working-directory: ./valgrind-3.18.1
     - run: sudo make install
       working-directory: ./valgrind-3.18.1
+    - run: apt-get install libc6-dbg:i386
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -141,7 +141,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: sudo apt-get install valgrind
+    - run: wget https://sourceware.org/pub/valgrind/valgrind-3.18.1.tar.bz2
+    - run: tar xvf valgrind-3.18.1.tar.bz2
+    - run: cd valgrind-3.18.1
+    - run: sudo make install
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -144,6 +144,7 @@ jobs:
     - run: wget https://sourceware.org/pub/valgrind/valgrind-3.18.1.tar.bz2
     - run: tar xvf valgrind-3.18.1.tar.bz2
     - run: cd valgrind-3.18.1
+    - run: make
     - run: sudo make install
     - uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,9 +143,12 @@ jobs:
     - uses: actions/checkout@v2
     - run: wget https://sourceware.org/pub/valgrind/valgrind-3.18.1.tar.bz2
     - run: tar xvf valgrind-3.18.1.tar.bz2
-    - run: ./valgrind-3.18.1/configure
-    - run: make -C valgrind-3.18.1
-    - run: sudo make -C valgrind-3.18.1 install
+    - run: /configure
+      working-directory: ./valgrind-3.18.1
+    - run: make
+      working-directory: ./valgrind-3.18.1
+    - run: sudo make install
+      working-directory: ./valgrind-3.18.1
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,10 +143,9 @@ jobs:
     - uses: actions/checkout@v2
     - run: wget https://sourceware.org/pub/valgrind/valgrind-3.18.1.tar.bz2
     - run: tar xvf valgrind-3.18.1.tar.bz2
-    - run: cd valgrind-3.18.1
-    - run: ./configure
-    - run: make
-    - run: sudo make install
+    - run: ./valgrind-3.18.1/configure
+    - run: make -C valgrind-3.18.1
+    - run: sudo make -C valgrind-3.18.1 install
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -149,7 +149,7 @@ jobs:
       working-directory: ./valgrind-3.18.1
     - run: sudo make install
       working-directory: ./valgrind-3.18.1
-    - run: apt-get install libc6-dbg:i386
+    - run: sudo apt-get install libc6-dbg:i386
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -165,8 +165,8 @@ jobs:
       with:
         command: hack
         args: valgrind test --feature-powerset --optional-deps
-        env:
-          RUSTFLAGS: --cfg skip_trybuild
+      env:
+        RUSTFLAGS: --cfg skip_trybuild
 
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -149,7 +149,7 @@ jobs:
       working-directory: ./valgrind-3.18.1
     - run: sudo make install
       working-directory: ./valgrind-3.18.1
-    - run: sudo apt-get install libc6-dbg:i386
+    - run: sudo apt-get install libc6-dbg
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ rayon = {version = "1.5.1", optional = true}
 serde = {version = "1.0.133", default-features = false, features = ["alloc"], optional = true}
 
 [dev-dependencies]
+rustversion = "1.0.6"
 serde_test = "1.0.133"
+trybuild = "1.0.56"
 
 [features]
 # TODO: Rename this to "rayon" when namespaced dependencies are stabilized in 1.60.0.

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -227,10 +227,10 @@ macro_rules! entities {
             )
         }
     };
-    ($(($($components:expr),*)),* $(,)?) => {
+    ($(($($components:expr),*)),+ $(,)?) => {
         unsafe {
             $crate::entities::Batch::new_unchecked(
-                $crate::entities!(@transpose [] $(($($components),*)),*)
+                $crate::entities!(@transpose [] $(($($components),*)),+)
             )
         }
     };
@@ -244,18 +244,21 @@ macro_rules! entities {
             $crate::entities::Batch::new_unchecked($crate::entities::Null)
         }
     };
+
     (@cloned ($component:expr $(,$components:expr)* $(,)?); $n:expr) => {
         ($crate::reexports::vec![$component; $n], $crate::entities!(@cloned ($($components),*); $n))
     };
     (@cloned (); $n:expr) => {
         $crate::entities::Null
     };
+
     (@transpose [$([$($column:expr),*])*] $(($component:expr $(,$components:expr)*  $(,)?)),*) => {
         $crate::entities!(@transpose [$([$($column),*])* [$($component),*]] $(($($components),*)),*)
     };
     (@transpose [$([$($column:expr),*])*] $(()),*) => {
         $crate::entities!(@as_vec ($(($($column),*)),*))
     };
+
     (@as_vec (($($column:expr),*) $(,($($columns:expr),*))* $(,)?)) => {
         ($crate::reexports::vec![$($column),*], $crate::entities!(@as_vec ($(($($columns),*)),*)))
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ mod archetype;
 mod archetypes;
 mod doc;
 mod hlist;
+mod r#macro;
 
 #[doc(inline)]
 pub use world::World;

--- a/src/macro.rs
+++ b/src/macro.rs
@@ -1,0 +1,16 @@
+//! Helper macros specifically for use by other macros within this crate.
+//!
+//! Although the macros here are exported publicly, it is only for use by other macros within this
+//! crate. These should not be depended upon by any external code, and are not considered a part of
+//! the public API.
+
+/// Indicate that the given tokens were unexpected.
+///
+/// Calling this macro with any tokens will return an error pointing to those tokens within the
+/// original macro. This allows more precise error messages from macros when input is not formatted
+/// correctly.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! unexpected {
+    () => {};
+}

--- a/src/system/schedule/stage/mod.rs
+++ b/src/system/schedule/stage/mod.rs
@@ -115,23 +115,159 @@ doc::non_root_macro! {
     /// [`schedule::Builder`]: crate::system::schedule::Builder
     /// [`System`]: crate::system::System
     macro_rules! stages {
-        ($($idents:tt $(: $systems:tt)?),* $(,)?) => (
-            stages!(internal @ $crate::system::schedule::stage::Null; $($idents $(: $systems)?,)*)
-        );
-        (internal @ $processed:ty; system: $system:ty, $($idents:tt $(: $systems:tt)?),* $(,)?) => (
-            stages!(internal @ ($crate::system::schedule::stage::Stage<$system, $crate::system::Null>, $processed); $($idents $(: $systems)?,)*)
-        );
-        (internal @ $processed:ty; par_system: $par_system:ty, $($idents:tt $(: $systems:tt)?),* $(,)?) => (
-            stages!(internal @ ($crate::system::schedule::stage::Stage<$crate::system::Null, $par_system>, $processed); $($idents $(: $systems)?,)*)
-        );
-        (internal @ $processed:ty; flush, $($idents:tt $(: $systems:tt)?),* $(,)?) => (
-            stages!(internal @ ($crate::system::schedule::stage::Stage<$crate::system::Null, $crate::system::Null>, $processed); $($idents $(: $systems)?,)*)
-        );
-        (internal @ $processed:ty;) => (
-            $processed
-        );
-        (internal @ $processed:ty; $ident:tt $(: $system:tt)?, $($idents:tt $(: $systems:tt)?),* $(,)?) => (
-            $crate::unexpected!($ident $(: $system:tt)?)
+        // Entry point for the macro.
+        //
+        // This just calls into the internal macro with all of the correct parameters.
+        ($($tt:tt)*) => (
+            $crate::stages_internal!(@task $crate::system::schedule::stage::Null; ($($tt)*) ($($tt)*))
         );
     }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! stages_internal {
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // Generic task macro.
+    //
+    // These patterns are for matching and processing generic tasks listed in the token tree. When
+    // each of the valid task types (system, par_system, and flush) are encountered, the tokens are
+    // passed to the appropriate patterns (@system, @par_system, and @flush) to be consumed.
+    //
+    // Note that we require two copies of the input token tree here. The first is matched on, and
+    // the second is used to trigger errors.
+    //
+    // Invoked as:
+    // $crate::stages_internal!(@task $crate::system::schedule::stage::Null; ($($tt)*) ($($tt)*))
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Match a system task.
+    (@task $processed:ty; (system $($rest:tt)*) $copy:tt) => (
+        $crate::stages_internal!(@system $processed; ($($rest)*) ($($rest)*))
+    );
+
+    // Match a par_system task.
+    (@task $processed:ty; (par_system $($rest:tt)*) $copy:tt) => (
+        $crate::stages_internal!(@par_system $processed; ($($rest)*) ($($rest)*))
+    );
+
+    // Match a flush task.
+    (@task $processed:ty; (flush $($rest:tt)*) $copy:tt) => (
+        $crate::stages_internal!(@flush $processed; ($($rest)*) ($($rest)*))
+    );
+
+    // End case. We return the processed result.
+    (@task $processed:ty; () ()) => (
+        $processed
+    );
+
+    // Match any other unexpected input. This will output an error.
+    (@task $processed:ty; ($($rest:tt)*) $copy:tt) => (
+        $crate::unexpected!($($rest)*)
+    );
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // System task macro.
+    //
+    // These patterns match the remainder of a system task entry. This will match a colon followed
+    // by a system type. Trailing commas are also matched here.
+    //
+    // Note that we require two copies of the input token tree here. The first is matched on, and
+    // the second is used to trigger errors.
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Match a system type without a trailing comma. This will only match at the end of the token
+    // tree.
+    (@system $processed:ty; (: $system:ty) $copy:tt) => {
+        $crate::stages_internal(@task ($crate::system::schedule::stage::Stage<$system, $crate::system::Null>, $processed); () ())
+    };
+
+    // Match a system type with a trailing comma.
+    (@system $processed:ty; (: $system:ty, $($rest:tt)*) $copy:tt) => (
+        $crate::stages_internal!(@task ($crate::system::schedule::stage::Stage<$system, $crate::system::Null>, $processed); ($($rest)*) ($($rest)*))
+    );
+
+    // Match a system type with no trailing comma not at the end of the token tree. This will
+    // output an error.
+    (@system $processed:ty; (: $system:tt $($rest:tt)*) $copy:tt) => {
+        $crate::unexpected!($($rest)*)
+    };
+
+    // Match a comma with no system type provided. This will output an error.
+    (@system $processed:ty; (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => (
+        $crate::unexpected!($comma)
+    );
+
+    // Match any other unexpected input. This will output an error.
+    (@system $processed:ty; ($($rest:tt)*) $copy:tt) => (
+        $crate::unexpected!($($rest)*)
+    );
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // Parallel system task macro.
+    //
+    // These patterns match the remainder of a par_system task entry. This will match a colon
+    // followed by a parallel system type. Trailing commas are also matched here.
+    //
+    // Note that we require two copies of the input token tree here. The first is matched on, and
+    // the second is used to trigger errors.
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Match a parallel system type without a trailing comma. This will only match at the end of
+    // the token tree.
+    (@par_system $processed:ty; (: $par_system:ty) $copy:tt) => (
+        $crate::stages_internal!(@task ($crate::system::schedule::stage::Stage<$crate::system::Null, $par_system>, $processed); () ())
+    );
+
+    // Match a parallel system type with a trailing comma.
+    (@par_system $processed:ty; (: $par_system:ty, $($rest:tt)*) $copy:tt) => (
+        $crate::stages_internal!(@task ($crate::system::schedule::stage::Stage<$crate::system::Null, $par_system>, $processed); ($($rest)*) ($($rest)*))
+    );
+
+    // Match a parallel system type with no trailing comma not at the end of the token tree. This
+    // will output an error.
+    (@par_system $processed:ty; (: $par_system:tt $($rest:tt)*) $copy:tt) => {
+        $crate::unexpected!($($rest)*)
+    };
+
+    // Match a comma with no parallel system type provided. This will output an error.
+    (@par_system $processed:ty; (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => (
+        $crate::unexpected!($comma)
+    );
+    
+    // Match any other unexpected input. This will output an error.
+    (@par_system $processed:ty; ($($rest:tt)*) $copy:tt) => (
+        $crate::unexpected!($($rest)*)
+    );
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // Flush task macro.
+    //
+    // These patterns match the remainder of a flush task entry, which is only either a comma or
+    // nothing.
+    //
+    // Note that we require two copies of the input token tree here. The first is matched on, and
+    // the second is used to trigger errors.
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    
+    // Match a comma.
+    (@flush $processed:ty; (, $($rest:tt)*) $copy:tt) => (
+        $crate::stages_internal!(@task ($crate::system::schedule::stage::Stage<$crate::system::Null, $crate::system::Null>, $processed); ($($rest)*) ($($rest)*))
+    );
+
+    // Match a colon. This is invalid and will output an error.
+    (@flush $processed:ty; (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => (
+        $crate::unexpected!($colon)
+    );
+
+    // Match nothing. This will only occur at the end of the input token tree, which is the only
+    // time when a trailing comma is not required.
+    (@flush $processed:ty; () ()) => (
+        $crate::stages_internal!(@task ($crate::system::schedule::stage::Stage<$crate::system::Null, $crate::system::Null>, $processed); () ())
+    );
+    
+    // Match any other unexpected input. This will output an error.
+    (@flush $processed:ty; ($($rest:tt)*) $copy:tt) => (
+        $crate::unexpected!($($rest)*)
+    );
 }

--- a/src/system/schedule/stage/mod.rs
+++ b/src/system/schedule/stage/mod.rs
@@ -127,8 +127,11 @@ doc::non_root_macro! {
         (internal @ $processed:ty; flush, $($idents:tt $(: $systems:tt)?),* $(,)?) => (
             stages!(internal @ ($crate::system::schedule::stage::Stage<$crate::system::Null, $crate::system::Null>, $processed); $($idents $(: $systems)?,)*)
         );
-        (internal @ $processed:ty; $($idents:tt $(: $systems:tt)?),* $(,)?) => (
+        (internal @ $processed:ty;) => (
             $processed
+        );
+        (internal @ $processed:ty; $ident:tt $(: $system:tt)?, $($idents:tt $(: $systems:tt)?),* $(,)?) => (
+            $crate::unexpected!($ident $(: $system:tt)?)
         );
     }
 }

--- a/src/system/schedule/stage/mod.rs
+++ b/src/system/schedule/stage/mod.rs
@@ -234,7 +234,7 @@ macro_rules! stages_internal {
     (@par_system $processed:ty; (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => (
         $crate::unexpected!($comma)
     );
-    
+
     // Match any other unexpected input. This will output an error.
     (@par_system $processed:ty; ($($rest:tt)*) $copy:tt) => (
         $crate::unexpected!($($rest)*)
@@ -249,7 +249,7 @@ macro_rules! stages_internal {
     // Note that we require two copies of the input token tree here. The first is matched on, and
     // the second is used to trigger errors.
     ///////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     // Match a comma.
     (@flush $processed:ty; (, $($rest:tt)*) $copy:tt) => (
         $crate::stages_internal!(@task ($crate::system::schedule::stage::Stage<$crate::system::Null, $crate::system::Null>, $processed); ($($rest)*) ($($rest)*))
@@ -265,7 +265,7 @@ macro_rules! stages_internal {
     (@flush $processed:ty; () ()) => (
         $crate::stages_internal!(@task ($crate::system::schedule::stage::Stage<$crate::system::Null, $crate::system::Null>, $processed); () ())
     );
-    
+
     // Match any other unexpected input. This will output an error.
     (@flush $processed:ty; ($($rest:tt)*) $copy:tt) => (
         $crate::unexpected!($($rest)*)

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -15,6 +15,7 @@ macro_rules! trybuild_test {
 trybuild_test!(entities);
 trybuild_test!(entity);
 trybuild_test!(registry);
+trybuild_test!(result);
 #[cfg(feature = "parallel")]
 trybuild_test!(stages);
 trybuild_test!(views);

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -1,0 +1,9 @@
+macro_rules! trybuild_test {
+    ($test_name:ident) => {
+        #[test]
+        #[rustversion::attr(not(nightly), ignore)]
+        fn $test_name() {
+            trybuild::TestCases::new().compile_fail(concat!("tests/trybuild/", stringify!($test_name), "/*.rs"));
+        }
+    }
+}

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -14,5 +14,6 @@ macro_rules! trybuild_test {
 
 trybuild_test!(entities);
 trybuild_test!(entity);
+trybuild_test!(registry);
 #[cfg(feature = "parallel")]
 trybuild_test!(stages);

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -9,3 +9,5 @@ macro_rules! trybuild_test {
 }
 
 trybuild_test!(entities);
+#[cfg(feature = "parallel")]
+trybuild_test!(stages);

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -13,5 +13,6 @@ macro_rules! trybuild_test {
 }
 
 trybuild_test!(entities);
+trybuild_test!(entity);
 #[cfg(feature = "parallel")]
 trybuild_test!(stages);

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -3,9 +3,13 @@ macro_rules! trybuild_test {
         #[test]
         #[rustversion::attr(not(nightly), ignore)]
         fn $test_name() {
-            trybuild::TestCases::new().compile_fail(concat!("tests/trybuild/", stringify!($test_name), "/*.rs"));
+            trybuild::TestCases::new().compile_fail(concat!(
+                "tests/trybuild/",
+                stringify!($test_name),
+                "/*.rs"
+            ));
         }
-    }
+    };
 }
 
 trybuild_test!(entities);

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -1,3 +1,5 @@
+#![cfg(not(skip_trybuild))]
+
 macro_rules! trybuild_test {
     ($test_name:ident) => {
         #[test]

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -17,3 +17,4 @@ trybuild_test!(entity);
 trybuild_test!(registry);
 #[cfg(feature = "parallel")]
 trybuild_test!(stages);
+trybuild_test!(views);

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -7,3 +7,5 @@ macro_rules! trybuild_test {
         }
     }
 }
+
+trybuild_test!(entities);

--- a/tests/trybuild/entities/comma_alone.rs
+++ b/tests/trybuild/entities/comma_alone.rs
@@ -1,0 +1,5 @@
+use brood::entities;
+
+fn main () {
+    let entities = entities!(,);
+}

--- a/tests/trybuild/entities/comma_alone.stderr
+++ b/tests/trybuild/entities/comma_alone.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/entities/comma_alone.rs:4:30
+  |
+4 |     let entities = entities!(,);
+  |                              ^ no rules expected this token in macro call

--- a/tests/trybuild/entities/component_order.rs
+++ b/tests/trybuild/entities/component_order.rs
@@ -1,0 +1,9 @@
+use brood::entities;
+
+// Define components.
+struct A;
+struct B;
+
+fn main () {
+    let entities = entities!((A, B), (B, A));
+}

--- a/tests/trybuild/entities/component_order.stderr
+++ b/tests/trybuild/entities/component_order.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+ --> tests/trybuild/entities/component_order.rs:8:39
+  |
+8 |     let entities = entities!((A, B), (B, A));
+  |                                       ^ expected struct `A`, found struct `B`
+
+error[E0308]: mismatched types
+ --> tests/trybuild/entities/component_order.rs:8:42
+  |
+8 |     let entities = entities!((A, B), (B, A));
+  |                                          ^ expected struct `B`, found struct `A`

--- a/tests/trybuild/entities/double_comma.rs
+++ b/tests/trybuild/entities/double_comma.rs
@@ -1,0 +1,9 @@
+use brood::entities;
+
+// Define components.
+struct A;
+struct B;
+
+fn main () {
+    let entities = entities!((A, B),, (A, B));
+}

--- a/tests/trybuild/entities/double_comma.stderr
+++ b/tests/trybuild/entities/double_comma.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/entities/double_comma.rs:8:37
+  |
+8 |     let entities = entities!((A, B),, (A, B));
+  |                                     ^ no rules expected this token in macro call

--- a/tests/trybuild/entities/length_not_integer.rs
+++ b/tests/trybuild/entities/length_not_integer.rs
@@ -1,0 +1,11 @@
+use brood::entities;
+
+// Define components.
+#[derive(Clone)]
+struct A;
+#[derive(Clone)]
+struct B;
+
+fn main () {
+    let entities = entities!((A, B); 1.5);
+}

--- a/tests/trybuild/entities/length_not_integer.stderr
+++ b/tests/trybuild/entities/length_not_integer.stderr
@@ -1,0 +1,5 @@
+error[E0308]: mismatched types
+  --> tests/trybuild/entities/length_not_integer.rs:10:38
+   |
+10 |     let entities = entities!((A, B); 1.5);
+   |                                      ^^^ expected `usize`, found floating-point number

--- a/tests/trybuild/entities/same_components.rs
+++ b/tests/trybuild/entities/same_components.rs
@@ -1,0 +1,10 @@
+use brood::entities;
+
+// Define components.
+struct A;
+struct B;
+struct C;
+
+fn main () {
+    let entities = entities!((A, B), (A, C));
+}

--- a/tests/trybuild/entities/same_components.stderr
+++ b/tests/trybuild/entities/same_components.stderr
@@ -1,0 +1,5 @@
+error[E0308]: mismatched types
+ --> tests/trybuild/entities/same_components.rs:9:42
+  |
+9 |     let entities = entities!((A, B), (A, C));
+  |                                          ^ expected struct `B`, found struct `C`

--- a/tests/trybuild/entities/semicolon_separated.rs
+++ b/tests/trybuild/entities/semicolon_separated.rs
@@ -1,0 +1,11 @@
+use brood::entities;
+
+// Define components.
+#[derive(Clone)]
+struct A;
+#[derive(Clone)]
+struct B;
+
+fn main () {
+    let entities = entities!((A, B); (A, B); (A, B));
+}

--- a/tests/trybuild/entities/semicolon_separated.stderr
+++ b/tests/trybuild/entities/semicolon_separated.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `;`
+  --> tests/trybuild/entities/semicolon_separated.rs:10:44
+   |
+10 |     let entities = entities!((A, B); (A, B); (A, B));
+   |                                            ^ no rules expected this token in macro call

--- a/tests/trybuild/entities/unexpected_token.rs
+++ b/tests/trybuild/entities/unexpected_token.rs
@@ -1,0 +1,9 @@
+use brood::entities;
+
+// Define components.
+struct A;
+struct B;
+
+fn main () {
+    let entities = entities!((A, B), (A, B), + (A, B));
+}

--- a/tests/trybuild/entities/unexpected_token.stderr
+++ b/tests/trybuild/entities/unexpected_token.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `+`
+ --> tests/trybuild/entities/unexpected_token.rs:8:46
+  |
+8 |     let entities = entities!((A, B), (A, B), + (A, B));
+  |                                              ^ no rules expected this token in macro call

--- a/tests/trybuild/entity/comma_alone.rs
+++ b/tests/trybuild/entity/comma_alone.rs
@@ -1,0 +1,5 @@
+use brood::entity;
+
+fn main() {
+    let entity = entity!(,);
+}

--- a/tests/trybuild/entity/comma_alone.stderr
+++ b/tests/trybuild/entity/comma_alone.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/entity/comma_alone.rs:4:26
+  |
+4 |     let entity = entity!(,);
+  |                          ^ no rules expected this token in macro call

--- a/tests/trybuild/entity/unexpected_token.rs
+++ b/tests/trybuild/entity/unexpected_token.rs
@@ -1,0 +1,9 @@
+use brood::entity;
+
+// Define components.
+struct A;
+struct B;
+
+fn main() {
+    let entity = entity!(A, + B,);
+}

--- a/tests/trybuild/entity/unexpected_token.stderr
+++ b/tests/trybuild/entity/unexpected_token.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `+`
+ --> tests/trybuild/entity/unexpected_token.rs:8:29
+  |
+8 |     let entity = entity!(A, + B,);
+  |                             ^ no rules expected this token in macro call

--- a/tests/trybuild/registry/comma_alone.rs
+++ b/tests/trybuild/registry/comma_alone.rs
@@ -1,5 +1,5 @@
 use brood::registry;
 
-fn main() {
-    let registry = registry!(,);
-}
+type Registry = registry!(,);
+
+fn main() {}

--- a/tests/trybuild/registry/comma_alone.rs
+++ b/tests/trybuild/registry/comma_alone.rs
@@ -1,0 +1,5 @@
+use brood::registry;
+
+fn main() {
+    let registry = registry!(,);
+}

--- a/tests/trybuild/registry/comma_alone.stderr
+++ b/tests/trybuild/registry/comma_alone.stderr
@@ -1,5 +1,5 @@
 error: no rules expected the token `,`
- --> tests/trybuild/registry/comma_alone.rs:4:30
+ --> tests/trybuild/registry/comma_alone.rs:3:27
   |
-4 |     let registry = registry!(,);
-  |                              ^ no rules expected this token in macro call
+3 | type Registry = registry!(,);
+  |                           ^ no rules expected this token in macro call

--- a/tests/trybuild/registry/comma_alone.stderr
+++ b/tests/trybuild/registry/comma_alone.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/registry/comma_alone.rs:4:30
+  |
+4 |     let registry = registry!(,);
+  |                              ^ no rules expected this token in macro call

--- a/tests/trybuild/registry/unexpected_token.rs
+++ b/tests/trybuild/registry/unexpected_token.rs
@@ -4,6 +4,6 @@ use brood::registry;
 struct A;
 struct B;
 
-fn main() {
-    let registry = registry!(A, + B,);
-}
+type Registry = registry!(A, + B,);
+
+fn main() {}

--- a/tests/trybuild/registry/unexpected_token.rs
+++ b/tests/trybuild/registry/unexpected_token.rs
@@ -1,0 +1,9 @@
+use brood::registry;
+
+// Define components.
+struct A;
+struct B;
+
+fn main() {
+    let registry = registry!(A, + B,);
+}

--- a/tests/trybuild/registry/unexpected_token.stderr
+++ b/tests/trybuild/registry/unexpected_token.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `+`
+ --> tests/trybuild/registry/unexpected_token.rs:8:33
+  |
+8 |     let registry = registry!(A, + B,);
+  |                                 ^ no rules expected this token in macro call

--- a/tests/trybuild/registry/unexpected_token.stderr
+++ b/tests/trybuild/registry/unexpected_token.stderr
@@ -1,5 +1,5 @@
 error: no rules expected the token `+`
- --> tests/trybuild/registry/unexpected_token.rs:8:33
+ --> tests/trybuild/registry/unexpected_token.rs:7:30
   |
-8 |     let registry = registry!(A, + B,);
-  |                                 ^ no rules expected this token in macro call
+7 | type Registry = registry!(A, + B,);
+  |                              ^ no rules expected this token in macro call

--- a/tests/trybuild/result/comma_alone.rs
+++ b/tests/trybuild/result/comma_alone.rs
@@ -1,0 +1,5 @@
+use brood::query::result;
+
+fn main() {
+    let result!(,) = result::Null;
+}

--- a/tests/trybuild/result/comma_alone.stderr
+++ b/tests/trybuild/result/comma_alone.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/result/comma_alone.rs:4:17
+  |
+4 |     let result!(,) = result::Null;
+  |                 ^ no rules expected this token in macro call

--- a/tests/trybuild/result/unexpected_token.rs
+++ b/tests/trybuild/result/unexpected_token.rs
@@ -1,0 +1,9 @@
+use brood::query::result;
+
+// Define components.
+struct A;
+struct B;
+
+fn main() {
+    let result!(a, + b) = (A, (A, result::Null));
+}

--- a/tests/trybuild/result/unexpected_token.stderr
+++ b/tests/trybuild/result/unexpected_token.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `+`
+ --> tests/trybuild/result/unexpected_token.rs:8:20
+  |
+8 |     let result!(a, + b) = (A, (A, result::Null));
+  |                    ^ no rules expected this token in macro call

--- a/tests/trybuild/stages/colon_alone.rs
+++ b/tests/trybuild/stages/colon_alone.rs
@@ -1,0 +1,7 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    :
+};
+
+fn main() {}

--- a/tests/trybuild/stages/colon_alone.stderr
+++ b/tests/trybuild/stages/colon_alone.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `:`
+ --> tests/trybuild/stages/colon_alone.rs:4:5
+  |
+4 |     :
+  |     ^ no rules expected this token in macro call

--- a/tests/trybuild/stages/comma_alone.rs
+++ b/tests/trybuild/stages/comma_alone.rs
@@ -1,0 +1,7 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    ,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/comma_alone.stderr
+++ b/tests/trybuild/stages/comma_alone.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/stages/comma_alone.rs:4:5
+  |
+4 |     ,
+  |     ^ no rules expected this token in macro call

--- a/tests/trybuild/stages/double_comma.rs
+++ b/tests/trybuild/stages/double_comma.rs
@@ -1,0 +1,7 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    flush,,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/double_comma.stderr
+++ b/tests/trybuild/stages/double_comma.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/stages/double_comma.rs:4:11
+  |
+4 |     flush,,
+  |           ^ no rules expected this token in macro call

--- a/tests/trybuild/stages/flush_missing_comma.rs
+++ b/tests/trybuild/stages/flush_missing_comma.rs
@@ -1,0 +1,8 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    flush
+    flush
+};
+
+fn main() {}

--- a/tests/trybuild/stages/flush_missing_comma.stderr
+++ b/tests/trybuild/stages/flush_missing_comma.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `flush`
+ --> tests/trybuild/stages/flush_missing_comma.rs:5:5
+  |
+5 |     flush
+  |     ^^^^^ no rules expected this token in macro call

--- a/tests/trybuild/stages/flush_with_colon.rs
+++ b/tests/trybuild/stages/flush_with_colon.rs
@@ -1,0 +1,7 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    flush: value,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/flush_with_colon.stderr
+++ b/tests/trybuild/stages/flush_with_colon.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `:`
+ --> tests/trybuild/stages/flush_with_colon.rs:4:10
+  |
+4 |     flush: value,
+  |          ^ no rules expected this token in macro call

--- a/tests/trybuild/stages/par_system_missing_comma.rs
+++ b/tests/trybuild/stages/par_system_missing_comma.rs
@@ -1,0 +1,17 @@
+use brood::{query::{filter, result, views}, registry::Registry, system::{schedule::stages, ParSystem}};
+
+struct MySystem;
+
+impl<'a> ParSystem<'a> for MySystem {
+    type Views = views!();
+    type Filter = filter::None;
+
+    fn run<R>(&mut self, query_results: result::ParIter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {}
+}
+
+type Stages = stages!{
+    par_system: MySystem
+    flush
+};
+
+fn main() {}

--- a/tests/trybuild/stages/par_system_missing_comma.stderr
+++ b/tests/trybuild/stages/par_system_missing_comma.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `flush`
+  --> tests/trybuild/stages/par_system_missing_comma.rs:14:5
+   |
+14 |     flush
+   |     ^^^^^ no rules expected this token in macro call

--- a/tests/trybuild/stages/par_system_no_colon.rs
+++ b/tests/trybuild/stages/par_system_no_colon.rs
@@ -1,0 +1,7 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    par_system,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/par_system_no_colon.stderr
+++ b/tests/trybuild/stages/par_system_no_colon.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/stages/par_system_no_colon.rs:4:15
+  |
+4 |     par_system,
+  |               ^ no rules expected this token in macro call

--- a/tests/trybuild/stages/system_missing_comma.rs
+++ b/tests/trybuild/stages/system_missing_comma.rs
@@ -1,0 +1,17 @@
+use brood::{query::{filter, result, views}, registry::Registry, system::{schedule::stages, System}};
+
+struct MySystem;
+
+impl<'a> System<'a> for MySystem {
+    type Views = views!();
+    type Filter = filter::None;
+
+    fn run<R>(&mut self, query_results: result::Iter<'a, R, Self::Filter, Self::Views>) where R: Registry + 'a {}
+}
+
+type Stages = stages!{
+    system: MySystem
+    flush
+};
+
+fn main() {}

--- a/tests/trybuild/stages/system_missing_comma.stderr
+++ b/tests/trybuild/stages/system_missing_comma.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `flush`
+  --> tests/trybuild/stages/system_missing_comma.rs:14:5
+   |
+14 |     flush
+   |     ^^^^^ no rules expected this token in macro call

--- a/tests/trybuild/stages/system_no_colon.rs
+++ b/tests/trybuild/stages/system_no_colon.rs
@@ -1,0 +1,7 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    system,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/system_no_colon.stderr
+++ b/tests/trybuild/stages/system_no_colon.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/stages/system_no_colon.rs:4:11
+  |
+4 |     system,
+  |           ^ no rules expected this token in macro call

--- a/tests/trybuild/stages/unexpected_command.rs
+++ b/tests/trybuild/stages/unexpected_command.rs
@@ -1,0 +1,7 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    unexpected,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/unexpected_command.stderr
+++ b/tests/trybuild/stages/unexpected_command.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `unexpected`
+ --> tests/trybuild/stages/unexpected_command.rs:4:5
+  |
+4 |     unexpected,
+  |     ^^^^^^^^^^ no rules expected this token in macro call

--- a/tests/trybuild/stages/unexpected_command_first.rs
+++ b/tests/trybuild/stages/unexpected_command_first.rs
@@ -1,0 +1,8 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    unexpected,
+    flush,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/unexpected_command_first.stderr
+++ b/tests/trybuild/stages/unexpected_command_first.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `unexpected`
+ --> tests/trybuild/stages/unexpected_command_first.rs:4:5
+  |
+4 |     unexpected,
+  |     ^^^^^^^^^^ no rules expected this token in macro call

--- a/tests/trybuild/stages/unexpected_command_last.rs
+++ b/tests/trybuild/stages/unexpected_command_last.rs
@@ -1,0 +1,8 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    flush,
+    unexpected,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/unexpected_command_last.stderr
+++ b/tests/trybuild/stages/unexpected_command_last.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `unexpected`
+ --> tests/trybuild/stages/unexpected_command_last.rs:5:5
+  |
+5 |     unexpected,
+  |     ^^^^^^^^^^ no rules expected this token in macro call

--- a/tests/trybuild/stages/unexpected_command_middle.rs
+++ b/tests/trybuild/stages/unexpected_command_middle.rs
@@ -1,0 +1,9 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    flush,
+    unexpected,
+    flush,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/unexpected_command_middle.stderr
+++ b/tests/trybuild/stages/unexpected_command_middle.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `unexpected`
+ --> tests/trybuild/stages/unexpected_command_middle.rs:5:5
+  |
+5 |     unexpected,
+  |     ^^^^^^^^^^ no rules expected this token in macro call

--- a/tests/trybuild/stages/unexpected_command_with_colon.rs
+++ b/tests/trybuild/stages/unexpected_command_with_colon.rs
@@ -1,0 +1,7 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    unexpected: value,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/unexpected_command_with_colon.stderr
+++ b/tests/trybuild/stages/unexpected_command_with_colon.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `unexpected`
+ --> tests/trybuild/stages/unexpected_command_with_colon.rs:4:5
+  |
+4 |     unexpected: value,
+  |     ^^^^^^^^^^ no rules expected this token in macro call

--- a/tests/trybuild/stages/unexpected_token.rs
+++ b/tests/trybuild/stages/unexpected_token.rs
@@ -1,0 +1,9 @@
+use brood::system::schedule::stages;
+
+type Stages = stages!{
+    flush,
+    +,
+    flush,
+};
+
+fn main() {}

--- a/tests/trybuild/stages/unexpected_token.stderr
+++ b/tests/trybuild/stages/unexpected_token.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `+`
+ --> tests/trybuild/stages/unexpected_token.rs:5:5
+  |
+5 |     +,
+  |     ^ no rules expected this token in macro call

--- a/tests/trybuild/views/comma_alone.rs
+++ b/tests/trybuild/views/comma_alone.rs
@@ -1,0 +1,5 @@
+use brood::query::views;
+
+type Views = views!(,);
+
+fn main() {}

--- a/tests/trybuild/views/comma_alone.stderr
+++ b/tests/trybuild/views/comma_alone.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/views/comma_alone.rs:3:21
+  |
+3 | type Views = views!(,);
+  |                     ^ no rules expected this token in macro call

--- a/tests/trybuild/views/unexpected_token.rs
+++ b/tests/trybuild/views/unexpected_token.rs
@@ -1,0 +1,9 @@
+use brood::query::views;
+
+// Define components.
+struct A;
+struct B;
+
+type Views = views!(&A, + &B,);
+
+fn main() {}

--- a/tests/trybuild/views/unexpected_token.stderr
+++ b/tests/trybuild/views/unexpected_token.stderr
@@ -1,0 +1,5 @@
+error: no rules expected the token `+`
+ --> tests/trybuild/views/unexpected_token.rs:7:25
+  |
+7 | type Views = views!(&A, + &B,);
+  |                         ^ no rules expected this token in macro call


### PR DESCRIPTION
This PR defines macro compilation tests using the [`trybuild`](https://crates.io/crates/trybuild) crate. These tests are for every macro defined within this crate. Additionally, some macros (specifically, the `stages!` macro and a small amount of the `entities!` macro) were rewritten to match the expected output (which is good, that means the tests are working!). More tests could be added in the future with #54, but for now I believe this covers all the possible failure cases of the macros.