### PR TITLE
Pedantic clippy lints.

### DIFF
--- a/src/archetype/identifier/impl_serde.rs
+++ b/src/archetype/identifier/impl_serde.rs
@@ -61,7 +61,7 @@ where
                     buffer.push(
                         seq.next_element()?
                             .ok_or_else(|| de::Error::invalid_length(i, &self))?,
-                    )
+                    );
                 }
 
                 // Check that trailing bits are not set.

--- a/src/archetype/identifier/impl_serde.rs
+++ b/src/archetype/identifier/impl_serde.rs
@@ -71,7 +71,7 @@ where
                     && unsafe { buffer.get_unchecked((R::LEN + 7) / 8 - 1) } & (255 << bit) != 0
                 {
                     return Err(de::Error::invalid_value(
-                        Unexpected::Unsigned(*byte as u64),
+                        Unexpected::Unsigned(u64::from(*byte)),
                         &self,
                     ));
                 }

--- a/src/archetype/identifier/iter.rs
+++ b/src/archetype/identifier/iter.rs
@@ -1,7 +1,7 @@
 use crate::registry::Registry;
 use core::marker::PhantomData;
 
-pub struct IdentifierIter<R>
+pub struct Iter<R>
 where
     R: Registry,
 {
@@ -13,7 +13,7 @@ where
     position: usize,
 }
 
-impl<R> IdentifierIter<R>
+impl<R> Iter<R>
 where
     R: Registry,
 {
@@ -29,7 +29,7 @@ where
     }
 }
 
-impl<R> Iterator for IdentifierIter<R>
+impl<R> Iterator for Iter<R>
 where
     R: Registry,
 {

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -75,9 +75,7 @@ where
     R: Registry,
 {
     fn drop(&mut self) {
-        drop(unsafe {
-            Vec::from_raw_parts(self.pointer, (R::LEN + 7) / 8, self.capacity)
-        });
+        drop(unsafe { Vec::from_raw_parts(self.pointer, (R::LEN + 7) / 8, self.capacity) });
     }
 }
 

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -77,7 +77,7 @@ where
     fn drop(&mut self) {
         drop(unsafe {
             Vec::from_raw_parts(self.pointer, (R::LEN + 7) / 8, self.capacity)
-        })
+        });
     }
 }
 

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -113,15 +113,15 @@ where
         slice::from_raw_parts(self.pointer, (R::LEN + 7) / 8)
     }
 
-    pub(crate) unsafe fn iter(&self) -> IdentifierIter<R> {
+    pub(crate) unsafe fn iter(self) -> IdentifierIter<R> {
         IdentifierIter::<R>::new(self.pointer)
     }
 
-    pub(crate) fn as_vec(&self) -> Vec<u8> {
+    pub(crate) fn as_vec(self) -> Vec<u8> {
         unsafe { self.as_slice() }.to_vec()
     }
 
-    pub(crate) unsafe fn get_unchecked(&self, index: usize) -> bool {
+    pub(crate) unsafe fn get_unchecked(self, index: usize) -> bool {
         (self.as_slice().get_unchecked(index / 8) >> (index % 8) & 1) != 0
     }
 }

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -3,7 +3,7 @@
 mod impl_serde;
 mod iter;
 
-pub(crate) use iter::IdentifierIter;
+pub use iter::Iter;
 
 use crate::registry::Registry;
 use alloc::vec::Vec;
@@ -52,8 +52,8 @@ where
         }
     }
 
-    pub(crate) unsafe fn iter(&self) -> IdentifierIter<R> {
-        IdentifierIter::<R>::new(self.pointer)
+    pub(crate) unsafe fn iter(&self) -> Iter<R> {
+        Iter::<R>::new(self.pointer)
     }
 
     pub(crate) fn size_of_components(&self) -> usize {
@@ -111,8 +111,8 @@ where
         slice::from_raw_parts(self.pointer, (R::LEN + 7) / 8)
     }
 
-    pub(crate) unsafe fn iter(self) -> IdentifierIter<R> {
-        IdentifierIter::<R>::new(self.pointer)
+    pub(crate) unsafe fn iter(self) -> Iter<R> {
+        Iter::<R>::new(self.pointer)
     }
 
     pub(crate) fn as_vec(self) -> Vec<u8> {

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -12,7 +12,7 @@ use core::{
     fmt::Debug,
     hash::{Hash, Hasher},
     marker::PhantomData,
-    mem::ManuallyDrop,
+    mem::{drop, ManuallyDrop},
     slice,
 };
 
@@ -75,9 +75,9 @@ where
     R: Registry,
 {
     fn drop(&mut self) {
-        unsafe {
-            let _ = Vec::from_raw_parts(self.pointer, (R::LEN + 7) / 8, self.capacity);
-        }
+        drop(unsafe {
+            Vec::from_raw_parts(self.pointer, (R::LEN + 7) / 8, self.capacity)
+        })
     }
 }
 

--- a/src/archetype/impl_drop.rs
+++ b/src/archetype/impl_drop.rs
@@ -1,5 +1,6 @@
 use crate::{archetype::Archetype, registry::Registry};
 use alloc::vec::Vec;
+use core::mem::drop;
 
 impl<R> Drop for Archetype<R>
 where
@@ -10,12 +11,12 @@ where
         unsafe {
             R::free_components(&self.components, self.length, self.identifier_buffer.iter());
         }
-        unsafe {
-            let _ = Vec::from_raw_parts(
+        drop(unsafe {
+            Vec::from_raw_parts(
                 self.entity_identifiers.0,
                 self.length,
                 self.entity_identifiers.1,
-            );
-        }
+            )
+        });
     }
 }

--- a/src/archetype/impl_serde.rs
+++ b/src/archetype/impl_serde.rs
@@ -591,6 +591,7 @@ impl<'de, R> Deserialize<'de> for Archetype<R>
 where
     R: RegistryDeserialize<'de>,
 {
+    #[allow(clippy::too_many_lines)]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/src/archetype/impl_serde.rs
+++ b/src/archetype/impl_serde.rs
@@ -6,7 +6,7 @@ use crate::{
     registry::{RegistryDeserialize, RegistrySerialize},
 };
 use alloc::vec::Vec;
-use core::{any::type_name, fmt, marker::PhantomData, mem::ManuallyDrop, write};
+use core::{any::type_name, fmt, marker::PhantomData, mem::{drop, ManuallyDrop}, write};
 use serde::{
     de::{self, DeserializeSeed, SeqAccess, Visitor},
     ser::SerializeTuple,
@@ -368,13 +368,13 @@ where
                         )
                     });
                     if let Err(error) = result {
-                        let _ = unsafe {
+                        drop(unsafe {
                             Vec::from_raw_parts(
                                 entity_identifiers.0,
                                 vec_length,
                                 entity_identifiers.1,
                             )
-                        };
+                        });
                         unsafe {
                             R::free_components(&components, vec_length, self.0.identifier.iter());
                         }
@@ -384,13 +384,13 @@ where
                     if let Some(()) = unsafe { result.unwrap_unchecked() } {
                         vec_length += 1;
                     } else {
-                        let _ = unsafe {
+                        drop(unsafe {
                             Vec::from_raw_parts(
                                 entity_identifiers.0,
                                 vec_length,
                                 entity_identifiers.1,
                             )
-                        };
+                        });
                         unsafe {
                             R::free_components(&components, vec_length, self.0.identifier.iter());
                         }
@@ -545,13 +545,13 @@ where
                 };
                 if let Err(error) = result {
                     // Free columns, since they are invalid and must be dropped.
-                    let _ = unsafe {
+                    drop(unsafe {
                         Vec::from_raw_parts(
                             entity_identifiers.0,
                             self.0.length,
                             entity_identifiers.1,
                         )
-                    };
+                    });
                     unsafe {
                         R::try_free_components(
                             &components,

--- a/src/archetype/impl_serde.rs
+++ b/src/archetype/impl_serde.rs
@@ -354,7 +354,7 @@ where
                         &mut components,
                         self.0.length,
                         self.0.identifier.iter(),
-                    )
+                    );
                 }
                 let mut vec_length = 0;
 

--- a/src/archetype/impl_serde.rs
+++ b/src/archetype/impl_serde.rs
@@ -6,7 +6,13 @@ use crate::{
     registry::{RegistryDeserialize, RegistrySerialize},
 };
 use alloc::vec::Vec;
-use core::{any::type_name, fmt, marker::PhantomData, mem::{drop, ManuallyDrop}, write};
+use core::{
+    any::type_name,
+    fmt,
+    marker::PhantomData,
+    mem::{drop, ManuallyDrop},
+    write,
+};
 use serde::{
     de::{self, DeserializeSeed, SeqAccess, Visitor},
     ser::SerializeTuple,

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -1,4 +1,3 @@
-mod identifier;
 mod impl_debug;
 mod impl_drop;
 mod impl_eq;
@@ -7,7 +6,9 @@ mod impl_send;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod impl_serde;
 
-pub(crate) use identifier::{Identifier, IdentifierIter, IdentifierRef};
+pub(crate) mod identifier;
+
+pub(crate) use identifier::{Identifier, IdentifierRef};
 #[cfg(feature = "serde")]
 pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
 

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -200,7 +200,7 @@ where
                         .get(&TypeId::of::<C>())
                         .unwrap_unchecked(),
                 )
-                .0 as *mut C,
+                .0.cast::<C>(),
             self.length,
         )
         .get_unchecked_mut(index) = component;

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -273,14 +273,14 @@ where
     pub(crate) unsafe fn push_from_buffer_and_component<C>(
         &mut self,
         entity_identifier: entity::Identifier,
-        buffer: Vec<u8>,
+        buffer: *const u8,
         component: C,
     ) -> usize
     where
         C: Component,
     {
         R::push_components_from_buffer_and_component(
-            buffer.as_ptr(),
+            buffer,
             MaybeUninit::new(component),
             &mut self.components,
             self.length,
@@ -306,13 +306,13 @@ where
     pub(crate) unsafe fn push_from_buffer_skipping_component<C>(
         &mut self,
         entity_identifier: entity::Identifier,
-        buffer: Vec<u8>,
+        buffer: *const u8,
     ) -> usize
     where
         C: Component,
     {
         R::push_components_from_buffer_skipping_component(
-            buffer.as_ptr(),
+            buffer,
             PhantomData::<C>,
             &mut self.components,
             self.length,

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -200,7 +200,8 @@ where
                         .get(&TypeId::of::<C>())
                         .unwrap_unchecked(),
                 )
-                .0.cast::<C>(),
+                .0
+                .cast::<C>(),
             self.length,
         )
         .get_unchecked_mut(index) = component;

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -136,6 +136,9 @@ where
     ///
     /// [`Entities`]: crate::entities::Entities
     /// [`entities!]: crate::entities!
+    ///
+    /// # Panics
+    /// Panics if the columns are not all the same length.
     pub fn new(entities: E) -> Self {
         assert!(entities.check_len());
         unsafe { Self::new_unchecked(entities) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 #![cfg_attr(doc_cfg, feature(doc_cfg, decl_macro))]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
 
 extern crate alloc;
 

--- a/src/query/view/assertion_buffer.rs
+++ b/src/query/view/assertion_buffer.rs
@@ -65,14 +65,16 @@ impl AssertionBuffer {
     where
         C: Component,
     {
-        if self.mutable_claims.contains(&TypeId::of::<C>()) {
-            panic!(
-                "the component {} cannot be viewed as mutable when it is already viewed as mutable",
-                type_name::<C>()
-            );
-        } else if self.immutable_claims.contains(&TypeId::of::<C>()) {
-            panic!("the component {} cannot be viewed as mutable when it is already viewed as immutable", type_name::<C>());
-        }
+        assert!(
+            !self.mutable_claims.contains(&TypeId::of::<C>()),
+            "the component {} cannot be viewed as mutable when it is already viewed as mutable",
+            type_name::<C>()
+        );
+        assert!(
+            !self.immutable_claims.contains(&TypeId::of::<C>()),
+            "the component {} cannot be viewed as mutable when it is already viewed as immutable",
+            type_name::<C>()
+        );
 
         self.mutable_claims.insert(TypeId::of::<C>());
     }
@@ -86,9 +88,11 @@ impl AssertionBuffer {
     where
         C: Component,
     {
-        if self.mutable_claims.contains(&TypeId::of::<C>()) {
-            panic!("the component {} cannot be viewed as immutable when it is already viewed as mutable", type_name::<C>());
-        }
+        assert!(
+            !self.mutable_claims.contains(&TypeId::of::<C>()),
+            "the component {} cannot be viewed as immutable when it is already viewed as mutable",
+            type_name::<C>()
+        );
 
         self.immutable_claims.insert(TypeId::of::<C>());
     }

--- a/src/query/view/par/seal/mod.rs
+++ b/src/query/view/par/seal/mod.rs
@@ -75,6 +75,7 @@ where
     }
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn wrap_some<T>(val: T) -> Option<T> {
     Some(val)
 }

--- a/src/query/view/par/seal/mod.rs
+++ b/src/query/view/par/seal/mod.rs
@@ -46,7 +46,7 @@ where
         core::slice::from_raw_parts::<'a, C>(
             columns
                 .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
-                .0 as *mut C,
+                .0.cast::<C>(),
             length,
         )
         .par_iter()
@@ -68,7 +68,7 @@ where
         core::slice::from_raw_parts_mut::<'a, C>(
             columns
                 .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
-                .0 as *mut C,
+                .0.cast::<C>(),
             length,
         )
         .par_iter_mut()
@@ -96,7 +96,7 @@ where
     ) -> Self::ParResult {
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
-                core::slice::from_raw_parts(columns.get_unchecked(*index).0 as *mut C, length)
+                core::slice::from_raw_parts(columns.get_unchecked(*index).0.cast::<C>(), length)
                     .par_iter()
                     .map(wrap_some),
             ),
@@ -122,7 +122,7 @@ where
     ) -> Self::ParResult {
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
-                core::slice::from_raw_parts_mut(columns.get_unchecked(*index).0 as *mut C, length)
+                core::slice::from_raw_parts_mut(columns.get_unchecked(*index).0.cast::<C>(), length)
                     .par_iter_mut()
                     .map(wrap_some),
             ),

--- a/src/query/view/par/seal/mod.rs
+++ b/src/query/view/par/seal/mod.rs
@@ -46,7 +46,8 @@ where
         core::slice::from_raw_parts::<'a, C>(
             columns
                 .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
-                .0.cast::<C>(),
+                .0
+                .cast::<C>(),
             length,
         )
         .par_iter()
@@ -68,7 +69,8 @@ where
         core::slice::from_raw_parts_mut::<'a, C>(
             columns
                 .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
-                .0.cast::<C>(),
+                .0
+                .cast::<C>(),
             length,
         )
         .par_iter_mut()
@@ -123,9 +125,12 @@ where
     ) -> Self::ParResult {
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
-                core::slice::from_raw_parts_mut(columns.get_unchecked(*index).0.cast::<C>(), length)
-                    .par_iter_mut()
-                    .map(wrap_some),
+                core::slice::from_raw_parts_mut(
+                    columns.get_unchecked(*index).0.cast::<C>(),
+                    length,
+                )
+                .par_iter_mut()
+                .map(wrap_some),
             ),
             None => Either::Left(RepeatNone::new(length)),
         }

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -39,7 +39,8 @@ where
         slice::from_raw_parts::<'a, C>(
             columns
                 .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
-                .0.cast::<C>(),
+                .0
+                .cast::<C>(),
             length,
         )
         .iter()
@@ -65,7 +66,8 @@ where
         slice::from_raw_parts_mut::<'a, C>(
             columns
                 .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
-                .0.cast::<C>(),
+                .0
+                .cast::<C>(),
             length,
         )
         .iter_mut()

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -145,7 +145,7 @@ where
 }
 
 impl<'a> ViewSeal<'a> for entity::Identifier {
-    type Result = iter::Cloned<slice::Iter<'a, Self>>;
+    type Result = iter::Copied<slice::Iter<'a, Self>>;
 
     unsafe fn view(
         _columns: &[(*mut u8, usize)],
@@ -155,7 +155,7 @@ impl<'a> ViewSeal<'a> for entity::Identifier {
     ) -> Self::Result {
         slice::from_raw_parts_mut::<'a, Self>(entity_identifiers.0, length)
             .iter()
-            .cloned()
+            .copied()
     }
 
     fn assert_claim(_buffer: &mut AssertionBuffer) {}

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -76,6 +76,7 @@ where
     }
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn wrap_some<T>(val: T) -> Option<T> {
     Some(val)
 }

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -39,7 +39,7 @@ where
         slice::from_raw_parts::<'a, C>(
             columns
                 .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
-                .0 as *mut C,
+                .0.cast::<C>(),
             length,
         )
         .iter()
@@ -65,7 +65,7 @@ where
         slice::from_raw_parts_mut::<'a, C>(
             columns
                 .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
-                .0 as *mut C,
+                .0.cast::<C>(),
             length,
         )
         .iter_mut()
@@ -97,7 +97,7 @@ where
     ) -> Self::Result {
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
-                slice::from_raw_parts(columns.get_unchecked(*index).0 as *mut C, length)
+                slice::from_raw_parts(columns.get_unchecked(*index).0.cast::<C>(), length)
                     .iter()
                     .map(wrap_some),
             ),
@@ -131,7 +131,7 @@ where
 
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
-                slice::from_raw_parts_mut(columns.get_unchecked(*index).0 as *mut C, length)
+                slice::from_raw_parts_mut(columns.get_unchecked(*index).0.cast::<C>(), length)
                     .iter_mut()
                     .map(wrap_some),
             ),

--- a/src/registry/debug.rs
+++ b/src/registry/debug.rs
@@ -15,14 +15,14 @@ pub trait RegistryDebug: Registry {
         index: usize,
         components: &[(*mut u8, usize)],
         pointers: &mut Vec<*const u8>,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry;
 
     unsafe fn debug_components<'a, 'b, R>(
         pointers: &[*const u8],
         debug_map: &mut DebugMap<'a, 'b>,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry;
 }
@@ -32,7 +32,7 @@ impl RegistryDebug for Null {
         _index: usize,
         _components: &[(*mut u8, usize)],
         _pointers: &mut Vec<*const u8>,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry,
     {
@@ -41,7 +41,7 @@ impl RegistryDebug for Null {
     unsafe fn debug_components<'a, 'b, R>(
         _pointers: &[*const u8],
         _debug_map: &mut DebugMap<'a, 'b>,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry,
     {
@@ -57,7 +57,7 @@ where
         index: usize,
         mut components: &[(*mut u8, usize)],
         pointers: &mut Vec<*const u8>,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         R_: Registry,
     {
@@ -72,7 +72,7 @@ where
     unsafe fn debug_components<'a, 'b, R_>(
         mut pointers: &[*const u8],
         debug_map: &mut DebugMap<'a, 'b>,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         R_: Registry,
     {

--- a/src/registry/eq.rs
+++ b/src/registry/eq.rs
@@ -11,7 +11,7 @@ pub trait RegistryPartialEq: Registry {
         components_a: &[(*mut u8, usize)],
         components_b: &[(*mut u8, usize)],
         length: usize,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) -> bool
     where
         R: Registry;
@@ -22,7 +22,7 @@ impl RegistryPartialEq for Null {
         _components_a: &[(*mut u8, usize)],
         _components_b: &[(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) -> bool
     where
         R: Registry,
@@ -40,7 +40,7 @@ where
         mut components_a: &[(*mut u8, usize)],
         mut components_b: &[(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) -> bool
     where
         R_: Registry,

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -378,7 +378,7 @@ where
             components,
             length,
             identifier_iter,
-        )
+        );
     }
 
     unsafe fn free_components<R_>(

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -241,7 +241,7 @@ where
     where
         R_: Registry,
     {
-        (identifier_iter.next().unwrap_unchecked() as usize * size_of::<C>())
+        (usize::from(identifier_iter.next().unwrap_unchecked()) * size_of::<C>())
             + R::size_of_components_for_identifier(identifier_iter)
     }
 

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -229,7 +229,7 @@ where
     {
         if identifier_iter.next().unwrap_unchecked() {
             let mut v = ManuallyDrop::new(Vec::<C>::with_capacity(length));
-            components.push((v.as_mut_ptr() as *mut u8, v.capacity()));
+            components.push((v.as_mut_ptr().cast::<u8>(), v.capacity()));
         }
 
         R::new_components_with_capacity(components, length, identifier_iter);
@@ -284,7 +284,7 @@ where
                 component_column.1,
             ));
 
-            ptr::write_unaligned(buffer as *mut C, v.swap_remove(index));
+            ptr::write_unaligned(buffer.cast::<C>(), v.swap_remove(index));
             buffer = buffer.add(size_of::<C>());
 
             components = components.get_unchecked(1..);
@@ -317,7 +317,7 @@ where
                 v.push(component.assume_init());
                 component = MaybeUninit::uninit();
 
-                *component_column = (v.as_mut_ptr() as *mut u8, v.capacity());
+                *component_column = (v.as_mut_ptr().cast::<u8>(), v.capacity());
             } else {
                 let mut v = ManuallyDrop::new(Vec::<C>::from_raw_parts(
                     component_column.0.cast::<C>(),
@@ -327,7 +327,7 @@ where
                 v.push(buffer.cast::<C>().read_unaligned());
                 buffer = buffer.add(size_of::<C>());
 
-                *component_column = (v.as_mut_ptr() as *mut u8, v.capacity());
+                *component_column = (v.as_mut_ptr().cast::<u8>(), v.capacity());
             }
 
             components = components.get_unchecked_mut(1..);
@@ -366,7 +366,7 @@ where
                 component_column.1,
             ));
             v.push(buffer.cast::<C>().read_unaligned());
-            *component_column = (v.as_mut_ptr() as *mut u8, v.capacity());
+            *component_column = (v.as_mut_ptr().cast::<u8>(), v.capacity());
 
             components = components.get_unchecked_mut(1..);
             buffer = buffer.add(size_of::<C>());

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -19,19 +19,19 @@ pub trait Storage {
     unsafe fn create_component_map_for_key<R>(
         component_map: &mut HashMap<TypeId, usize>,
         index: usize,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry;
 
     unsafe fn new_components_with_capacity<R>(
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry;
 
     unsafe fn size_of_components_for_identifier<R>(
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) -> usize
     where
         R: Registry;
@@ -40,7 +40,7 @@ pub trait Storage {
         index: usize,
         components: &[(*mut u8, usize)],
         length: usize,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry;
 
@@ -49,7 +49,7 @@ pub trait Storage {
         buffer: *mut u8,
         components: &[(*mut u8, usize)],
         length: usize,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry;
 
@@ -58,7 +58,7 @@ pub trait Storage {
         component: MaybeUninit<C>,
         components: &mut [(*mut u8, usize)],
         length: usize,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         C: Component,
         R: Registry;
@@ -68,7 +68,7 @@ pub trait Storage {
         component: PhantomData<C>,
         components: &mut [(*mut u8, usize)],
         length: usize,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         C: Component,
         R: Registry;
@@ -76,20 +76,20 @@ pub trait Storage {
     unsafe fn free_components<R>(
         components: &[(*mut u8, usize)],
         length: usize,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry;
 
     unsafe fn try_free_components<R>(
         components: &[(*mut u8, usize)],
         length: usize,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry;
 
     unsafe fn debug_identifier<R>(
         debug_list: &mut DebugList,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry;
 }
@@ -100,7 +100,7 @@ impl Storage for Null {
     unsafe fn create_component_map_for_key<R>(
         _component_map: &mut HashMap<TypeId, usize>,
         _index: usize,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry,
     {
@@ -109,14 +109,14 @@ impl Storage for Null {
     unsafe fn new_components_with_capacity<R>(
         _components: &mut Vec<(*mut u8, usize)>,
         _length: usize,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry,
     {
     }
 
     unsafe fn size_of_components_for_identifier<R>(
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) -> usize
     where
         R: Registry,
@@ -128,7 +128,7 @@ impl Storage for Null {
         _index: usize,
         _components: &[(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry,
     {
@@ -139,7 +139,7 @@ impl Storage for Null {
         _buffer: *mut u8,
         _components: &[(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry,
     {
@@ -150,7 +150,7 @@ impl Storage for Null {
         _component: MaybeUninit<C>,
         _components: &mut [(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         C: Component,
         R: Registry,
@@ -162,7 +162,7 @@ impl Storage for Null {
         _component: PhantomData<C>,
         _components: &mut [(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         C: Component,
         R: Registry,
@@ -172,7 +172,7 @@ impl Storage for Null {
     unsafe fn free_components<R>(
         _components: &[(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry,
     {
@@ -181,7 +181,7 @@ impl Storage for Null {
     unsafe fn try_free_components<R>(
         _components: &[(*mut u8, usize)],
         _length: usize,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry,
     {
@@ -189,7 +189,7 @@ impl Storage for Null {
 
     unsafe fn debug_identifier<R>(
         _debug_list: &mut DebugList,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry,
     {
@@ -209,7 +209,7 @@ where
     unsafe fn create_component_map_for_key<R_>(
         component_map: &mut HashMap<TypeId, usize>,
         mut index: usize,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         R_: Registry,
     {
@@ -223,7 +223,7 @@ where
     unsafe fn new_components_with_capacity<R_>(
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         R_: Registry,
     {
@@ -236,7 +236,7 @@ where
     }
 
     unsafe fn size_of_components_for_identifier<R_>(
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) -> usize
     where
         R_: Registry,
@@ -249,7 +249,7 @@ where
         index: usize,
         mut components: &[(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         R_: Registry,
     {
@@ -272,7 +272,7 @@ where
         mut buffer: *mut u8,
         mut components: &[(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         R_: Registry,
     {
@@ -297,7 +297,7 @@ where
         mut component: MaybeUninit<C_>,
         mut components: &mut [(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         C_: Component,
         R_: Registry,
@@ -347,7 +347,7 @@ where
         component: PhantomData<C_>,
         mut components: &mut [(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         C_: Component,
         R_: Registry,
@@ -384,7 +384,7 @@ where
     unsafe fn free_components<R_>(
         mut components: &[(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         R_: Registry,
     {
@@ -403,7 +403,7 @@ where
     unsafe fn try_free_components<R_>(
         mut components: &[(*mut u8, usize)],
         length: usize,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         R_: Registry,
     {
@@ -431,7 +431,7 @@ where
 
     unsafe fn debug_identifier<R_>(
         debug_list: &mut DebugList,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         R_: Registry,
     {

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -8,7 +8,7 @@ use core::{
     any::{type_name, TypeId},
     fmt::DebugList,
     marker::PhantomData,
-    mem::{size_of, ManuallyDrop, MaybeUninit},
+    mem::{drop, size_of, ManuallyDrop, MaybeUninit},
     ptr,
 };
 use hashbrown::HashMap;
@@ -390,11 +390,11 @@ where
     {
         if identifier_iter.next().unwrap_unchecked() {
             let component_column = components.get_unchecked(0);
-            let _ = Vec::<C>::from_raw_parts(
+            drop(Vec::<C>::from_raw_parts(
                 component_column.0.cast::<C>(),
                 length,
                 component_column.1,
-            );
+            ));
             components = components.get_unchecked(1..);
         }
         R::free_components(components, length, identifier_iter);
@@ -414,11 +414,11 @@ where
                     return;
                 }
             };
-            let _ = Vec::<C>::from_raw_parts(
+            drop(Vec::<C>::from_raw_parts(
                 component_column.0.cast::<C>(),
                 length,
                 component_column.1,
-            );
+            ));
             components = match components.get(1..) {
                 Some(components) => components,
                 None => {

--- a/src/registry/serde.rs
+++ b/src/registry/serde.rs
@@ -194,7 +194,7 @@ where
                 .ok_or_else(|| {
                     de::Error::custom(format!("expected a column of type `{}`", type_name::<C>()))
                 })?;
-            components.push((component_column.0 as *mut u8, component_column.1));
+            components.push((component_column.0.cast::<u8>(), component_column.1));
         }
 
         R::deserialize_components_by_column(components, length, seq, identifier_iter)

--- a/src/registry/serde.rs
+++ b/src/registry/serde.rs
@@ -14,7 +14,7 @@ pub trait RegistrySerialize: Registry {
         components: &[(*mut u8, usize)],
         length: usize,
         tuple: &mut S,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) -> Result<(), S::Error>
     where
         R: Registry,
@@ -25,7 +25,7 @@ pub trait RegistrySerialize: Registry {
         length: usize,
         index: usize,
         tuple: &mut S,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) -> Result<(), S::Error>
     where
         R: Registry,
@@ -37,7 +37,7 @@ impl RegistrySerialize for Null {
         _components: &[(*mut u8, usize)],
         _length: usize,
         _tuple: &mut S,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) -> Result<(), S::Error>
     where
         R: Registry,
@@ -51,7 +51,7 @@ impl RegistrySerialize for Null {
         _length: usize,
         _index: usize,
         _tuple: &mut S,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) -> Result<(), S::Error>
     where
         R: Registry,
@@ -70,7 +70,7 @@ where
         mut components: &[(*mut u8, usize)],
         length: usize,
         tuple: &mut S,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) -> Result<(), S::Error>
     where
         R_: Registry,
@@ -97,7 +97,7 @@ where
         length: usize,
         index: usize,
         tuple: &mut S,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) -> Result<(), S::Error>
     where
         R_: Registry,
@@ -127,7 +127,7 @@ pub trait RegistryDeserialize<'de>: Registry + 'de {
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,
         seq: &mut V,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) -> Result<(), V::Error>
     where
         R: Registry,
@@ -137,7 +137,7 @@ pub trait RegistryDeserialize<'de>: Registry + 'de {
         components: &mut [(*mut u8, usize)],
         length: usize,
         seq: &mut V,
-        identifier_iter: archetype::IdentifierIter<R>,
+        identifier_iter: archetype::identifier::Iter<R>,
     ) -> Result<(), V::Error>
     where
         R: Registry,
@@ -149,7 +149,7 @@ impl<'de> RegistryDeserialize<'de> for Null {
         _components: &mut Vec<(*mut u8, usize)>,
         _length: usize,
         _seq: &mut V,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) -> Result<(), V::Error>
     where
         R: Registry,
@@ -162,7 +162,7 @@ impl<'de> RegistryDeserialize<'de> for Null {
         _components: &mut [(*mut u8, usize)],
         _length: usize,
         _seq: &mut V,
-        _identifier_iter: archetype::IdentifierIter<R>,
+        _identifier_iter: archetype::identifier::Iter<R>,
     ) -> Result<(), V::Error>
     where
         R: Registry,
@@ -181,7 +181,7 @@ where
         components: &mut Vec<(*mut u8, usize)>,
         length: usize,
         seq: &mut V,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) -> Result<(), V::Error>
     where
         R_: Registry,
@@ -204,7 +204,7 @@ where
         mut components: &mut [(*mut u8, usize)],
         length: usize,
         seq: &mut V,
-        mut identifier_iter: archetype::IdentifierIter<R_>,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
     ) -> Result<(), V::Error>
     where
         R_: Registry,

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -155,6 +155,7 @@ impl Schedule<stage::Null> {
     /// ```
     ///
     /// [`schedule::Builder`]: crate::system::schedule::Builder
+    #[must_use]
     pub fn builder() -> Builder<raw_task::Null> {
         Builder::new()
     }

--- a/src/system/schedule/raw_task/seal.rs
+++ b/src/system/schedule/raw_task/seal.rs
@@ -66,6 +66,11 @@ where
 
         match self.0 {
             RawTask::Task(task) => {
+                // Helper function to check whether the intersection betwen two sets is nonempty.
+                fn intersects(a: &HashSet<TypeId>, b: &HashSet<TypeId>) -> bool {
+                    a.intersection(b).next().is_some()
+                }
+
                 mutable_buffer.clear();
                 immutable_buffer.clear();
 
@@ -78,11 +83,6 @@ where
                 // Identify this stage's claims on components.
                 S::Views::claim(mutable_buffer, immutable_buffer);
                 P::Views::claim(mutable_buffer, immutable_buffer);
-
-                // Helper function to check whether the intersection betwen two sets is nonempty.
-                fn intersects(a: &HashSet<TypeId>, b: &HashSet<TypeId>) -> bool {
-                    a.intersection(b).next().is_some()
-                }
 
                 // If the claims are incompatible, a new stage must begin.
                 //

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -74,8 +74,8 @@ where
                 self.world
                     .archetypes
                     .get_unchecked_mut(self.location.identifier)
-                    .set_component_unchecked(self.location.index, component)
-            };
+                    .set_component_unchecked(self.location.index, component);
+            }
         } else {
             // The component needs to be added to the entity.
             let (entity_identifier, current_component_bytes) = unsafe {

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -100,7 +100,7 @@ where
             let index = unsafe {
                 archetype.push_from_buffer_and_component(
                     entity_identifier,
-                    current_component_bytes,
+                    current_component_bytes.as_ptr(),
                     component,
                 )
             };
@@ -164,7 +164,7 @@ where
             let index = unsafe {
                 archetype.push_from_buffer_skipping_component::<C>(
                     entity_identifier,
-                    current_component_bytes,
+                    current_component_bytes.as_ptr(),
                 )
             };
 

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -63,6 +63,9 @@ where
     ///
     /// entry.add(Baz(1.5));
     /// ```
+    ///
+    /// # Panics
+    /// Panics if the component `C` is not in the registry R.
     pub fn add<C>(&mut self, component: C)
     where
         C: Component,
@@ -134,6 +137,9 @@ where
     ///
     /// entry.remove::<Foo>();
     /// ```
+    ///
+    /// # Panics
+    /// Panics if the component `C` is not in the registry R.
     pub fn remove<C>(&mut self)
     where
         C: Component,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -114,6 +114,7 @@ where
     /// ```
     ///
     /// [`Registry`]: crate::registry::Registry
+    #[must_use]
     pub fn new() -> Self {
         Self::from_raw_parts(Archetypes::new(), entity::Allocator::new())
     }


### PR DESCRIPTION
This PR enables `clippy::pedantic` lints.

Everything is enabled except `clippy::module_name_repetitions`, due to some issues with applying allowances to use statements. There is [an issue](https://github.com/rust-lang/rust-clippy/issues/7511) open about it already, but for now I'm just going to disable it.