### PR TITLE
Fix valgrind workflow in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -142,6 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - run: sudo apt-get update
     - run: sudo apt-get install valgrind
     - uses: actions-rs/toolchain@v1
       with:


### PR DESCRIPTION
Fixes #65.

Seems valgrind being installed from source is more trouble than it's worth. Since I was installing from source to attempt to resolve an issue with running trybuild tests anyway, which we ended up skipping in the end, this reverts back to installing with `apt-get`.