### PR TITLE
Check documentation on CI.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,9 +113,9 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: doc
-        args: --no-deps --cfg doc_cfg
+        args: --no-deps --all-features
       env:
-        RUSTDOCFLAGS: -D warnings
+        RUSTDOCFLAGS: --cfg doc_cfg -D warnings
 
   private_doc:
     runs-on: ubuntu-latest
@@ -128,9 +128,9 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: doc
-        args: --no-deps --cfg doc_cfg --document-private-items
+        args: --no-deps --all-features --document-private-items
       env:
-        RUSTDOCFLAGS: -D warnings
+        RUSTDOCFLAGS: --cfg doc_cfg -D warnings
 
   msrv:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,8 +114,8 @@ jobs:
       with:
         command: doc
         args: --no-deps --cfg doc_cfg
-        env:
-          RUSTDOCFLAGS: -D warnings
+      env:
+        RUSTDOCFLAGS: -D warnings
 
   private_doc:
     runs-on: ubuntu-latest
@@ -129,8 +129,8 @@ jobs:
       with:
         command: doc
         args: --no-deps --cfg doc_cfg --document-private-items
-        env:
-          RUSTDOCFLAGS: -D warnings
+      env:
+        RUSTDOCFLAGS: -D warnings
 
   msrv:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,6 +102,36 @@ jobs:
         command: hack
         args: clippy --feature-powerset --optional-deps -- --deny warnings
 
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --no-deps --cfg doc_cfg
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+  private_doc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+    - uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --no-deps --cfg doc_cfg --document-private-items
+        env:
+          RUSTDOCFLAGS: -D warnings
+
   msrv:
     runs-on: ubuntu-latest
     steps:

--- a/src/query/view/assertion_buffer.rs
+++ b/src/query/view/assertion_buffer.rs
@@ -37,6 +37,8 @@ impl AssertionBuffer {
     /// Create a new empty buffer.
     ///
     /// It is recommended to use [`with_capacity`] if possible, as it will save allocations.
+    ///
+    /// [`with_capacity`]: AssertionBuffer::with_capacity()
     #[cfg(feature = "parallel")]
     pub(crate) fn new() -> Self {
         Self::with_capacity(0)

--- a/src/registry/seal/assertions.rs
+++ b/src/registry/seal/assertions.rs
@@ -1,11 +1,10 @@
 //! This module defines and implements assertions on a [`Registry`].
 //!
 //! All assertions on invariants that must be upheld by a `Registry` should be included within the
-//! `Assertions` trait defined here. This trait acts as an extension to the [`registry::Seal`]
+//! `Assertions` trait defined here. This trait acts as an extension to the `registry::Seal`
 //! trait, implementing it on all registries.
 //!
 //! [`Registry`]: crate::registry::Registry
-//! [`registry::Seal`]: crate::registry::seal::Seal;
 
 use crate::{component::Component, registry::Null};
 use core::any::TypeId;


### PR DESCRIPTION
This builds documentation on CI with `-D warnings` to (hopefully) ensure that the documentation builds correctly. There may be more things to do in the future to further assure that things are working correctly, but for now this works well, since the most common error is going to be intra-doc-links, which are covered here.

Fixes #67.