### PR TITLE
Split World::run() method into three separate methods.

### DIFF
--- a/src/query/view/assertion_buffer.rs
+++ b/src/query/view/assertion_buffer.rs
@@ -5,6 +5,7 @@
 //! is not sound.
 //!
 //! [`Views`]: crate::query::view::Views
+//! [`World`]: crate::world::World
 
 use crate::component::Component;
 use core::any::{type_name, TypeId};

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -62,7 +62,7 @@ use hashbrown::HashMap;
 /// in a panic.
 ///
 /// Components of entities can be queried using the [`query()`] method. [`System`]s can also be run
-/// over components of entities using the various `run` methods. 
+/// over components of entities using the various `run` methods.
 ///
 /// [`query()`]: crate::World::query()
 /// [`Registry`]: crate::registry::Registry

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -492,7 +492,7 @@ where
     where
         S: Stages<'a>,
     {
-        schedule.run(self)
+        schedule.run(self);
     }
 
     /// Gets an [`Entry`] for the entity associated with an [`entity::Identifier`] for


### PR DESCRIPTION
Rather than using extra `Runnable` and `ParallelRunnable` traits, which are nearly duplicates of the `System` and `ParSystem` traits, I decided to instead split `run()` into three separate methods: `run_system()`, `run_par_system()`, and `run_schedule()`. 

This resolves #42.