### PR TITLE
Safety Audit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
           - stable
           - beta
           - nightly
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rayon = {version = "1.5.1", optional = true}
 serde = {version = "1.0.133", default-features = false, features = ["alloc"], optional = true}
 
 [dev-dependencies]
+claim = "0.5.0"
 rustversion = "1.0.6"
 serde_test = "1.0.133"
 trybuild = "1.0.56"

--- a/src/archetype/identifier/impl_serde.rs
+++ b/src/archetype/identifier/impl_serde.rs
@@ -18,6 +18,7 @@ where
     {
         let mut tuple = serializer.serialize_tuple((R::LEN + 7) / 8)?;
 
+        // SAFETY: The slice returned here is guaranteed to be outlived by `self`.
         for byte in unsafe { self.as_slice() } {
             tuple.serialize_element(byte)?;
         }
@@ -65,10 +66,12 @@ where
                 }
 
                 // Check that trailing bits are not set.
+                // SAFETY: `buffer` is guaranteed to have `(R::LEN + 7) / 8` elements, so this will
+                // always be within the bounds of `buffer.`
                 let byte = unsafe { buffer.get_unchecked((R::LEN + 7) / 8 - 1) };
                 let bit = R::LEN % 8;
                 if bit != 0
-                    && unsafe { buffer.get_unchecked((R::LEN + 7) / 8 - 1) } & (255 << bit) != 0
+                    && byte & (255 << bit) != 0
                 {
                     return Err(de::Error::invalid_value(
                         Unexpected::Unsigned(u64::from(*byte)),

--- a/src/archetype/identifier/impl_serde.rs
+++ b/src/archetype/identifier/impl_serde.rs
@@ -70,9 +70,7 @@ where
                 // always be within the bounds of `buffer.`
                 let byte = unsafe { buffer.get_unchecked((R::LEN + 7) / 8 - 1) };
                 let bit = R::LEN % 8;
-                if bit != 0
-                    && byte & (255 << bit) != 0
-                {
+                if bit != 0 && byte & (255 << bit) != 0 {
                     return Err(de::Error::invalid_value(
                         Unexpected::Unsigned(u64::from(*byte)),
                         &self,

--- a/src/archetype/identifier/iter.rs
+++ b/src/archetype/identifier/iter.rs
@@ -1,15 +1,42 @@
 use crate::registry::Registry;
 use core::marker::PhantomData;
 
+/// An iterator over the bits of an [`Identifier`].
+///
+/// This iterator is guaranteed to return exactly `(R::LEN + 7) / 8` boolean values indicating
+/// the components within `R` that are identified.
+///
+/// [`Identifier`]: crate::archetype::identifier::Identifier
 pub struct Iter<R>
 where
     R: Registry,
 {
+    /// The [`Registry`] defining the set of valid values of this identifier.
+    ///
+    /// Each identifier must exist within a set defined by a `Registry`. This defines a space over
+    /// which each identifier can uniquely define a set of components. Each bit within the
+    /// identifier corresponds with a component in the registry.
+    ///
+    /// [`Registry`]: crate::registry::Registry
     registry: PhantomData<R>,
 
+    /// A pointer to the allocated bits.
+    ///
+    /// Note that this allocation is not owned by this struct. It is owned by an [`Identifier`] and
+    /// is invariantly guaranteed to outlive this struct.
+    ///
+    /// As iteration progresses, this pointer will move along to point to the current byte.
+    ///
+    /// [`Identifier`]: crate::archetype::identifier::Identifier
     pointer: *const u8,
 
+    /// The current byte being iterated over.
+    ///
+    /// This byte just includes the remaining bits of the current value.
     current: u8,
+    /// The current bit position.
+    ///
+    /// If this value is greater than or equal to `(R::LEN + 7) / 8`, iteration has completed.
     position: usize,
 }
 
@@ -17,13 +44,26 @@ impl<R> Iter<R>
 where
     R: Registry,
 {
+    /// Create a new iterator for an [`Identifier`].
+    ///
+    /// # Safety
+    /// `pointer` must be a pointer to a valid `Identifier` allocation, and must be ensured to live
+    /// as long as the returned `Iter`.
+    ///
+    /// [`Identifier`]: crate::archetype::identifier::Identifier
     pub(super) unsafe fn new(pointer: *const u8) -> Self {
         Self {
             registry: PhantomData,
 
             pointer,
 
-            current: if R::LEN > 0 { unsafe { *pointer } } else { 0 },
+            current: if R::LEN > 0 {
+                // SAFETY: `pointer` is a valid `Identifier` allocation that is nonempty, meaning
+                // it points to at least one `u8` which is dereferenced here.
+                unsafe { *pointer }
+            } else {
+                0
+            },
             position: 0,
         }
     }
@@ -42,8 +82,16 @@ where
             let result = self.current & 1 != 0;
             self.position += 1;
             if self.position < R::LEN && self.position % 8 == 0 {
-                self.pointer = unsafe { self.pointer.add(1) };
-                self.current = unsafe { *self.pointer };
+                self.pointer =
+                    // SAFETY: The allocation pointed to is guaranteed to have at least
+                    // `(R::LEN + 7) / 8` bytes. Therefore, since `self.position` is only
+                    // incremented once on each iteration, we will only enter this block for every
+                    // eighth byte and therefore not offset past the end of the allocation.
+                    unsafe { self.pointer.add(1) };
+                self.current =
+                    // SAFETY: Due to the reasons above, `self.pointer` will always point to a
+                    // valid `u8` that can be dereferenced here without fail.
+                    unsafe { *self.pointer };
             } else {
                 self.current >>= 1;
             }

--- a/src/archetype/identifier/iter.rs
+++ b/src/archetype/identifier/iter.rs
@@ -23,7 +23,7 @@ where
 
             pointer,
 
-            current: if R::LEN > 0 { *pointer } else { 0 },
+            current: if R::LEN > 0 { unsafe { *pointer } } else { 0 },
             position: 0,
         }
     }

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -256,7 +256,7 @@ where
         (
             // SAFETY: `index` is guaranteed to be less than R::LEN, so therefore index / 8 will be
             // within the bounds of `self.as_slice()`.
-            unsafe {self.as_slice().get_unchecked(index / 8)} >> (index % 8) & 1
+            unsafe { self.as_slice().get_unchecked(index / 8) } >> (index % 8) & 1
         ) != 0
     }
 }
@@ -284,7 +284,7 @@ where
     where
         H: Hasher,
     {
-        // SAFETY: The slice created here will be outlived by the referenced `Identifier`, as the 
+        // SAFETY: The slice created here will be outlived by the referenced `Identifier`, as the
         // slice will only live for the scope of this function.
         unsafe { self.as_slice() }.hash(state);
     }

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -188,7 +188,7 @@ where
 /// [`Archetypes`]: crate::archetypes::Archetypes
 /// [`entity::Allocator`]: crate::entity::allocator::Allocator
 /// [`Identifier`]: crate::archetype::identifier::Identifier
-pub(crate) struct IdentifierRef<R>
+pub struct IdentifierRef<R>
 where
     R: Registry,
 {

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -235,7 +235,7 @@ where
     /// The caller must ensure the referenced `Identifier` outlives the returned [`Iter`].
     ///
     /// [`Iter`]: crate::archetype::identifier::Iter
-    pub(crate) unsafe fn iter(&self) -> Iter<R> {
+    pub(crate) unsafe fn iter(self) -> Iter<R> {
         // SAFETY: `self.pointer` will be valid as long as the returned `Iter` exists, assuming the
         // caller ensures the `Identifier` outlives it.
         unsafe { Iter::<R>::new(self.pointer) }

--- a/src/archetype/impl_debug.rs
+++ b/src/archetype/impl_debug.rs
@@ -68,7 +68,7 @@ where
                     i,
                     &self.components,
                     &mut component_pointers,
-                    self.identifier_buffer.iter(),
+                    self.identifier.iter(),
                 );
             }
             debug_map.entry(
@@ -77,7 +77,7 @@ where
                     identifier: *unsafe { entity_identifiers.get_unchecked(i) },
                     components: Components {
                         pointers: component_pointers,
-                        identifier: unsafe { self.identifier_buffer.as_ref() },
+                        identifier: unsafe { self.identifier.as_ref() },
                     },
                 },
             );

--- a/src/archetype/impl_debug.rs
+++ b/src/archetype/impl_debug.rs
@@ -19,6 +19,9 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut debug_map = f.debug_map();
+        // SAFETY: `pointers` is guaranteed to contain the same number of values as there are
+        // components, each pointing to a valid component of type `C`. Also, `self.identifier` will
+        // yield the same number of values as there are components in `R`.
         unsafe {
             R::debug_components(&self.pointers, &mut debug_map, self.identifier.iter());
         }
@@ -53,16 +56,24 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut debug_map = f.debug_map();
 
-        let entity_identifiers = ManuallyDrop::new(unsafe {
-            Vec::from_raw_parts(
-                self.entity_identifiers.0,
-                self.length,
-                self.entity_identifiers.1,
-            )
-        });
+        let entity_identifiers = ManuallyDrop::new(
+            // SAFETY: `self.identifiers`, together with `self.length`, are guaranteed to be the
+            // raw parts for a valid `Vec<entity::Identifier>`.
+            unsafe {
+                Vec::from_raw_parts(
+                    self.entity_identifiers.0,
+                    self.length,
+                    self.entity_identifiers.1,
+                )
+            },
+        );
 
         for i in 0..self.length {
             let mut component_pointers = Vec::new();
+            // SAFETY: `self.components` contains the same number of values as
+            // `self.identifier.iter()` has bits. Each tuple in `components` corresponds to a valid
+            // `Vec<C>` for each component `C` with a length of `self.length`. Therefore, `i` will
+            // be within the bounds of each of those `Vec<C>`s as well.
             unsafe {
                 R::extract_component_pointers(
                     i,
@@ -74,9 +85,12 @@ where
             debug_map.entry(
                 &i,
                 &Row::<R> {
+                    // SAFETY: `entity_identifiers` is guaranteed to be of length `self.length`.
                     identifier: *unsafe { entity_identifiers.get_unchecked(i) },
                     components: Components {
                         pointers: component_pointers,
+                        // SAFETY: This `IdentifierRef` will not outlive its referenced
+                        // `Identifier`.
                         identifier: unsafe { self.identifier.as_ref() },
                     },
                 },

--- a/src/archetype/impl_drop.rs
+++ b/src/archetype/impl_drop.rs
@@ -9,7 +9,7 @@ where
     #[inline]
     fn drop(&mut self) {
         unsafe {
-            R::free_components(&self.components, self.length, self.identifier_buffer.iter());
+            R::free_components(&self.components, self.length, self.identifier.iter());
         }
         drop(unsafe {
             Vec::from_raw_parts(

--- a/src/archetype/impl_drop.rs
+++ b/src/archetype/impl_drop.rs
@@ -8,15 +8,22 @@ where
 {
     #[inline]
     fn drop(&mut self) {
+        // SAFETY: `self.components` contains the raw parts making valid `Vec<C>`s of size
+        // `self.length` for each `C` identified by `self.identifier`. Also, `self.identifier` is
+        // generic over the same `R` upon which this function is called.
         unsafe {
             R::free_components(&self.components, self.length, self.identifier.iter());
         }
-        drop(unsafe {
-            Vec::from_raw_parts(
-                self.entity_identifiers.0,
-                self.length,
-                self.entity_identifiers.1,
-            )
-        });
+        drop(
+            // SAFETY: `self.entity_identifiers` is guaranteed to contain the raw parts for a valid
+            // `Vec` of size `self.length`.
+            unsafe {
+                Vec::from_raw_parts(
+                    self.entity_identifiers.0,
+                    self.length,
+                    self.entity_identifiers.1,
+                )
+            },
+        );
     }
 }

--- a/src/archetype/impl_eq.rs
+++ b/src/archetype/impl_eq.rs
@@ -12,20 +12,36 @@ where
     fn eq(&self, other: &Self) -> bool {
         self.length == other.length
             && self.identifier == other.identifier
-            && ManuallyDrop::new(unsafe {
+            && ManuallyDrop::new(
+                // SAFETY: `self.entity_identifiers` is guaranteed to contain the raw parts for a
+                // valid `Vec` of size `self.length`.
+                unsafe {
                 Vec::from_raw_parts(
                     self.entity_identifiers.0,
                     self.length,
                     self.entity_identifiers.1,
                 )
-            }) == ManuallyDrop::new(unsafe {
+            }) == ManuallyDrop::new(
+                // SAFETY: `other.entity_identifiers` is guaranteed to contain the raw parts for a
+                // valid `Vec` of size `other.length`.
+                unsafe {
                 Vec::from_raw_parts(
                     other.entity_identifiers.0,
                     other.length,
                     other.entity_identifiers.1,
                 )
             })
-            && unsafe {
+            &&
+            // SAFETY: Since `self.identifier` is equal to `other.identifier`, the components Vecs
+            // will contain the same number of values as there are bits in `self.identifier`.
+            //
+            // `self.components` and `other.components` both contain raw parts for valid `Vec<C>`s
+            // for each identified component `C` of size `self.length` (since `self.length` and
+            // `other.length` are equal).
+            //
+            // `self.identifier` is generic over the same `R` upon which this function is being
+            // called.
+            unsafe {
                 R::component_eq(
                     &self.components,
                     &other.components,

--- a/src/archetype/impl_eq.rs
+++ b/src/archetype/impl_eq.rs
@@ -11,7 +11,7 @@ where
 {
     fn eq(&self, other: &Self) -> bool {
         self.length == other.length
-            && self.identifier_buffer == other.identifier_buffer
+            && self.identifier == other.identifier
             && ManuallyDrop::new(unsafe {
                 Vec::from_raw_parts(
                     self.entity_identifiers.0,
@@ -30,7 +30,7 @@ where
                     &self.components,
                     &other.components,
                     self.length,
-                    self.identifier_buffer.iter(),
+                    self.identifier.iter(),
                 )
             }
     }

--- a/src/archetype/impl_serde.rs
+++ b/src/archetype/impl_serde.rs
@@ -54,12 +54,8 @@ where
     where
         S: Serializer,
     {
-        let mut tuple = serializer.serialize_tuple(
-            unsafe { self.0.identifier.iter() }
-                .filter(|b| *b)
-                .count()
-                + 1,
-        )?;
+        let mut tuple = serializer
+            .serialize_tuple(unsafe { self.0.identifier.iter() }.filter(|b| *b).count() + 1)?;
         tuple.serialize_element(&SerializeColumn(&ManuallyDrop::new(unsafe {
             Vec::from_raw_parts(
                 self.0.entity_identifiers.0,

--- a/src/archetype/impl_serde.rs
+++ b/src/archetype/impl_serde.rs
@@ -55,7 +55,7 @@ where
         S: Serializer,
     {
         let mut tuple = serializer.serialize_tuple(
-            unsafe { self.0.identifier_buffer.iter() }
+            unsafe { self.0.identifier.iter() }
                 .filter(|b| *b)
                 .count()
                 + 1,
@@ -72,7 +72,7 @@ where
                 &self.0.components,
                 self.0.length,
                 &mut tuple,
-                self.0.identifier_buffer.iter(),
+                self.0.identifier.iter(),
             )?;
         }
         tuple.end()
@@ -92,7 +92,7 @@ where
         S: Serializer,
     {
         let mut tuple = serializer.serialize_tuple(3)?;
-        tuple.serialize_element(&self.0.identifier_buffer)?;
+        tuple.serialize_element(&self.0.identifier)?;
         tuple.serialize_element(&self.0.length)?;
         tuple.serialize_element(&SerializeColumns(self.0))?;
         tuple.end()
@@ -116,7 +116,7 @@ where
         S: Serializer,
     {
         let mut tuple = serializer.serialize_tuple(
-            unsafe { self.archetype.identifier_buffer.iter() }
+            unsafe { self.archetype.identifier.iter() }
                 .filter(|b| *b)
                 .count()
                 + 1,
@@ -137,7 +137,7 @@ where
                 self.archetype.length,
                 self.index,
                 &mut tuple,
-                self.archetype.identifier_buffer.iter(),
+                self.archetype.identifier.iter(),
             )?;
         }
 
@@ -181,7 +181,7 @@ where
         S: Serializer,
     {
         let mut tuple = serializer.serialize_tuple(3)?;
-        tuple.serialize_element(&self.0.identifier_buffer)?;
+        tuple.serialize_element(&self.0.identifier)?;
         tuple.serialize_element(&self.0.length)?;
         tuple.serialize_element(&SerializeRows(self.0))?;
         tuple.end()

--- a/src/archetype/impl_serde.rs
+++ b/src/archetype/impl_serde.rs
@@ -236,6 +236,10 @@ impl<'a, 'de, R> DeserializeRow<'a, 'de, R>
 where
     R: RegistryDeserialize<'de>,
 {
+    /// # Safety
+    /// `entity_identifiers` must be the valid raw parts for a `Vec<entity::Identifier>` of size
+    /// `length`. Each element in `components` must be the valid raw parts for a `Vec<C>` of size
+    /// `length` for each component `C` identified by `identifier`.
     unsafe fn new(
         identifier: archetype::IdentifierRef<R>,
         entity_identifiers: &'a mut (*mut entity::Identifier, usize),
@@ -283,13 +287,17 @@ where
             where
                 A: SeqAccess<'de>,
             {
-                let mut entity_identifiers = ManuallyDrop::new(unsafe {
-                    Vec::from_raw_parts(
-                        self.0.entity_identifiers.0,
-                        self.0.length,
-                        self.0.entity_identifiers.1,
-                    )
-                });
+                let mut entity_identifiers = ManuallyDrop::new(
+                    // SAFETY: `entity_identifiers` contains the valid raw parts for a
+                    // `Vec<entity::Identifier> of size `length`.
+                    unsafe {
+                        Vec::from_raw_parts(
+                            self.0.entity_identifiers.0,
+                            self.0.length,
+                            self.0.entity_identifiers.1,
+                        )
+                    },
+                );
                 entity_identifiers
                     .push(seq.next_element()?.ok_or_else(|| {
                         de::Error::invalid_length(0, &"number of components + 1")
@@ -299,6 +307,10 @@ where
                     entity_identifiers.capacity(),
                 );
 
+                // SAFETY: Each element of `self.0.components` contains the raw parts for a valid
+                // `Vec<C>` of size `self.0.length` for each component `C` identified by the
+                // identifier. The registry `R` over which `self.0.identifier` is generic is the
+                // same `R` on which this function is called.
                 unsafe {
                     R::deserialize_components_by_row(
                         self.0.components,
@@ -313,6 +325,7 @@ where
         }
 
         deserializer.deserialize_tuple(
+            // SAFETY: The identifier here will outlive the derived `Iter`.
             unsafe { self.identifier.iter() }.filter(|b| *b).count() + 1,
             DeserializeRowVisitor(self),
         )
@@ -368,8 +381,12 @@ where
                     entity_identifiers_vec.capacity(),
                 );
 
-                let components_len = unsafe { self.0.identifier.iter() }.filter(|b| *b).count();
+                let components_len =
+                    // SAFETY: The identifier here will outlive the derived `Iter`.
+                    unsafe { self.0.identifier.iter() }.filter(|b| *b).count();
                 let mut components = Vec::with_capacity(components_len);
+                // SAFETY: The registry `R` over which `self.0.identifier` is generic is the same
+                // `R` on which this function is called.
                 unsafe {
                     R::new_components_with_capacity(
                         &mut components,
@@ -380,38 +397,62 @@ where
                 let mut vec_length = 0;
 
                 for i in 0..self.0.length {
-                    let result = seq.next_element_seed(unsafe {
-                        DeserializeRow::new(
-                            self.0.identifier.as_ref(),
-                            &mut entity_identifiers,
-                            &mut components,
-                            vec_length,
-                        )
-                    });
-                    if let Err(error) = result {
-                        drop(unsafe {
-                            Vec::from_raw_parts(
-                                entity_identifiers.0,
+                    let result = seq.next_element_seed(
+                        // SAFETY: `entity_identifiers` and `components` both contain the raw parts
+                        // for valid `Vec`s of length `vec_length`.
+                        unsafe {
+                            DeserializeRow::new(
+                                self.0.identifier.as_ref(),
+                                &mut entity_identifiers,
+                                &mut components,
                                 vec_length,
-                                entity_identifiers.1,
                             )
-                        });
+                        },
+                    );
+                    if let Err(error) = result {
+                        drop(
+                            // SAFETY: `entity_identifiers` contains the raw parts for a valid
+                            // `Vec<entity::Identifier>` of size `vec_length`.
+                            unsafe {
+                                Vec::from_raw_parts(
+                                    entity_identifiers.0,
+                                    vec_length,
+                                    entity_identifiers.1,
+                                )
+                            },
+                        );
+                        // SAFETY: `components` contains the raw parts for valid `Vec<C>`s of
+                        // length `vec_length` for each component identified by the identifier. The
+                        // registry `R` over which `self.0.identifier` is generic is the same `R`
+                        // on which this function is called.
                         unsafe {
                             R::free_components(&components, vec_length, self.0.identifier.iter());
                         }
 
                         return Err(error);
                     }
-                    if let Some(()) = unsafe { result.unwrap_unchecked() } {
+                    if let Some(()) =
+                        // SAFETY: If the `result` was an `Err` variant, the function would have
+                        // returned in the previous `if` block.
+                        unsafe { result.unwrap_unchecked() }
+                    {
                         vec_length += 1;
                     } else {
-                        drop(unsafe {
-                            Vec::from_raw_parts(
-                                entity_identifiers.0,
-                                vec_length,
-                                entity_identifiers.1,
-                            )
-                        });
+                        drop(
+                            // SAFETY: `entity_identifiers` contains the raw parts for a valid
+                            // `Vec<entity::Identifier>` of size `vec_length`.
+                            unsafe {
+                                Vec::from_raw_parts(
+                                    entity_identifiers.0,
+                                    vec_length,
+                                    entity_identifiers.1,
+                                )
+                            },
+                        );
+                        // SAFETY: `components` contains the raw parts for valid `Vec<C>`s of
+                        // length `vec_length` for each component identified by the identifier. The
+                        // registry `R` over which `self.0.identifier` is generic is the same `R`
+                        // on which this function is called.
                         unsafe {
                             R::free_components(&components, vec_length, self.0.identifier.iter());
                         }
@@ -420,14 +461,19 @@ where
                     }
                 }
 
-                Ok(unsafe {
-                    Archetype::from_raw_parts(
-                        self.0.identifier,
-                        entity_identifiers,
-                        components,
-                        self.0.length,
-                    )
-                })
+                Ok(
+                    // SAFETY: `entity_identifiers` and `components` both contain the raw parts for
+                    // valid `Vec`s of length `self.0.length` for the entity identifiers and
+                    // components identified by `self.0.identifier`.
+                    unsafe {
+                        Archetype::from_raw_parts(
+                            self.0.identifier,
+                            entity_identifiers,
+                            components,
+                            self.0.length,
+                        )
+                    },
+                )
             }
         }
 
@@ -554,9 +600,14 @@ where
                     .next_element_seed(DeserializeColumn::new(self.0.length))?
                     .ok_or_else(|| de::Error::invalid_length(2, &self))?;
 
-                let mut components =
-                    Vec::with_capacity(unsafe { self.0.identifier.iter() }.filter(|b| *b).count());
-                let result = unsafe {
+                let mut components = Vec::with_capacity(
+                    // SAFETY: The identifier here will outlive the derived `Iter`.
+                    unsafe { self.0.identifier.iter() }.filter(|b| *b).count(),
+                );
+                let result =
+                    // SAFETY: The `R` over which `self.0.identifier` is generic is the same `R` on
+                    // which this function is being called. 
+                    unsafe {
                     R::deserialize_components_by_column(
                         &mut components,
                         self.0.length,
@@ -566,13 +617,23 @@ where
                 };
                 if let Err(error) = result {
                     // Free columns, since they are invalid and must be dropped.
-                    drop(unsafe {
-                        Vec::from_raw_parts(
-                            entity_identifiers.0,
-                            self.0.length,
-                            entity_identifiers.1,
-                        )
-                    });
+                    drop(
+                        // SAFETY: `entity_identifiers` are the raw parts for a valid
+                        // `Vec<entity::Identifier>` of length `self.0.length`.
+                        unsafe {
+                            Vec::from_raw_parts(
+                                entity_identifiers.0,
+                                self.0.length,
+                                entity_identifiers.1,
+                            )
+                        },
+                    );
+                    // SAFETY: All elements in `components` are raw parts for valid `Vec<C>`s for
+                    // each component `C` identified by `self.0.identifier` (although there may not
+                    // necessarily be the same number of elements as there are components, which is
+                    // allowed in the safety contract). The registry `R` over which
+                    // `self.0.identifier` is generic is the same `R` on which this function is
+                    // called.
                     unsafe {
                         R::try_free_components(
                             &components,
@@ -584,18 +645,24 @@ where
                     return Err(error);
                 }
 
-                Ok(unsafe {
-                    Archetype::from_raw_parts(
-                        self.0.identifier,
-                        entity_identifiers,
-                        components,
-                        self.0.length,
-                    )
-                })
+                Ok(
+                    // SAFETY: `entity_identifiers` and `components` both contain the raw parts for
+                    // valid `Vec`s of length `self.0.length` for the entity identifiers and
+                    // components identified by `self.0.identifier`.
+                    unsafe {
+                        Archetype::from_raw_parts(
+                            self.0.identifier,
+                            entity_identifiers,
+                            components,
+                            self.0.length,
+                        )
+                    },
+                )
             }
         }
 
         deserializer.deserialize_tuple(
+            // SAFETY: The identifier here will outlive the derived `Iter`.
             unsafe { self.identifier.iter() }.filter(|b| *b).count() + 1,
             DeserializeColumnsVisitor(self),
         )

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -143,8 +143,8 @@ where
                 &self.component_map,
                 &mut self.components,
                 self.length,
-            )
-        };
+            );
+        }
 
         let entity_identifiers = entity_allocator.allocate_batch(Locations::new(
             self.length..(self.length + component_len),
@@ -216,8 +216,8 @@ where
                     .cast::<C>(),
                 self.length,
             )
-            .get_unchecked_mut(index) = component
-        };
+            .get_unchecked_mut(index) = component;
+        }
     }
 
     pub(crate) unsafe fn remove_row_unchecked(
@@ -242,8 +242,8 @@ where
                 entity_allocator.modify_location_index_unchecked(
                     *entity_identifiers.last().unwrap_unchecked(),
                     index,
-                )
-            };
+                );
+            }
         }
         entity_identifiers.swap_remove(index);
 
@@ -264,8 +264,8 @@ where
                 &self.components,
                 self.length,
                 self.identifier.iter(),
-            )
-        };
+            );
+        }
         unsafe { bytes.set_len(size_of_components) };
 
         let mut entity_identifiers = ManuallyDrop::new(unsafe {
@@ -281,8 +281,8 @@ where
                 entity_allocator.modify_location_index_unchecked(
                     *entity_identifiers.last().unwrap_unchecked(),
                     index,
-                )
-            };
+                );
+            }
         }
         let entity_identifier = entity_identifiers.swap_remove(index);
 
@@ -307,8 +307,8 @@ where
                 &mut self.components,
                 self.length,
                 self.identifier.iter(),
-            )
-        };
+            );
+        }
 
         let mut entity_identifiers = ManuallyDrop::new(unsafe {
             Vec::from_raw_parts(
@@ -343,8 +343,8 @@ where
                 &mut self.components,
                 self.length,
                 self.identifier.iter(),
-            )
-        };
+            );
+        }
 
         let mut entity_identifiers = ManuallyDrop::new(unsafe {
             Vec::from_raw_parts(

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -59,7 +59,9 @@ where
         length: usize,
     ) -> Self {
         let mut component_map = HashMap::new();
-        R::create_component_map_for_identifier(&mut component_map, 0, identifier_buffer.iter());
+        unsafe {
+            R::create_component_map_for_identifier(&mut component_map, 0, identifier_buffer.iter())
+        };
 
         Self {
             identifier_buffer,
@@ -75,22 +77,24 @@ where
     pub(crate) unsafe fn new(identifier_buffer: Identifier<R>) -> Self {
         let mut entity_identifiers = ManuallyDrop::new(Vec::new());
 
-        let entity_len = identifier_buffer.iter().filter(|b| *b).count();
+        let entity_len = unsafe { identifier_buffer.iter() }.filter(|b| *b).count();
         let mut components = Vec::with_capacity(entity_len);
         for _ in 0..entity_len {
             let mut v = ManuallyDrop::new(Vec::new());
             components.push((v.as_mut_ptr(), v.capacity()));
         }
 
-        Self::from_raw_parts(
-            identifier_buffer,
-            (
-                entity_identifiers.as_mut_ptr(),
-                entity_identifiers.capacity(),
-            ),
-            components,
-            0,
-        )
+        unsafe {
+            Self::from_raw_parts(
+                identifier_buffer,
+                (
+                    entity_identifiers.as_mut_ptr(),
+                    entity_identifiers.capacity(),
+                ),
+                components,
+                0,
+            )
+        }
     }
 
     pub(crate) unsafe fn push<E>(
@@ -101,18 +105,20 @@ where
     where
         E: Entity,
     {
-        entity.push_components(&self.component_map, &mut self.components, self.length);
+        unsafe { entity.push_components(&self.component_map, &mut self.components, self.length) };
 
         let entity_identifier = entity_allocator.allocate(Location {
-            identifier: self.identifier_buffer.as_ref(),
+            identifier: unsafe { self.identifier_buffer.as_ref() },
             index: self.length,
         });
 
-        let mut entity_identifiers = ManuallyDrop::new(Vec::from_raw_parts(
-            self.entity_identifiers.0,
-            self.length,
-            self.entity_identifiers.1,
-        ));
+        let mut entity_identifiers = ManuallyDrop::new(unsafe {
+            Vec::from_raw_parts(
+                self.entity_identifiers.0,
+                self.length,
+                self.entity_identifiers.1,
+            )
+        });
         entity_identifiers.push(entity_identifier);
         self.entity_identifiers = (
             entity_identifiers.as_mut_ptr(),
@@ -134,20 +140,26 @@ where
     {
         let component_len = entities.entities.component_len();
 
-        entities
-            .entities
-            .extend_components(&self.component_map, &mut self.components, self.length);
+        unsafe {
+            entities.entities.extend_components(
+                &self.component_map,
+                &mut self.components,
+                self.length,
+            )
+        };
 
         let entity_identifiers = entity_allocator.allocate_batch(Locations::new(
             self.length..(self.length + component_len),
-            self.identifier_buffer.as_ref(),
+            unsafe { self.identifier_buffer.as_ref() },
         ));
 
-        let mut entity_identifiers_v = ManuallyDrop::new(Vec::from_raw_parts(
-            self.entity_identifiers.0,
-            self.length,
-            self.entity_identifiers.1,
-        ));
+        let mut entity_identifiers_v = ManuallyDrop::new(unsafe {
+            Vec::from_raw_parts(
+                self.entity_identifiers.0,
+                self.length,
+                self.entity_identifiers.1,
+            )
+        });
         entity_identifiers_v.extend(entity_identifiers.iter());
         self.entity_identifiers = (
             entity_identifiers_v.as_mut_ptr(),
@@ -193,19 +205,21 @@ where
     where
         C: Component,
     {
-        *slice::from_raw_parts_mut(
-            self.components
-                .get_unchecked(
-                    *self
-                        .component_map
-                        .get(&TypeId::of::<C>())
-                        .unwrap_unchecked(),
-                )
-                .0
-                .cast::<C>(),
-            self.length,
-        )
-        .get_unchecked_mut(index) = component;
+        unsafe {
+            *slice::from_raw_parts_mut(
+                self.components
+                    .get_unchecked(
+                        *self
+                            .component_map
+                            .get(&TypeId::of::<C>())
+                            .unwrap_unchecked(),
+                    )
+                    .0
+                    .cast::<C>(),
+                self.length,
+            )
+            .get_unchecked_mut(index) = component
+        };
     }
 
     pub(crate) unsafe fn remove_row_unchecked(
@@ -213,24 +227,30 @@ where
         index: usize,
         entity_allocator: &mut entity::Allocator<R>,
     ) {
-        R::remove_component_row(
-            index,
-            &self.components,
-            self.length,
-            self.identifier_buffer.iter(),
-        );
+        unsafe {
+            R::remove_component_row(
+                index,
+                &self.components,
+                self.length,
+                self.identifier_buffer.iter(),
+            )
+        };
 
-        let mut entity_identifiers = ManuallyDrop::new(Vec::from_raw_parts(
-            self.entity_identifiers.0,
-            self.length,
-            self.entity_identifiers.1,
-        ));
+        let mut entity_identifiers = ManuallyDrop::new(unsafe {
+            Vec::from_raw_parts(
+                self.entity_identifiers.0,
+                self.length,
+                self.entity_identifiers.1,
+            )
+        });
         // Update swapped index if this isn't the last row.
         if index < self.length - 1 {
-            entity_allocator.modify_location_index_unchecked(
-                *entity_identifiers.last().unwrap_unchecked(),
-                index,
-            );
+            unsafe {
+                entity_allocator.modify_location_index_unchecked(
+                    *entity_identifiers.last().unwrap_unchecked(),
+                    index,
+                )
+            };
         }
         entity_identifiers.swap_remove(index);
 
@@ -244,26 +264,32 @@ where
     ) -> (entity::Identifier, Vec<u8>) {
         let size_of_components = self.identifier_buffer.size_of_components();
         let mut bytes = Vec::with_capacity(size_of_components);
-        R::pop_component_row(
-            index,
-            bytes.as_mut_ptr(),
-            &self.components,
-            self.length,
-            self.identifier_buffer.iter(),
-        );
-        bytes.set_len(size_of_components);
+        unsafe {
+            R::pop_component_row(
+                index,
+                bytes.as_mut_ptr(),
+                &self.components,
+                self.length,
+                self.identifier_buffer.iter(),
+            )
+        };
+        unsafe { bytes.set_len(size_of_components) };
 
-        let mut entity_identifiers = ManuallyDrop::new(Vec::from_raw_parts(
-            self.entity_identifiers.0,
-            self.length,
-            self.entity_identifiers.1,
-        ));
+        let mut entity_identifiers = ManuallyDrop::new(unsafe {
+            Vec::from_raw_parts(
+                self.entity_identifiers.0,
+                self.length,
+                self.entity_identifiers.1,
+            )
+        });
         // Update swapped index if this isn't the last row.
         if index < self.length - 1 {
-            entity_allocator.modify_location_index_unchecked(
-                *entity_identifiers.last().unwrap_unchecked(),
-                index,
-            );
+            unsafe {
+                entity_allocator.modify_location_index_unchecked(
+                    *entity_identifiers.last().unwrap_unchecked(),
+                    index,
+                )
+            };
         }
         let entity_identifier = entity_identifiers.swap_remove(index);
 
@@ -281,19 +307,23 @@ where
     where
         C: Component,
     {
-        R::push_components_from_buffer_and_component(
-            buffer,
-            MaybeUninit::new(component),
-            &mut self.components,
-            self.length,
-            self.identifier_buffer.iter(),
-        );
+        unsafe {
+            R::push_components_from_buffer_and_component(
+                buffer,
+                MaybeUninit::new(component),
+                &mut self.components,
+                self.length,
+                self.identifier_buffer.iter(),
+            )
+        };
 
-        let mut entity_identifiers = ManuallyDrop::new(Vec::from_raw_parts(
-            self.entity_identifiers.0,
-            self.length,
-            self.entity_identifiers.1,
-        ));
+        let mut entity_identifiers = ManuallyDrop::new(unsafe {
+            Vec::from_raw_parts(
+                self.entity_identifiers.0,
+                self.length,
+                self.entity_identifiers.1,
+            )
+        });
         entity_identifiers.push(entity_identifier);
         self.entity_identifiers = (
             entity_identifiers.as_mut_ptr(),
@@ -313,19 +343,23 @@ where
     where
         C: Component,
     {
-        R::push_components_from_buffer_skipping_component(
-            buffer,
-            PhantomData::<C>,
-            &mut self.components,
-            self.length,
-            self.identifier_buffer.iter(),
-        );
+        unsafe {
+            R::push_components_from_buffer_skipping_component(
+                buffer,
+                PhantomData::<C>,
+                &mut self.components,
+                self.length,
+                self.identifier_buffer.iter(),
+            )
+        };
 
-        let mut entity_identifiers = ManuallyDrop::new(Vec::from_raw_parts(
-            self.entity_identifiers.0,
-            self.length,
-            self.entity_identifiers.1,
-        ));
+        let mut entity_identifiers = ManuallyDrop::new(unsafe {
+            Vec::from_raw_parts(
+                self.entity_identifiers.0,
+                self.length,
+                self.entity_identifiers.1,
+            )
+        });
         entity_identifiers.push(entity_identifier);
         self.entity_identifiers = (
             entity_identifiers.as_mut_ptr(),
@@ -339,20 +373,24 @@ where
 
     pub(crate) unsafe fn clear(&mut self, entity_allocator: &mut entity::Allocator<R>) {
         // Clear each column.
-        R::clear_components(
-            &mut self.components,
-            self.length,
-            self.identifier_buffer.iter(),
-        );
+        unsafe {
+            R::clear_components(
+                &mut self.components,
+                self.length,
+                self.identifier_buffer.iter(),
+            )
+        };
 
         // Free each entity.
-        let mut entity_identifiers = ManuallyDrop::new(Vec::from_raw_parts(
-            self.entity_identifiers.0,
-            self.length,
-            self.entity_identifiers.1,
-        ));
+        let mut entity_identifiers = ManuallyDrop::new(unsafe {
+            Vec::from_raw_parts(
+                self.entity_identifiers.0,
+                self.length,
+                self.entity_identifiers.1,
+            )
+        });
         for entity_identifier in entity_identifiers.iter() {
-            entity_allocator.free_unchecked(*entity_identifier);
+            unsafe { entity_allocator.free_unchecked(*entity_identifier) };
         }
         entity_identifiers.clear();
 
@@ -360,7 +398,7 @@ where
     }
 
     pub(crate) unsafe fn identifier(&self) -> IdentifierRef<R> {
-        self.identifier_buffer.as_ref()
+        unsafe { self.identifier_buffer.as_ref() }
     }
 
     #[cfg(feature = "serde")]

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -218,10 +218,21 @@ where
         entity_identifiers
     }
 
-    pub(crate) fn view<'a, V>(&mut self) -> V::Results
+    /// # Safety
+    /// Each component viewed by `V` must also be identified by this archetype's `Identifier`.
+    pub(crate) unsafe fn view<'a, V>(&mut self) -> V::Results
     where
         V: Views<'a>,
     {
+        // SAFETY: `self.components` contains the raw parts for `Vec<C>`s of size `self.length`,
+        // where each `C` is a component for which the entry in `component_map` corresponds to the
+        // correct index.
+        //
+        // `self.entity_identifiers` also contains the raw parts for a valid
+        // `Vec<entity::Identifier>` of size `self.length`.
+        //
+        // Since each component viewed by `V` is also identified by this archetype's `Identifier`,
+        // `self.component` will contain an entry for every viewed component.
         unsafe {
             V::view(
                 &self.components,
@@ -232,12 +243,23 @@ where
         }
     }
 
+    /// # Safety
+    /// Each component viewed by `V` must also be identified by this archetype's `Identifier`.
     #[cfg(feature = "parallel")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
-    pub(crate) fn par_view<'a, V>(&mut self) -> V::ParResults
+    pub(crate) unsafe fn par_view<'a, V>(&mut self) -> V::ParResults
     where
         V: ParViews<'a>,
     {
+        // SAFETY: `self.components` contains the raw parts for `Vec<C>`s of size `self.length`,
+        // where each `C` is a component for which the entry in `component_map` corresponds to the
+        // correct index.
+        //
+        // `self.entity_identifiers` also contains the raw parts for a valid
+        // `Vec<entity::Identifier>` of size `self.length`.
+        //
+        // Since each component viewed by `V` is also identified by this archetype's `Identifier`,
+        // `self.component` will contain an entry for every viewed component.
         unsafe {
             V::par_view(
                 &self.components,

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -584,6 +584,8 @@ where
     #[cfg(feature = "serde")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
     pub(crate) fn entity_identifiers(&self) -> impl Iterator<Item = &entity::Identifier> {
+        // SAFETY: `self.entity_identifiers` is guaranteed to contain the raw parts for a valid
+        // `Vec` of size `self.length`.
         unsafe { slice::from_raw_parts(self.entity_identifiers.0, self.length) }.iter()
     }
 

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -270,10 +270,23 @@ where
         }
     }
 
+    /// # Safety
+    /// `C` must be a component type that is contained within this archetype, meaning the
+    /// archetype's `Identifier` must have the `C` bit set.
+    ///
+    /// `index` must be a valid index within this archetype (meaning it must be less than
+    /// `self.length`).
     pub(crate) unsafe fn set_component_unchecked<C>(&mut self, index: usize, component: C)
     where
         C: Component,
     {
+        // SAFETY: `self.component_map` is guaranteed to have an entry for `TypeId::of::<C>()` by
+        // the safety contract of this method. Additionally, `self.components` is guaranteed to
+        // have an entry for the index returned from `self.component_map`, and furthermore that
+        // entry is guaranteed to be the valid raw parts for a `Vec<C>` of length `self.length`.
+        //
+        // The slice view over the component column for `C` is also guaranteed by the safety
+        // contract of this method to have an entry for the given `index`.
         unsafe {
             *slice::from_raw_parts_mut(
                 self.components

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -417,6 +417,12 @@ where
         (entity_identifier, bytes)
     }
 
+    /// # Safety
+    /// `buffer` must be valid for reads and be an allocated buffer of packed, properly initialized
+    /// components corresponding to the components identified by this archetype's `identifier`
+    /// field.
+    /// 
+    /// The registry `R` over which this archetype is generic must contain no duplicate components.
     pub(crate) unsafe fn push_from_buffer_and_component<C>(
         &mut self,
         entity_identifier: entity::Identifier,
@@ -426,6 +432,21 @@ where
     where
         C: Component,
     {
+        // SAFETY: `self.components` has the same number of values as there are set bits in
+        // `self.identifier`. Also, each element in `self.components` defines a `Vec<C>` of size
+        // `self.length` for each `C` identified by `self.identifier`.
+        //
+        // `buffer` is valid for reads and is an allocated buffer of packed properly initialized
+        // components corresponding to the components identified by `self.identifier`, as is
+        // guaranteed by the safety contract of this method.
+        //
+        // The `MaybeUninit<C>` provided here is properly initialized.
+        //
+        // `R` contains no duplicate components, as is guaranteed by the safety contract of this
+        // method.
+        //
+        // The `R` over which `self.identifier` is generic is the same `R` on which this function
+        // is being called. 
         unsafe {
             R::push_components_from_buffer_and_component(
                 buffer,
@@ -436,13 +457,17 @@ where
             );
         }
 
-        let mut entity_identifiers = ManuallyDrop::new(unsafe {
-            Vec::from_raw_parts(
-                self.entity_identifiers.0,
-                self.length,
-                self.entity_identifiers.1,
-            )
-        });
+        let mut entity_identifiers = ManuallyDrop::new(
+            // SAFETY: `self.entity_identifiers` is guaranteed to contain the raw parts for a valid
+            // `Vec` of size `self.length`.
+            unsafe {
+                Vec::from_raw_parts(
+                    self.entity_identifiers.0,
+                    self.length,
+                    self.entity_identifiers.1,
+                )
+            },
+        );
         entity_identifiers.push(entity_identifier);
         self.entity_identifiers = (
             entity_identifiers.as_mut_ptr(),

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -384,7 +384,11 @@ where
         self.length = 0;
     }
 
+    /// # Safety
+    /// The `Archetype` must outlive the returned `IdentifierRef`.
     pub(crate) unsafe fn identifier(&self) -> IdentifierRef<R> {
+        // SAFETY: The safety contract of this method guarantees the returned `IdentifierRef` will
+        // outlive `self.identifier`.
         unsafe { self.identifier.as_ref() }
     }
 

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -59,9 +59,7 @@ where
         length: usize,
     ) -> Self {
         let mut component_map = HashMap::new();
-        unsafe {
-            R::create_component_map_for_identifier(&mut component_map, 0, identifier.iter())
-        };
+        unsafe { R::create_component_map_for_identifier(&mut component_map, 0, identifier.iter()) };
 
         Self {
             identifier,
@@ -228,12 +226,7 @@ where
         entity_allocator: &mut entity::Allocator<R>,
     ) {
         unsafe {
-            R::remove_component_row(
-                index,
-                &self.components,
-                self.length,
-                self.identifier.iter(),
-            )
+            R::remove_component_row(index, &self.components, self.length, self.identifier.iter())
         };
 
         let mut entity_identifiers = ManuallyDrop::new(unsafe {
@@ -373,13 +366,7 @@ where
 
     pub(crate) unsafe fn clear(&mut self, entity_allocator: &mut entity::Allocator<R>) {
         // Clear each column.
-        unsafe {
-            R::clear_components(
-                &mut self.components,
-                self.length,
-                self.identifier.iter(),
-            )
-        };
+        unsafe { R::clear_components(&mut self.components, self.length, self.identifier.iter()) };
 
         // Free each entity.
         let mut entity_identifiers = ManuallyDrop::new(unsafe {

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -318,8 +318,8 @@ where
         // `self.identifier` is generic over the same registry `R` as this method is being called
         // on.
         unsafe {
-            R::remove_component_row(index, &self.components, self.length, self.identifier.iter())
-        };
+            R::remove_component_row(index, &self.components, self.length, self.identifier.iter());
+        }
 
         let mut entity_identifiers = ManuallyDrop::new(
             // SAFETY: `self.entity_identifiers` is guaranteed to contain the raw parts for a valid

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -305,8 +305,8 @@ where
     }
 
     /// # Safety
-    /// `entity_allocator` must contain entries for the entities stored in the archetype. This
-    /// archetype must also be nonempty.
+    /// `entity_allocator` must contain entries for the entities stored in the archetype. The
+    /// `index` must be a valid index to a row in this archetype.
     pub(crate) unsafe fn remove_row_unchecked(
         &mut self,
         index: usize,
@@ -337,7 +337,8 @@ where
             // SAFETY: `entity_allocator` contains an entry for the entity identifiers stored in
             // `entity_identifiers`.
             //
-            // Additionally, `entity_identifiers` is guaranteed to be nonempty.
+            // Additionally, `entity_identifiers` is guaranteed to be nonempty, because the index
+            // is not for the last row.
             unsafe {
                 entity_allocator.modify_location_index_unchecked(
                     *entity_identifiers.last().unwrap_unchecked(),

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -72,7 +72,7 @@ where
         }
     }
 
-    pub(crate) unsafe fn new(identifier: Identifier<R>) -> Self {
+    pub(crate) fn new(identifier: Identifier<R>) -> Self {
         let mut entity_identifiers = ManuallyDrop::new(Vec::new());
 
         let entity_len = unsafe { identifier.iter() }.filter(|b| *b).count();

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -482,7 +482,7 @@ where
     /// # Safety
     /// `buffer` must be valid for reads and be an allocated buffer of packed, properly initialized
     /// components corresponding to the components identified by this archetype's `identifier`
-    /// field, skipping the component `C`.
+    /// field, also including the component `C`.
     ///
     /// The registry `R` over which this archetype is generic must contain no duplicate components.
     pub(crate) unsafe fn push_from_buffer_skipping_component<C>(
@@ -498,8 +498,8 @@ where
         // `self.length` for each `C` identified by `self.identifier`.
         //
         // `buffer` is valid for reads and is an allocated buffer of packed properly initialized
-        // components corresponding to the components identified by `self.identifier`, skipping
-        // the component `C`, as is guaranteed by the safety contract of this method.
+        // components corresponding to the components identified by `self.identifier`, also
+        // including the component `C`, as is guaranteed by the safety contract of this method.
         //
         // `R` contains no duplicate components, as is guaranteed by the safety contract of this
         // method.

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -57,7 +57,7 @@ where
     /// size `length`.
     ///
     /// `components` must contain the raw parts for valid `Vec<C>`s of size `length` for each
-    /// component `C` in the registry `R`.
+    /// component `C` identified by `identifier`.
     pub(crate) unsafe fn from_raw_parts(
         identifier: Identifier<R>,
         entity_identifiers: (*mut entity::Identifier, usize),

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -539,8 +539,7 @@ where
     }
 
     /// # Safety
-    /// `entity_allocator` must contain entries for the entities stored in the archetype. The
-    /// `index` must be a valid index to a row in this archetype.
+    /// `entity_allocator` must contain entries for the entities stored in the archetype.
     pub(crate) unsafe fn clear(&mut self, entity_allocator: &mut entity::Allocator<R>) {
         // Clear each column.
         // SAFETY: `self.components` has the same number of values as there are set bits in

--- a/src/archetypes/impl_debug.rs
+++ b/src/archetypes/impl_debug.rs
@@ -7,10 +7,14 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map()
-            .entries(
-                self.iter()
-                    .map(|archetype| (unsafe { archetype.identifier() }, archetype)),
-            )
+            .entries(self.iter().map(|archetype| {
+                (
+                    // SAFETY: The `IdentifierRef` obtained here does not live longer than the
+                    // `archetype`.
+                    unsafe { archetype.identifier() },
+                    archetype,
+                )
+            }))
             .finish()
     }
 }

--- a/src/archetypes/impl_eq.rs
+++ b/src/archetypes/impl_eq.rs
@@ -14,7 +14,11 @@ where
 
         self.iter().all(|archetype| {
             other
-                .get(unsafe { archetype.identifier() })
+                .get(
+                    // SAFETY: The `IdentifierRef` obtained here does not live longer than the
+                    // `archetype`.
+                    unsafe { archetype.identifier() },
+                )
                 .map_or(false, |other_archetype| archetype == other_archetype)
         })
     }

--- a/src/archetypes/iter.rs
+++ b/src/archetypes/iter.rs
@@ -31,10 +31,11 @@ where
     type Item = &'a Archetype<R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.raw_iter.next().map(|archetype_bucket|
-                // SAFETY: The reference to the archetype stored in this bucket is guaranteed to be
-                // unique.
-                unsafe { archetype_bucket.as_ref() })
+        self.raw_iter.next().map(|archetype_bucket| {
+            // SAFETY: The reference to the archetype stored in this bucket is guaranteed to be
+            // unique.
+            unsafe { archetype_bucket.as_ref() }
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -71,10 +72,11 @@ where
     type Item = &'a mut Archetype<R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.raw_iter.next().map(|archetype_bucket|
-                // SAFETY: The reference to the archetype stored in this bucket is guaranteed to be
-                // unique.
-                unsafe { archetype_bucket.as_mut() })
+        self.raw_iter.next().map(|archetype_bucket| {
+            // SAFETY: The reference to the archetype stored in this bucket is guaranteed to be
+            // unique.
+            unsafe { archetype_bucket.as_mut() }
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/archetypes/iter.rs
+++ b/src/archetypes/iter.rs
@@ -31,9 +31,10 @@ where
     type Item = &'a Archetype<R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.raw_iter
-            .next()
-            .map(|archetype_bucket| unsafe { archetype_bucket.as_ref() })
+        self.raw_iter.next().map(|archetype_bucket|
+                // SAFETY: The reference to the archetype stored in this bucket is guaranteed to be
+                // unique.
+                unsafe { archetype_bucket.as_ref() })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -70,9 +71,10 @@ where
     type Item = &'a mut Archetype<R>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.raw_iter
-            .next()
-            .map(|archetype_bucket| unsafe { archetype_bucket.as_mut() })
+        self.raw_iter.next().map(|archetype_bucket|
+                // SAFETY: The reference to the archetype stored in this bucket is guaranteed to be
+                // unique.
+                unsafe { archetype_bucket.as_mut() })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -94,12 +94,14 @@ where
         &mut self,
         identifier: archetype::IdentifierRef<R>,
     ) -> &mut Archetype<R> {
-        self.raw_archetypes
-            .get_mut(
-                Self::make_hash(identifier, &self.hash_builder),
-                Self::equivalent_identifier(identifier),
-            )
-            .unwrap_unchecked()
+        unsafe {
+            self.raw_archetypes
+                .get_mut(
+                    Self::make_hash(identifier, &self.hash_builder),
+                    Self::equivalent_identifier(identifier),
+                )
+                .unwrap_unchecked()
+        }
     }
 
     #[cfg(feature = "serde")]
@@ -127,7 +129,7 @@ where
 
     pub(crate) unsafe fn clear(&mut self, entity_allocator: &mut entity::Allocator<R>) {
         for archetype in self.iter_mut() {
-            archetype.clear(entity_allocator);
+            unsafe { archetype.clear(entity_allocator) };
         }
     }
 }

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -67,9 +67,13 @@ where
     fn equivalent_identifier(
         identifier: archetype::IdentifierRef<R>,
     ) -> impl Fn(&Archetype<R>) -> bool {
-        move |archetype: &Archetype<R>|
-            // SAFETY: The `IdentifierRef` obtained here does not live longer than the `archetype`.
-            unsafe { archetype.identifier() } == identifier
+        move |archetype: &Archetype<R>| {
+            (
+                // SAFETY: The `IdentifierRef` obtained here does not live longer than the
+                // `archetype`.
+                unsafe { archetype.identifier() }
+            ) == identifier
+        }
     }
 
     pub(crate) fn get(&self, identifier: archetype::IdentifierRef<R>) -> Option<&Archetype<R>> {

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -84,7 +84,7 @@ where
             Some(archetype_bucket) => unsafe { archetype_bucket.as_mut() },
             None => self.raw_archetypes.insert_entry(
                 hash,
-                unsafe { Archetype::new(identifier_buffer) },
+                Archetype::new(identifier_buffer),
                 Self::make_hasher(&self.hash_builder),
             ),
         }

--- a/src/archetypes/par_iter.rs
+++ b/src/archetypes/par_iter.rs
@@ -37,7 +37,10 @@ where
         C: UnindexedConsumer<Self::Item>,
     {
         self.raw_iter
-            .map(|archetype_bucket| unsafe { archetype_bucket.as_mut() })
+            .map(|archetype_bucket|
+                // SAFETY: The reference to the archetype stored in this bucket is guaranteed to be
+                // unique.
+                unsafe { archetype_bucket.as_mut() })
             .drive_unindexed(consumer)
     }
 }
@@ -48,6 +51,10 @@ where
 {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub(crate) fn par_iter_mut(&mut self) -> ParIterMut<R> {
-        ParIterMut::new(unsafe { self.raw_archetypes.par_iter() })
+        ParIterMut::new(
+            // SAFETY: The `ParIterMut` containing this `RawIter` is guaranteed to not outlive
+            // `self`.
+            unsafe { self.raw_archetypes.par_iter() },
+        )
     }
 }

--- a/src/archetypes/par_iter.rs
+++ b/src/archetypes/par_iter.rs
@@ -37,10 +37,11 @@ where
         C: UnindexedConsumer<Self::Item>,
     {
         self.raw_iter
-            .map(|archetype_bucket|
+            .map(|archetype_bucket| {
                 // SAFETY: The reference to the archetype stored in this bucket is guaranteed to be
                 // unique.
-                unsafe { archetype_bucket.as_mut() })
+                unsafe { archetype_bucket.as_mut() }
+            })
             .drive_unindexed(consumer)
     }
 }

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -136,7 +136,7 @@ where
     /// ```
     ///
     /// [`Entities`]: crate::entities::Entities
-    /// [`entities!]: crate::entities!
+    /// [`entities!`]: crate::entities!
     ///
     /// # Panics
     /// Panics if the columns are not all the same length.
@@ -167,7 +167,7 @@ where
     /// let batch = unsafe { Batch::new_unchecked((vec![42; 10], (vec![true; 10], entities::Null))) };
     /// ```
     /// [`Entities`]: crate::entities::Entities
-    /// [`entities!]: crate::entities!
+    /// [`entities!`]: crate::entities!
     pub unsafe fn new_unchecked(entities: E) -> Self {
         Self {
             len: entities.component_len(),

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -142,6 +142,7 @@ where
     /// Panics if the columns are not all the same length.
     pub fn new(entities: E) -> Self {
         assert!(entities.check_len());
+        // SAFETY: We just guaranteed the lengths of all columns are equal.
         unsafe { Self::new_unchecked(entities) }
     }
 
@@ -232,6 +233,7 @@ where
 #[macro_export]
 macro_rules! entities {
     (($component:expr $(,$components:expr)* $(,)?); $n:expr) => {
+        // SAFETY: Each `Vec` created here will be of length `$n`.
         unsafe {
             $crate::entities::Batch::new_unchecked(
                 ($crate::reexports::vec![$component; $n], $crate::entities!(@cloned ($($components),*); $n))
@@ -239,6 +241,8 @@ macro_rules! entities {
         }
     };
     ($(($($components:expr),*)),+ $(,)?) => {
+        // SAFETY: During transposition, each column is guaranteed to have an equal number of
+        // components.
         unsafe {
             $crate::entities::Batch::new_unchecked(
                 $crate::entities!(@transpose [] $(($($components),*)),+)
@@ -246,11 +250,13 @@ macro_rules! entities {
         }
     };
     ((); $n:expr) => {
+        // SAFETY: There are no columns to check.
         unsafe {
             $crate::entities::Batch::new_unchecked($crate::entities::Null)
         }
     };
     () => {
+        // SAFETY: There are no columns to check.
         unsafe {
             $crate::entities::Batch::new_unchecked($crate::entities::Null)
         }

--- a/src/entities/seal/storage.rs
+++ b/src/entities/seal/storage.rs
@@ -11,7 +11,7 @@ pub trait Storage {
         length: usize,
     );
 
-    unsafe fn to_key(key: &mut [u8], component_map: &HashMap<TypeId, usize>);
+    unsafe fn to_identifier(identifier: &mut [u8], component_map: &HashMap<TypeId, usize>);
 }
 
 impl Storage for Null {
@@ -23,7 +23,7 @@ impl Storage for Null {
     ) {
     }
 
-    unsafe fn to_key(_key: &mut [u8], _component_map: &HashMap<TypeId, usize>) {}
+    unsafe fn to_identifier(_identifier: &mut [u8], _component_map: &HashMap<TypeId, usize>) {}
 }
 
 impl<C, E> Storage for (Vec<C>, E)
@@ -54,13 +54,13 @@ where
         E::extend_components(self.1, component_map, components, length);
     }
 
-    unsafe fn to_key(key: &mut [u8], component_map: &HashMap<TypeId, usize>) {
+    unsafe fn to_identifier(identifier: &mut [u8], component_map: &HashMap<TypeId, usize>) {
         let component_index = component_map.get(&TypeId::of::<C>()).unwrap();
         let index = component_index / 8;
         let bit = component_index % 8;
 
-        *key.get_unchecked_mut(index) |= 1 << bit;
+        *identifier.get_unchecked_mut(index) |= 1 << bit;
 
-        E::to_key(key, component_map);
+        E::to_identifier(identifier, component_map);
     }
 }

--- a/src/entities/seal/storage.rs
+++ b/src/entities/seal/storage.rs
@@ -81,7 +81,11 @@ where
                 // `component_column` extracted is guaranteed by the safety contract to correspond to
                 // the column for component `C`.
                 unsafe {
-                    Vec::<C>::from_raw_parts(component_column.0.cast::<C>(), length, component_column.1)
+                    Vec::<C>::from_raw_parts(
+                        component_column.0.cast::<C>(),
+                        length,
+                        component_column.1,
+                    )
                 },
             );
             v.extend(self.0);

--- a/src/entities/seal/storage.rs
+++ b/src/entities/seal/storage.rs
@@ -4,6 +4,19 @@ use core::{any::TypeId, mem::ManuallyDrop};
 use hashbrown::HashMap;
 
 pub trait Storage {
+    /// Extend the component columns with the components contained in this heterogeneous list.
+    ///
+    /// This consumes the entities, moving the components into their appropriate columns.
+    ///
+    /// The components are stored within the `Vec<C>`s defined by `components` and `length`, using
+    /// the given `component_map` to determine which column each components should be added to.
+    ///
+    /// # Safety
+    /// `component_map` must contain an entry for every type `C` that makes up these entities. Each
+    /// entry must contain a unique index corresponding with a valid `components` entry.
+    ///
+    /// `components`, together with `length`, must define a valid `Vec<C>` for each component for
+    /// which `component_map` has an entry whose index references it.
     unsafe fn extend_components(
         self,
         component_map: &HashMap<TypeId, usize>,
@@ -11,6 +24,21 @@ pub trait Storage {
         length: usize,
     );
 
+    /// Populate raw identifier bits corresponding to the entities' components.
+    ///
+    /// The bits are filled according to the provided `component_map`. This ideally should be a map
+    /// created using a `Registry` of components.
+    ///
+    /// # Safety
+    /// `identifier` must be a zeroed-out allocation of enough bytes to have bits up to the highest
+    /// bit index value stored in `component_map`.
+    ///
+    /// `component_map` may only contain `usize` values up to the number of components in the
+    /// registry.
+    ///
+    /// # Panics
+    /// This method will panic if the entities contain a component that does not have an entry in
+    /// the given `component_map`.
     unsafe fn to_identifier(identifier: &mut [u8], component_map: &HashMap<TypeId, usize>);
 }
 
@@ -38,20 +66,31 @@ where
         length: usize,
     ) {
         let component_column =
-            components.get_unchecked_mut(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked());
+            // SAFETY: `component_map` is guaranteed to have an entry for `TypeId::of::<C>`, and
+            // entry is guaranteed to be a valid index into `components`.
+            unsafe {
+                components.get_unchecked_mut(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
+            };
         if length == 0 {
             let mut v = ManuallyDrop::new(self.0);
             *component_column = (v.as_mut_ptr().cast::<u8>(), v.capacity());
         } else {
-            let mut v = ManuallyDrop::new(Vec::<C>::from_raw_parts(
-                component_column.0.cast::<C>(),
-                length,
-                component_column.1,
-            ));
+            let mut v = ManuallyDrop::new(
+                // SAFETY: The `component_column` extracted from `components` is guaranteed to,
+                // together with `length`, define a valid `Vec<C>` for the current `C`, because the
+                // `component_column` extracted is guaranteed by the safety contract to correspond to
+                // the column for component `C`.
+                unsafe {
+                    Vec::<C>::from_raw_parts(component_column.0.cast::<C>(), length, component_column.1)
+                },
+            );
             v.extend(self.0);
             *component_column = (v.as_mut_ptr().cast::<u8>(), v.capacity());
         }
-        E::extend_components(self.1, component_map, components, length);
+        // SAFETY: Since `component_map`, `components`, and `length` all meet the safety
+        // requirements for the current method body, they will meet those same requirements for
+        // this method call.
+        unsafe { E::extend_components(self.1, component_map, components, length) };
     }
 
     unsafe fn to_identifier(identifier: &mut [u8], component_map: &HashMap<TypeId, usize>) {
@@ -59,8 +98,15 @@ where
         let index = component_index / 8;
         let bit = component_index % 8;
 
-        *identifier.get_unchecked_mut(index) |= 1 << bit;
+        // SAFETY: `identifier` is guaranteed by the safety contract of this function to have
+        // enough bits to be indexed by any value in the given `component_map`.
+        unsafe {
+            *identifier.get_unchecked_mut(index) |= 1 << bit;
+        }
 
-        E::to_identifier(identifier, component_map);
+        // SAFETY: `identifier` is guaranteed by the safety contract of this method to be large
+        // enough to store bits up to the number of components. `component_map` will also still
+        // contain `usize` values not larger than the number of components in the full registry.
+        unsafe { E::to_identifier(identifier, component_map) };
     }
 }

--- a/src/entity/allocator/impl_serde.rs
+++ b/src/entity/allocator/impl_serde.rs
@@ -251,9 +251,10 @@ where
         Ok(Self {
             slots: slots
                 .into_iter()
-                .map(|slot|
+                .map(|slot| {
                     // SAFETY: We just checked above that each `slot` is not `None`.
-                    unsafe { slot.unwrap_unchecked() })
+                    unsafe { slot.unwrap_unchecked() }
+                })
                 .collect(),
             free: free
                 .into_iter()

--- a/src/entity/allocator/slot.rs
+++ b/src/entity/allocator/slot.rs
@@ -13,15 +13,23 @@ impl<R> Slot<R>
 where
     R: Registry,
 {
-    // TODO: Should this really be considered unsafe?
-    pub(super) unsafe fn new(location: Location<R>) -> Self {
+    pub(super) fn new(location: Location<R>) -> Self {
         Self {
             generation: 0,
             location: Some(location),
         }
     }
 
-    // TODO: Should this really be considered unsafe?
+    /// Activate this slot without checking whether it is already activated.
+    ///
+    /// If the current slot is already active, this will lead to invalidation of
+    /// `entity::Identifier`s prematurely and make it impossible to remove entities from the
+    /// `World`. Additionally, it would leave invalid identifiers within archetype tables, causing
+    /// some improper assumptions. Therefore, this method is considered `unsafe` and must be called
+    /// with care.
+    ///
+    /// # Safety
+    /// A `Slot` this method is called on must not already be active.
     pub(super) unsafe fn activate_unchecked(&mut self, location: Location<R>) {
         self.generation = self.generation.wrapping_add(1);
         self.location = Some(location);

--- a/src/entity/seal/storage.rs
+++ b/src/entity/seal/storage.rs
@@ -33,6 +33,9 @@ pub trait Storage {
     /// `identifier` must be a zeroed-out allocation of enough bytes to have bits up to the highest
     /// bit index value stored in `component_map`.
     ///
+    /// `component_map` may only contain `usize` values up to the number of components in the
+    /// registry.
+    ///
     /// # Panics
     /// This method will panic if this entity contains a component that does not have an entry in
     /// the given `component_map`.
@@ -96,6 +99,9 @@ where
             *identifier.get_unchecked_mut(index) |= 1 << bit;
         }
 
-        E::to_identifier(identifier, component_map);
+        // SAFETY: `identifier` is guaranteed by the safety contract of this method to be large
+        // enough to store bits up to the number of components. `component_map` will also still
+        // contain `usize` values not larger than the number of components in the full registry.
+        unsafe { E::to_identifier(identifier, component_map) };
     }
 }

--- a/src/entity/seal/storage.rs
+++ b/src/entity/seal/storage.rs
@@ -4,6 +4,19 @@ use core::{any::TypeId, mem::ManuallyDrop};
 use hashbrown::HashMap;
 
 pub trait Storage {
+    /// Push the components contained in this heterogeneous list into component columns.
+    ///
+    /// This consumes the entity, moving the components into their appropriate columns.
+    ///
+    /// The components are stored within the `Vec<C>`s defined by `components` and `length`, using
+    /// the given `component_map` to determine which column each component should be added to.
+    ///
+    /// # Safety
+    /// `component_map` must contain an entry for every type `C` that makes up this entity. Each
+    /// entry must contain a unique index corresponding with a valid `components` entry.
+    ///
+    /// `components`, together with `length`, must define a valid `Vec<C>` for each component for
+    /// which `component_map` has an entry whose index references it.
     unsafe fn push_components(
         self,
         component_map: &HashMap<TypeId, usize>,
@@ -11,7 +24,19 @@ pub trait Storage {
         length: usize,
     );
 
-    unsafe fn to_key(key: &mut [u8], component_map: &HashMap<TypeId, usize>);
+    /// Populate raw identifier bits corresponding to this entity's components.
+    ///
+    /// The bits are filled according to the provided `component_map`. This ideally should be a map
+    /// created using a `Registry` of components.
+    ///
+    /// # Safety
+    /// `identifier` must be a zeroed-out allocation of enough bytes to have bits up to the highest
+    /// bit index value stored in `component_map`.
+    ///
+    /// # Panics
+    /// This method will panic if this entity contains a component that does not have an entry in
+    /// the given `component_map`.
+    unsafe fn to_identifier(identifier: &mut [u8], component_map: &HashMap<TypeId, usize>);
 }
 
 impl Storage for Null {
@@ -23,7 +48,7 @@ impl Storage for Null {
     ) {
     }
 
-    unsafe fn to_key(_key: &mut [u8], _component_map: &HashMap<TypeId, usize>) {}
+    unsafe fn to_identifier(_identifier: &mut [u8], _component_map: &HashMap<TypeId, usize>) {}
 }
 
 impl<C, E> Storage for (C, E)
@@ -38,24 +63,39 @@ where
         length: usize,
     ) {
         let component_column =
-            components.get_unchecked_mut(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked());
-        let mut v = ManuallyDrop::new(Vec::<C>::from_raw_parts(
-            component_column.0.cast::<C>(),
-            length,
-            component_column.1,
-        ));
+            // SAFETY: `component_map` is guaranteed to have an entry for `TypeId::of::<C>`, and
+            // entry is guaranteed to be a valid index into `components`.
+            unsafe {
+                components.get_unchecked_mut(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
+            };
+        let mut v = ManuallyDrop::new(
+            // SAFETY: The `component_column` extracted from `components` is guaranteed to,
+            // together with `length`, define a valid `Vec<C>` for the current `C`, because the
+            // `component_column` extracted is guaranteed by the safety contract to correspond to
+            // the column for component `C`.
+            unsafe {
+                Vec::<C>::from_raw_parts(component_column.0.cast::<C>(), length, component_column.1)
+            },
+        );
         v.push(self.0);
         *component_column = (v.as_mut_ptr().cast::<u8>(), v.capacity());
-        E::push_components(self.1, component_map, components, length);
+        // SAFETY: Since `component_map`, `components`, and `length` all meet the safety
+        // requirements for the current method body, they will meet those same requirements for
+        // this method call.
+        unsafe { E::push_components(self.1, component_map, components, length) };
     }
 
-    unsafe fn to_key(key: &mut [u8], component_map: &HashMap<TypeId, usize>) {
+    unsafe fn to_identifier(identifier: &mut [u8], component_map: &HashMap<TypeId, usize>) {
         let component_index = component_map.get(&TypeId::of::<C>()).unwrap();
         let index = component_index / 8;
         let bit = component_index % 8;
 
-        *key.get_unchecked_mut(index) |= 1 << bit;
+        // SAFETY: `identifier` is guaranteed by the safety contract of this function to have
+        // enough bits to be indexed by any value in the given `component_map`.
+        unsafe {
+            *identifier.get_unchecked_mut(index) |= 1 << bit;
+        }
 
-        E::to_key(key, component_map);
+        E::to_identifier(identifier, component_map);
     }
 }

--- a/src/query/claim.rs
+++ b/src/query/claim.rs
@@ -50,7 +50,7 @@ impl Claim for view::Null {
     fn claim(_mutable_claims: &mut HashSet<TypeId>, _immutable_claims: &mut HashSet<TypeId>) {}
 }
 
-impl<'a, V, W> Claim for (V, W)
+impl<V, W> Claim for (V, W)
 where
     V: Claim,
     W: Claim,

--- a/src/query/filter/seal.rs
+++ b/src/query/filter/seal.rs
@@ -26,7 +26,7 @@ where
 {
     unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
         match component_map.get(&TypeId::of::<C>()) {
-            Some(index) => key.get_unchecked(index / 8) & (1 << (index % 8)) != 0,
+            Some(index) => unsafe { key.get_unchecked(index / 8) & (1 << (index % 8)) != 0 },
             Option::None => false,
         }
     }
@@ -37,7 +37,7 @@ where
     F: Filter,
 {
     unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        !F::filter(key, component_map)
+        unsafe { !F::filter(key, component_map) }
     }
 }
 
@@ -47,7 +47,7 @@ where
     F2: Filter,
 {
     unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        F1::filter(key, component_map) && F2::filter(key, component_map)
+        unsafe { F1::filter(key, component_map) && F2::filter(key, component_map) }
     }
 }
 
@@ -57,7 +57,7 @@ where
     F2: Filter,
 {
     unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        F1::filter(key, component_map) || F2::filter(key, component_map)
+        unsafe { F1::filter(key, component_map) || F2::filter(key, component_map) }
     }
 }
 
@@ -66,7 +66,7 @@ where
     C: Component,
 {
     unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        Has::<C>::filter(key, component_map)
+        unsafe { Has::<C>::filter(key, component_map) }
     }
 }
 
@@ -75,7 +75,7 @@ where
     C: Component,
 {
     unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        Has::<C>::filter(key, component_map)
+        unsafe { Has::<C>::filter(key, component_map) }
     }
 }
 
@@ -115,6 +115,6 @@ where
     W: Views<'a>,
 {
     unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        And::<V, W>::filter(key, component_map)
+        unsafe { And::<V, W>::filter(key, component_map) }
     }
 }

--- a/src/query/filter/seal.rs
+++ b/src/query/filter/seal.rs
@@ -1,4 +1,5 @@
 use crate::{
+    archetype,
     component::Component,
     entity,
     query::{
@@ -6,16 +7,33 @@ use crate::{
         view,
         view::{View, Views},
     },
+    registry::Registry,
 };
 use core::any::TypeId;
 use hashbrown::HashMap;
 
 pub trait Seal {
-    unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool;
+    /// # Safety
+    /// `component_map` must contain an entry for the `TypeId<C>` of each component `C` in the
+    /// registry `R` corresponding to the index of that component in the archetype identifier.
+    ///
+    /// Note that the component(s) being viewed do not necessarily need to be in the registry `R`.
+    unsafe fn filter<R>(
+        identifier: archetype::IdentifierRef<R>,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry;
 }
 
 impl Seal for None {
-    unsafe fn filter(_key: &[u8], _component_map: &HashMap<TypeId, usize>) -> bool {
+    unsafe fn filter<R>(
+        _identifier: archetype::IdentifierRef<R>,
+        _component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
         true
     }
 }
@@ -24,9 +42,17 @@ impl<C> Seal for Has<C>
 where
     C: Component,
 {
-    unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
+    unsafe fn filter<R>(
+        identifier: archetype::IdentifierRef<R>,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
         match component_map.get(&TypeId::of::<C>()) {
-            Some(index) => unsafe { key.get_unchecked(index / 8) & (1 << (index % 8)) != 0 },
+            Some(&index) =>
+            // SAFETY: `index` is guaranteed to correspond to a valid component in `identifier`.
+            unsafe { identifier.get_unchecked(index) },
             Option::None => false,
         }
     }
@@ -36,8 +62,16 @@ impl<F> Seal for Not<F>
 where
     F: Filter,
 {
-    unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        unsafe { !F::filter(key, component_map) }
+    unsafe fn filter<R>(
+        identifier: archetype::IdentifierRef<R>,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
+        // SAFETY: The safety guarantees for this call are already upheld by the safety contract
+        // of this method.
+        unsafe { !F::filter(identifier, component_map) }
     }
 }
 
@@ -46,8 +80,16 @@ where
     F1: Filter,
     F2: Filter,
 {
-    unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        unsafe { F1::filter(key, component_map) && F2::filter(key, component_map) }
+    unsafe fn filter<R>(
+        identifier: archetype::IdentifierRef<R>,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
+        // SAFETY: The safety guarantees for these calls are already upheld by the safety contract
+        // of this method.
+        unsafe { F1::filter(identifier, component_map) && F2::filter(identifier, component_map) }
     }
 }
 
@@ -56,8 +98,16 @@ where
     F1: Filter,
     F2: Filter,
 {
-    unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        unsafe { F1::filter(key, component_map) || F2::filter(key, component_map) }
+    unsafe fn filter<R>(
+        identifier: archetype::IdentifierRef<R>,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
+        // SAFETY: The safety guarantees for these calls are already upheld by the safety contract
+        // of this method.
+        unsafe { F1::filter(identifier, component_map) || F2::filter(identifier, component_map) }
     }
 }
 
@@ -65,8 +115,16 @@ impl<C> Seal for &C
 where
     C: Component,
 {
-    unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        unsafe { Has::<C>::filter(key, component_map) }
+    unsafe fn filter<R>(
+        identifier: archetype::IdentifierRef<R>,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
+        // SAFETY: The safety guarantees for this call are already upheld by the safety contract
+        // of this method.
+        unsafe { Has::<C>::filter(identifier, component_map) }
     }
 }
 
@@ -74,8 +132,16 @@ impl<C> Seal for &mut C
 where
     C: Component,
 {
-    unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        unsafe { Has::<C>::filter(key, component_map) }
+    unsafe fn filter<R>(
+        identifier: archetype::IdentifierRef<R>,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
+        // SAFETY: The safety guarantees for this call are already upheld by the safety contract
+        // of this method.
+        unsafe { Has::<C>::filter(identifier, component_map) }
     }
 }
 
@@ -83,7 +149,13 @@ impl<C> Seal for Option<&C>
 where
     C: Component,
 {
-    unsafe fn filter(_key: &[u8], _component_map: &HashMap<TypeId, usize>) -> bool {
+    unsafe fn filter<R>(
+        _identifier: archetype::IdentifierRef<R>,
+        _component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
         true
     }
 }
@@ -92,19 +164,37 @@ impl<C> Seal for Option<&mut C>
 where
     C: Component,
 {
-    unsafe fn filter(_key: &[u8], _component_map: &HashMap<TypeId, usize>) -> bool {
+    unsafe fn filter<R>(
+        _identifier: archetype::IdentifierRef<R>,
+        _component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
         true
     }
 }
 
 impl Seal for entity::Identifier {
-    unsafe fn filter(_key: &[u8], _component_map: &HashMap<TypeId, usize>) -> bool {
+    unsafe fn filter<R>(
+        _identifier: archetype::IdentifierRef<R>,
+        _component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
         true
     }
 }
 
 impl Seal for view::Null {
-    unsafe fn filter(_key: &[u8], _component_map: &HashMap<TypeId, usize>) -> bool {
+    unsafe fn filter<R>(
+        _identifier: archetype::IdentifierRef<R>,
+        _component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
         true
     }
 }
@@ -114,7 +204,15 @@ where
     V: View<'a>,
     W: Views<'a>,
 {
-    unsafe fn filter(key: &[u8], component_map: &HashMap<TypeId, usize>) -> bool {
-        unsafe { And::<V, W>::filter(key, component_map) }
+    unsafe fn filter<R>(
+        identifier: archetype::IdentifierRef<R>,
+        component_map: &HashMap<TypeId, usize>,
+    ) -> bool
+    where
+        R: Registry,
+    {
+        // SAFETY: The safety guarantees for this call are already upheld by the safety contract
+        // of this method.
+        unsafe { And::<V, W>::filter(identifier, component_map) }
     }
 }

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -101,7 +101,7 @@ where
                 }
             }
             let archetype = self.archetypes_iter.find(|archetype| unsafe {
-                And::<V, F>::filter(archetype.identifier().as_slice(), self.component_map)
+                And::<V, F>::filter(archetype.identifier(), self.component_map)
             })?;
             self.current_results_iter = Some(unsafe { archetype.view::<V>() });
         }
@@ -129,8 +129,7 @@ where
         }
 
         self.archetypes_iter.fold(init, |acc, archetype| {
-            if unsafe { And::<V, F>::filter(archetype.identifier().as_slice(), self.component_map) }
-            {
+            if unsafe { And::<V, F>::filter(archetype.identifier(), self.component_map) } {
                 unsafe { archetype.view::<V>() }.fold(acc, &mut fold)
             } else {
                 acc

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -103,7 +103,7 @@ where
             let archetype = self.archetypes_iter.find(|archetype| unsafe {
                 And::<V, F>::filter(archetype.identifier().as_slice(), self.component_map)
             })?;
-            self.current_results_iter = Some(archetype.view::<V>());
+            self.current_results_iter = Some(unsafe { archetype.view::<V>() });
         }
     }
 
@@ -131,7 +131,7 @@ where
         self.archetypes_iter.fold(init, |acc, archetype| {
             if unsafe { And::<V, F>::filter(archetype.identifier().as_slice(), self.component_map) }
             {
-                archetype.view::<V>().fold(acc, &mut fold)
+                unsafe { archetype.view::<V>() }.fold(acc, &mut fold)
             } else {
                 acc
             }

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -100,10 +100,17 @@ where
                     return result;
                 }
             }
-            let archetype = self.archetypes_iter.find(|archetype| unsafe {
-                And::<V, F>::filter(archetype.identifier(), self.component_map)
+            let archetype = self.archetypes_iter.find(|archetype| {
+                // SAFETY: `self.component_map` contains an entry for each `TypeId<C>` per
+                // component `C` in the registry `R`.
+                unsafe { And::<V, F>::filter(archetype.identifier(), self.component_map) }
             })?;
-            self.current_results_iter = Some(unsafe { archetype.view::<V>() });
+            self.current_results_iter = Some(
+                // SAFETY: Each component viewed by `V` is guaranteed to be within the `archetype`,
+                // since the archetype was not removed by the `find()` method above which filters
+                // out archetypes that do not contain the viewed components.
+                unsafe { archetype.view::<V>() },
+            );
         }
     }
 
@@ -129,7 +136,12 @@ where
         }
 
         self.archetypes_iter.fold(init, |acc, archetype| {
-            if unsafe { And::<V, F>::filter(archetype.identifier(), self.component_map) } {
+            if
+            // SAFETY: `self.component_map` contains an entry for each `TypeId<C>` per component
+            // `C` in the registry `R`.
+            unsafe { And::<V, F>::filter(archetype.identifier(), self.component_map) } {
+                // SAFETY: Each component viewed by `V` is guaranteed to be within the `archetype`
+                // since the `filter` function in the if-statement returned `true`.
                 unsafe { archetype.view::<V>() }.fold(acc, &mut fold)
             } else {
                 acc

--- a/src/query/result/par_iter.rs
+++ b/src/query/result/par_iter.rs
@@ -219,7 +219,7 @@ where
     type Result = C::Result;
 
     fn consume(self, archetype: &'a mut Archetype<R>) -> Self {
-        if unsafe { And::<V, F>::filter(archetype.identifier().as_slice(), self.component_map) } {
+        if unsafe { And::<V, F>::filter(archetype.identifier(), self.component_map) } {
             let consumer = self.base.split_off_left();
             let result = unsafe { archetype.par_view::<V>() }.drive_unindexed(consumer);
 

--- a/src/query/result/par_iter.rs
+++ b/src/query/result/par_iter.rs
@@ -221,7 +221,7 @@ where
     fn consume(self, archetype: &'a mut Archetype<R>) -> Self {
         if unsafe { And::<V, F>::filter(archetype.identifier().as_slice(), self.component_map) } {
             let consumer = self.base.split_off_left();
-            let result = archetype.par_view::<V>().drive_unindexed(consumer);
+            let result = unsafe { archetype.par_view::<V>() }.drive_unindexed(consumer);
 
             let previous = match self.previous {
                 None => Some(result),

--- a/src/query/result/par_iter.rs
+++ b/src/query/result/par_iter.rs
@@ -219,9 +219,15 @@ where
     type Result = C::Result;
 
     fn consume(self, archetype: &'a mut Archetype<R>) -> Self {
-        if unsafe { And::<V, F>::filter(archetype.identifier(), self.component_map) } {
+        if
+        // SAFETY: `self.component_map` contains an entry for each `TypeId<C>` per component `C` in
+        // the registry `R`.
+        unsafe { And::<V, F>::filter(archetype.identifier(), self.component_map) } {
             let consumer = self.base.split_off_left();
-            let result = unsafe { archetype.par_view::<V>() }.drive_unindexed(consumer);
+            let result =
+                // SAFETY: Each component viewed by `V` is guaranteed to be within the `archetype`
+                // since the `filter` function in the if-statement returned `true`.
+                unsafe { archetype.par_view::<V>() }.drive_unindexed(consumer);
 
             let previous = match self.previous {
                 None => Some(result),

--- a/src/query/view/par/seal/mod.rs
+++ b/src/query/view/par/seal/mod.rs
@@ -23,6 +23,16 @@ use repeat::RepeatNone;
 pub trait ParViewSeal<'a>: View<'a> {
     type ParResult: IndexedParallelIterator;
 
+    /// # Safety
+    /// Each tuple in `columns` must contain the raw parts for a valid `Vec<C>` of size `length`
+    /// for components `C`. Each of those components `C` must have an entry in `component_map`,
+    /// paired with the correct index corresponding to that component's entry in `columns`.
+    ///
+    /// `entity_identifiers` must contain the raw parts for a valid `Vec<entity::Identifier` of
+    /// size `length`.
+    ///
+    /// `component_map` must contain an entry for every component `C` that is viewed by this
+    /// `ParView`.
     unsafe fn par_view(
         columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -36,13 +36,15 @@ where
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
-        slice::from_raw_parts::<'a, C>(
-            columns
-                .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
-                .0
-                .cast::<C>(),
-            length,
-        )
+        unsafe {
+            slice::from_raw_parts::<'a, C>(
+                columns
+                    .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
+                    .0
+                    .cast::<C>(),
+                length,
+            )
+        }
         .iter()
     }
 
@@ -63,13 +65,15 @@ where
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
-        slice::from_raw_parts_mut::<'a, C>(
-            columns
-                .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
-                .0
-                .cast::<C>(),
-            length,
-        )
+        unsafe {
+            slice::from_raw_parts_mut::<'a, C>(
+                columns
+                    .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
+                    .0
+                    .cast::<C>(),
+                length,
+            )
+        }
         .iter_mut()
     }
 
@@ -100,9 +104,11 @@ where
     ) -> Self::Result {
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
-                slice::from_raw_parts(columns.get_unchecked(*index).0.cast::<C>(), length)
-                    .iter()
-                    .map(wrap_some),
+                unsafe {
+                    slice::from_raw_parts(columns.get_unchecked(*index).0.cast::<C>(), length)
+                }
+                .iter()
+                .map(wrap_some),
             ),
             None => Either::Left(iter::repeat(None).take(length)),
         }
@@ -134,9 +140,11 @@ where
 
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
-                slice::from_raw_parts_mut(columns.get_unchecked(*index).0.cast::<C>(), length)
-                    .iter_mut()
-                    .map(wrap_some),
+                unsafe {
+                    slice::from_raw_parts_mut(columns.get_unchecked(*index).0.cast::<C>(), length)
+                }
+                .iter_mut()
+                .map(wrap_some),
             ),
             None => Either::Left(iter::repeat_with(none as fn() -> Option<&'a mut C>).take(length)),
         }
@@ -156,7 +164,7 @@ impl<'a> ViewSeal<'a> for entity::Identifier {
         length: usize,
         _component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
-        slice::from_raw_parts_mut::<'a, Self>(entity_identifiers.0, length)
+        unsafe { slice::from_raw_parts_mut::<'a, Self>(entity_identifiers.0, length) }
             .iter()
             .copied()
     }
@@ -205,12 +213,14 @@ where
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Results {
-        V::view(columns, entity_identifiers, length, component_map).zip(W::view(
-            columns,
-            entity_identifiers,
-            length,
-            component_map,
-        ))
+        unsafe {
+            V::view(columns, entity_identifiers, length, component_map).zip(W::view(
+                columns,
+                entity_identifiers,
+                length,
+                component_map,
+            ))
+        }
     }
 
     fn assert_claims(buffer: &mut AssertionBuffer) {

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -23,7 +23,9 @@ pub trait ViewSeal<'a>: Claim {
     /// size `length`.
     ///
     /// `component_map` must contain an entry for every component `C` that is viewed by this
-    /// `View`.
+    /// `View`, and that entry must contain the index for the column of type `C` in `columns`. Note
+    /// that it is not required for optionally viewed components to be contained in the
+    /// `component_map`.
     unsafe fn view(
         columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),
@@ -46,6 +48,10 @@ where
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
+        // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of size
+        // `length`. Since `component_map` contains an entry for the given component `C`'s entry in
+        // `columns`, then the column obtained here can be interpreted as a slice of type `C` of
+        // size `length`.
         unsafe {
             slice::from_raw_parts::<'a, C>(
                 columns
@@ -75,6 +81,10 @@ where
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
+        // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of size
+        // `length`. Since `component_map` contains an entry for the given component `C`'s entry in
+        // `columns`, then the column obtained here can be interpreted as a slice of type `C` of
+        // size `length`.
         unsafe {
             slice::from_raw_parts_mut::<'a, C>(
                 columns
@@ -114,6 +124,10 @@ where
     ) -> Self::Result {
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
+                // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of
+                // size `length`. Since `component_map` contains an entry for the given component
+                // `C`'s entry in `columns`, then the column obtained here can be interpreted as a
+                // slice of type `C` of size `length`.
                 unsafe {
                     slice::from_raw_parts(columns.get_unchecked(*index).0.cast::<C>(), length)
                 }
@@ -150,6 +164,10 @@ where
 
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
+                // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of
+                // size `length`. Since `component_map` contains an entry for the given component
+                // `C`'s entry in `columns`, then the column obtained here can be interpreted as a
+                // slice of type `C` of size `length`.
                 unsafe {
                     slice::from_raw_parts_mut(columns.get_unchecked(*index).0.cast::<C>(), length)
                 }
@@ -174,6 +192,8 @@ impl<'a> ViewSeal<'a> for entity::Identifier {
         length: usize,
         _component_map: &HashMap<TypeId, usize>,
     ) -> Self::Result {
+        // SAFETY: `entity_identifiers` is guaranteed to contain the raw parts for a valid
+        // `Vec<entity::Identifier>` of size `length`.
         unsafe { slice::from_raw_parts_mut::<'a, Self>(entity_identifiers.0, length) }
             .iter()
             .copied()
@@ -185,6 +205,18 @@ impl<'a> ViewSeal<'a> for entity::Identifier {
 pub trait ViewsSeal<'a>: Claim {
     type Results: Iterator;
 
+    /// # Safety
+    /// Each tuple in `columns` must contain the raw parts for a valid `Vec<C>` of size `length`
+    /// for components `C`. Each of those components `C` must have an entry in `component_map`,
+    /// paired with the correct index corresponding to that component's entry in `columns`.
+    ///
+    /// `entity_identifiers` must contain the raw parts for a valid `Vec<entity::Identifier` of
+    /// size `length`.
+    ///
+    /// `component_map` must contain an entry for every component `C` that is viewed by this
+    /// `Views`, and that entry must contain the index for the column of type `C` in `columns`. Note
+    /// that it is not required for optionally viewed components to be contained in the
+    /// `component_map`.
     unsafe fn view(
         columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),
@@ -223,6 +255,8 @@ where
         length: usize,
         component_map: &HashMap<TypeId, usize>,
     ) -> Self::Results {
+        // SAFETY: The safety guarantees of this method are the exact what are required by the
+        // safety guarantees of both `V::view()` and `W::view()`.
         unsafe {
             V::view(columns, entity_identifiers, length, component_map).zip(W::view(
                 columns,

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -14,6 +14,16 @@ use hashbrown::HashMap;
 pub trait ViewSeal<'a>: Claim {
     type Result: Iterator;
 
+    /// # Safety
+    /// Each tuple in `columns` must contain the raw parts for a valid `Vec<C>` of size `length`
+    /// for components `C`. Each of those components `C` must have an entry in `component_map`,
+    /// paired with the correct index corresponding to that component's entry in `columns`.
+    ///
+    /// `entity_identifiers` must contain the raw parts for a valid `Vec<entity::Identifier` of
+    /// size `length`.
+    ///
+    /// `component_map` must contain an entry for every component `C` that is viewed by this
+    /// `View`.
     unsafe fn view(
         columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),

--- a/src/registry/debug.rs
+++ b/src/registry/debug.rs
@@ -1,3 +1,10 @@
+//! Functions for the `Debug` implementation of `Archetype`.
+//!
+//! The `RegistryDebug` trait is implemented on any `Registry` where each `Component` implements
+//! `Debug`. It is a "public-in-private" trait, so external users can't implement it. These methods
+//! should not be considered a part of the public API. The methods are used in the implementation
+//! of `Debug` on `Archetype`.
+
 use crate::{
     archetype,
     component::Component,
@@ -10,7 +17,29 @@ use core::{
     mem::size_of,
 };
 
+/// Functions for the `Debug` implementation of `Archetype`.
+///
+/// These functions are for performing row-wise debug formatting.
 pub trait RegistryDebug: Registry {
+    /// Returns pointers to the components stored at the given index.
+    ///
+    /// This function handles the offset arithmetic required to obtain each component and stores a
+    /// byte pointer for each one in `pointers`.
+    ///
+    /// # Safety
+    /// `components` must contain the same number of values as there are set bits in the
+    /// `identifier_iter`.
+    ///
+    /// Each `(*mut u8, usize)` in `components` must be the pointer and capacity respectively of a
+    /// `Vec<C>` where `C` is the component corresponding to the set bit in `identifier_iter`.
+    ///
+    /// `index` must be within the length of each `Vec<C>` defined in `components`.
+    ///
+    /// When called externally, the `Registry` `R` provided to the method must by the same as the
+    /// `Registry` on which this method is being called.
+    ///
+    /// When called internally, the `identifier_iter` must have the same amount of bits left as
+    /// there are components remaining.
     unsafe fn extract_component_pointers<R>(
         index: usize,
         components: &[(*mut u8, usize)],
@@ -19,6 +48,28 @@ pub trait RegistryDebug: Registry {
     ) where
         R: Registry;
 
+    /// Populates a [`DebugMap`] with key-value pairs of component type name and component value
+    /// for a single row in an archetype table.
+    ///
+    /// This function is meant to be called multiple times, once for each row in an archetype
+    /// table, and is only meant to be used in debugging contexts. The type name used here is not
+    /// guaranteed to be in any specific form. Therefore, the output is not guaranteed as a part of
+    /// the public API.
+    ///
+    /// # Safety
+    /// `pointers` must contain the same number of values as there are bits set in the
+    /// `identifier_iter`.
+    ///
+    /// Each pointer in `pointers` must point to a valid properly initialized value of type `C`,
+    /// where `C` is the component corresponding to the set bit in `identiifer_iter`.
+    ///
+    /// When called externally, the `Registry` `R` provided to the method must by the same as the
+    /// `Registry` on which this method is being called.
+    ///
+    /// When called internally, the `identifier_iter` must have the same amount of bits left as
+    /// there are components remaining.
+    ///
+    /// [`DebugMap`]: core::fmt::DebugMap
     unsafe fn debug_components<'a, 'b, R>(
         pointers: &[*const u8],
         debug_map: &mut DebugMap<'a, 'b>,
@@ -61,12 +112,46 @@ where
     ) where
         R_: Registry,
     {
-        if identifier_iter.next().unwrap_unchecked() {
-            pointers.push(components.get_unchecked(0).0.add(index * size_of::<C>()));
-            components = components.get_unchecked(1..);
+        if
+        // SAFETY: `identifier_iter` is guaranteed by the safety contract of this method to
+        // return a value for every component within the registry.
+        unsafe { identifier_iter.next().unwrap_unchecked() } {
+            pointers.push(
+                // SAFETY: `components` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column. Additionally, `index` is
+                // within the bounds of each component's `Vec<C>`, so the offset will still result
+                // in a valid pointer within the allocation.
+                unsafe { components.get_unchecked(0).0.add(index * size_of::<C>()) },
+            );
+            components =
+                // SAFETY: `components` is guaranteed to have the same number of values as
+                // there set bits in `identifier_iter`. Since a bit must have been set to enter
+                // this block, there must be at least one component column.
+                unsafe { components.get_unchecked(1..) };
         }
 
-        R::extract_component_pointers(index, components, pointers, identifier_iter);
+        // SAFETY: At this point, one bit of `identifier_iter` has been consumed. There are two
+        // possibilities here: either the bit was set or it was not.
+        //
+        // If the bit was set, then the `components` slice will no longer include the first value,
+        // which means the slice will still contain the same number of pointer and capacity tuples
+        // as there are set bits in `identifier_iter`. Additionally, since the first value was
+        // removed from the slice, which corresponded to the component identified by the consumed
+        // bit, all remaining component values will still correspond to valid `Vec<C>`s identified
+        // by the remaining set bits in `identifier_iter`.
+        //
+        // If the bit was not set, then `components` is unaltered, and there are still the same
+        // number of elements as there are set bits in `identifier_iter`, which still make valid
+        // `Vec<C>`s for each `C` identified by the remaining set bits in `identifier_iter`.
+        //
+        // Furthermore, regardless of whether the bit was set or not, `R` is one component smaller
+        // than `(C, R)`, and since `identifier_iter` has had one bit consumed, it still has the
+        // same number of bits remaining as `R` has components remaining.
+        //
+        // Since each `Vec<C>` is still valid for the remaining set components, then `index` is
+        // still a valid index into those allocations.
+        unsafe { R::extract_component_pointers(index, components, pointers, identifier_iter) };
     }
 
     unsafe fn debug_components<'a, 'b, R_>(
@@ -76,11 +161,42 @@ where
     ) where
         R_: Registry,
     {
-        if identifier_iter.next().unwrap_unchecked() {
-            debug_map.entry(&type_name::<C>(), &*pointers.get_unchecked(0).cast::<C>());
-            pointers = pointers.get_unchecked(1..);
+        if
+        // SAFETY: `identifier_iter` is guaranteed by the safety contract of this method to
+        // return a value for every component within the registry.
+        unsafe { identifier_iter.next().unwrap_unchecked() } {
+            debug_map.entry(
+                &type_name::<C>(),
+                // SAFETY: Since a set bit was found, there must invariantly be at least one valid
+                // pointer within pointers which points to a properly-initialized value of the
+                // corresponding component type `C`.
+                unsafe { &*pointers.get_unchecked(0).cast::<C>() },
+            );
+            pointers =
+                // SAFETY: `pointers` is guaranteed to have the same number of values as there are 
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one valid pointer remaining.
+                unsafe {pointers.get_unchecked(1..)};
         }
 
-        R::debug_components(pointers, debug_map, identifier_iter);
+        // SAFETY: At this point, one bit of `identifier_iter` has been consumed. There are two
+        // possibilities here: either the bit was set or it was not.
+        //
+        // If the bit was set, then the `pointers` slice will no longer include the first value,
+        // which means the slice will still contain the same number of values as there are set bits
+        // in `identifier_iter`. Additionally, since the first value was removed from the slice,
+        // which corresponded to the component identified by the consumed bit, all remaining
+        // pointer values will still correspond to valid `C` component types identified by the
+        // remaining set bits in `identifier_iter`.
+        //
+        // If the bit was not set, then `pointers` is unaltered, and there are still the same
+        // number of elements as there are set bits in `identifier_iter`, which still point to
+        // valid properly-initialized values of type `C` for each remaining `C` identified by the
+        // remaining set bits in `identifier_iter`.
+        //
+        // Furthermore, regardless of whether the bit was set or not, `R` is one component smaller
+        // than `(C, R)`, and since `identifier_iter` has had one bit consumed, it still has the
+        // same number of bits remaining as `R` has components remaining.
+        unsafe { R::debug_components(pointers, debug_map, identifier_iter) };
     }
 }

--- a/src/registry/eq.rs
+++ b/src/registry/eq.rs
@@ -100,11 +100,23 @@ where
             if ManuallyDrop::new(
                 // SAFETY: The pointer, capacity, and length are guaranteed by the safety contract
                 // of this method to define a valid `Vec<C>`.
-                unsafe { Vec::from_raw_parts(component_column_a.0.cast::<C>(), length, component_column_a.1) },
+                unsafe {
+                    Vec::from_raw_parts(
+                        component_column_a.0.cast::<C>(),
+                        length,
+                        component_column_a.1,
+                    )
+                },
             ) != ManuallyDrop::new(
                 // SAFETY: The pointer, capacity, and length are guaranteed by the safety contract
                 // of this method to define a valid `Vec<C>`.
-                unsafe { Vec::from_raw_parts(component_column_b.0.cast::<C>(), length, component_column_b.1) },
+                unsafe {
+                    Vec::from_raw_parts(
+                        component_column_b.0.cast::<C>(),
+                        length,
+                        component_column_b.1,
+                    )
+                },
             ) {
                 return false;
             }
@@ -191,7 +203,9 @@ mod tests {
             (c_column_b.as_mut_ptr().cast::<u8>(), c_column_b.capacity()),
         ];
 
-        assert!(unsafe {Registry::component_eq(&components_a, &components_b, 3, identifier.iter())});
+        assert!(unsafe {
+            Registry::component_eq(&components_a, &components_b, 3, identifier.iter())
+        });
     }
 
     #[test]
@@ -221,6 +235,8 @@ mod tests {
             (c_column_b.as_mut_ptr().cast::<u8>(), c_column_b.capacity()),
         ];
 
-        assert!(!unsafe {Registry::component_eq(&components_a, &components_b, 3, identifier.iter())});
+        assert!(!unsafe {
+            Registry::component_eq(&components_a, &components_b, 3, identifier.iter())
+        });
     }
 }

--- a/src/registry/eq.rs
+++ b/src/registry/eq.rs
@@ -1,3 +1,13 @@
+//! Functions for the `PartialEq` and `Eq` implementation of `Archetype`.
+//!
+//! These traits are implemented on `Registry`s whose components implement `PartialEq` and `Eq`,
+//! allowing `Archetype`s to implement `PartialEq` and `Eq` if and only if the components of the
+//! `Registry` do.
+//!
+//! These are implemented as "public in private" traits, and therefore cannot be implemented by
+//! external users of the library. The functions defined here are not considered part of the public
+//! API.
+
 use crate::{
     archetype,
     component::Component,
@@ -6,7 +16,34 @@ use crate::{
 use alloc::vec::Vec;
 use core::mem::ManuallyDrop;
 
+/// Component-wise implementation for `PartialEq` for a `Registry`.
+///
+/// Any `Registry` whose components implement `PartialEq` will implement this trait.
+///
+/// This trait is similar to `PartialEq`, but the implementation specifically allows for recursive
+/// equality evaluation of each component column within an archetype table.
 pub trait RegistryPartialEq: Registry {
+    /// Returns whether the components in `components_a` are equal to the components in
+    /// `components_b`, where `components_a` and `components_b` are lists of pointer-capacity
+    /// tuples defining `Vec<C>`s of length `length` for each `C` component type identified by the
+    /// `identifier_iter`.
+    ///
+    /// Note that evaluation of equality of components is ultimately deferred to each component
+    /// type's `PartialEq` implementation.
+    ///
+    /// # Safety
+    /// `components_a` and `components_b` must both contain the same number of values as there are
+    /// set bits in the `identifier_iter`.
+    ///
+    /// Each `(*mut u8, usize)` in `components_a` and `components_b` must be the pointer and
+    /// capacity respectively of a `Vec<C>` of length `length` where `C` is the component
+    /// corresponding to the set bit in `identifier_iter`.
+    ///
+    /// When called externally, the `Registry` `R` provided to the method must by the same as the
+    /// `Registry` on which this method is being called.
+    ///
+    /// When called internally, the `identifier_iter` must have the same amount of bits left as
+    /// there are components remaining.
     unsafe fn component_eq<R>(
         components_a: &[(*mut u8, usize)],
         components_b: &[(*mut u8, usize)],
@@ -45,30 +82,71 @@ where
     where
         R_: Registry,
     {
-        if identifier_iter.next().unwrap_unchecked() {
-            let component_column_a = components_a.get_unchecked(0);
-            let component_column_b = components_b.get_unchecked(0);
+        if
+        // SAFETY: `identifier_iter` is guaranteed by the safety contract of this method to
+        // return a value for every component within the registry.
+        unsafe { identifier_iter.next().unwrap_unchecked() } {
+            let component_column_a =
+                // SAFETY: `components_a` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column.
+                unsafe { components_a.get_unchecked(0) };
+            let component_column_b =
+                // SAFETY: `components_b` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column.
+                unsafe { components_b.get_unchecked(0) };
 
-            if ManuallyDrop::new(Vec::from_raw_parts(
-                component_column_a.0,
-                length,
-                component_column_a.1,
-            )) != ManuallyDrop::new(Vec::from_raw_parts(
-                component_column_b.0,
-                length,
-                component_column_b.1,
-            )) {
+            if ManuallyDrop::new(
+                // SAFETY: The pointer, capacity, and length are guaranteed by the safety contract
+                // of this method to define a valid `Vec<C>`.
+                unsafe { Vec::from_raw_parts(component_column_a.0.cast::<C>(), length, component_column_a.1) },
+            ) != ManuallyDrop::new(
+                // SAFETY: The pointer, capacity, and length are guaranteed by the safety contract
+                // of this method to define a valid `Vec<C>`.
+                unsafe { Vec::from_raw_parts(component_column_b.0.cast::<C>(), length, component_column_b.1) },
+            ) {
                 return false;
             }
 
-            components_a = components_a.get_unchecked(1..);
-            components_b = components_b.get_unchecked(1..);
+            components_a =
+                // SAFETY: `components_a` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column.
+                unsafe { components_a.get_unchecked(1..) };
+            components_b =
+                // SAFETY: `components_b` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column.
+                unsafe { components_b.get_unchecked(1..) };
         }
 
-        R::component_eq(components_a, components_b, length, identifier_iter)
+        // SAFETY: At this point, one bit of `identifier_iter` has been consumed. There are two
+        // possibilities here: either the bit was set or it was not.
+        //
+        // If the bit was set, then the `components_a` and `components_b` slices will no longer
+        // include their first values, which means these slices will both still contain the same
+        // number of pointer and capacity tuples as there are set bits in `identifier_iter`.
+        // Additionally, since the first value was removed from each slice, which corresponded to
+        // the component identified by the consumed bit, all remaining component values will still
+        // correspond to valid `Vec<C>`s identified by the remaining set bits in `identifier_iter`.
+        //
+        // If the bit was not set, then `components_a` and `components_b` are unaltered, and there
+        // are still the same number of elements as there are set bits in `identifier_iter`, which
+        // still make valid `Vec<C>`s for each `C` identified by the remaining set bits in
+        // `identifier_iter`.
+        //
+        // Furthermore, regardless of whether the bit was set or not, `R` is one component smaller
+        // than `(C, R)`, and since `identifier_iter` has had one bit consumed, it still has the
+        // same number of bits remaining as `R` has components remaining.
+        unsafe { R::component_eq(components_a, components_b, length, identifier_iter) }
     }
 }
 
+/// This trait indicates that all components within a registry implement `Eq`.
+///
+/// This is needed to indicate whether an archetype can implement `Eq`, since it is generic over
+/// a heterogeneous list of components.
 pub trait RegistryEq: RegistryPartialEq {}
 
 impl RegistryEq for Null {}
@@ -78,4 +156,71 @@ where
     C: Component + Eq,
     R: RegistryEq,
 {
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RegistryPartialEq;
+    use crate::{archetype::Identifier, registry};
+    use alloc::vec;
+
+    #[test]
+    fn components_equal() {
+        #[derive(PartialEq)]
+        struct A(usize);
+        #[derive(PartialEq)]
+        struct B(bool);
+        #[derive(PartialEq)]
+        struct C;
+        type Registry = registry!(A, B, C);
+        let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
+        let mut a_column_a = vec![A(0), A(1), A(2)];
+        let mut b_column_a = vec![B(false), B(true), B(true)];
+        let mut c_column_a = vec![C, C, C];
+        let mut components_a = vec![
+            (a_column_a.as_mut_ptr().cast::<u8>(), a_column_a.capacity()),
+            (b_column_a.as_mut_ptr().cast::<u8>(), b_column_a.capacity()),
+            (c_column_a.as_mut_ptr().cast::<u8>(), c_column_a.capacity()),
+        ];
+        let mut a_column_b = vec![A(0), A(1), A(2)];
+        let mut b_column_b = vec![B(false), B(true), B(true)];
+        let mut c_column_b = vec![C, C, C];
+        let mut components_b = vec![
+            (a_column_b.as_mut_ptr().cast::<u8>(), a_column_b.capacity()),
+            (b_column_b.as_mut_ptr().cast::<u8>(), b_column_b.capacity()),
+            (c_column_b.as_mut_ptr().cast::<u8>(), c_column_b.capacity()),
+        ];
+
+        assert!(unsafe {Registry::component_eq(&components_a, &components_b, 3, identifier.iter())});
+    }
+
+    #[test]
+    fn components_not_equal() {
+        #[derive(PartialEq)]
+        struct A(usize);
+        #[derive(PartialEq)]
+        struct B(bool);
+        #[derive(PartialEq)]
+        struct C;
+        type Registry = registry!(A, B, C);
+        let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
+        let mut a_column_a = vec![A(0), A(1), A(2)];
+        let mut b_column_a = vec![B(false), B(true), B(true)];
+        let mut c_column_a = vec![C, C, C];
+        let mut components_a = vec![
+            (a_column_a.as_mut_ptr().cast::<u8>(), a_column_a.capacity()),
+            (b_column_a.as_mut_ptr().cast::<u8>(), b_column_a.capacity()),
+            (c_column_a.as_mut_ptr().cast::<u8>(), c_column_a.capacity()),
+        ];
+        let mut a_column_b = vec![A(0), A(1), A(2)];
+        let mut b_column_b = vec![B(false), B(false), B(true)];
+        let mut c_column_b = vec![C, C, C];
+        let mut components_b = vec![
+            (a_column_b.as_mut_ptr().cast::<u8>(), a_column_b.capacity()),
+            (b_column_b.as_mut_ptr().cast::<u8>(), b_column_b.capacity()),
+            (c_column_b.as_mut_ptr().cast::<u8>(), c_column_b.capacity()),
+        ];
+
+        assert!(!unsafe {Registry::component_eq(&components_a, &components_b, 3, identifier.iter())});
+    }
 }

--- a/src/registry/seal/length.rs
+++ b/src/registry/seal/length.rs
@@ -1,6 +1,14 @@
+//! Defines and implements a trait for length on a [`Registry`].
+//!
+//! [`Registry`]: crate::registry::Registry
+
 use crate::{component::Component, registry::Null};
 
+/// Defines a length for the given heterogeneous list.
 pub trait Length {
+    /// The number of components within the heterogeneous list.
+    ///
+    /// This is defined recursively at compile time.
     const LEN: usize;
 }
 
@@ -14,4 +22,28 @@ where
     R: Length,
 {
     const LEN: usize = R::LEN + 1;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Length;
+    use crate::registry;
+
+    #[test]
+    fn empty() {
+        type Registry = registry!();
+
+        assert_eq!(Registry::LEN, 0);
+    }
+
+    #[test]
+    fn non_empty() {
+        struct A;
+        struct B;
+        struct C;
+
+        type Registry = registry!(A, B, C);
+
+        assert_eq!(Registry::LEN, 3);
+    }
 }

--- a/src/registry/seal/mod.rs
+++ b/src/registry/seal/mod.rs
@@ -1,3 +1,16 @@
+//! Traits functions internal to the library.
+//!
+//! While [`Registry`] is a public trait, there are some implementation details that should be kept
+//! private. This is done using a `Seal` trait, which is technically public, but within a private
+//! module and therefore inaccessible to external users of the library.
+//!
+//! Additionally, making `Registry` a sealed trait blocks any external users from implementing it
+//! on their own types that were never intended to be `Registry`s.
+//!
+//! Nothing within this module should be considered a part of the public API.
+//!
+//! [`Registry`]: crate::registry::Registry
+
 mod assertions;
 mod length;
 mod storage;
@@ -7,6 +20,15 @@ use assertions::Assertions;
 use length::Length;
 use storage::Storage;
 
+/// A trait that is public but defined within a private module.
+///
+/// This effectively hides all function definitions, making them only usable internally within this
+/// library. Additionally, no external types can implement this trait, and therefore no external
+/// types can implement `Registry`.
+///
+/// While this trait specifically does not have any functions implemented, the traits it relies on
+/// do. See the modules where they are defined for more details on the internal functionality
+/// defined through these sealed traits.
 pub trait Seal: Assertions + Length + Storage {}
 
 impl Seal for Null {}

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -752,8 +752,8 @@ where
                 components,
                 length,
                 identifier_iter,
-            )
-        };
+            );
+        }
     }
 
     unsafe fn push_components_from_buffer_skipping_component<C_, R_>(
@@ -860,8 +860,8 @@ where
                 components,
                 length,
                 identifier_iter,
-            )
-        };
+            );
+        }
     }
 
     unsafe fn free_components<R_>(

--- a/src/registry/serde.rs
+++ b/src/registry/serde.rs
@@ -8,8 +8,21 @@ use ::serde::{de, de::SeqAccess, ser::SerializeTuple, Deserialize, Serialize};
 use alloc::{format, vec::Vec};
 use core::{any::type_name, mem::ManuallyDrop};
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 pub trait RegistrySerialize: Registry {
+    /// # Safety
+    /// `components` must contain the same number of values as there are set bits in the
+    /// `identifier_iter`.
+    ///
+    /// Each `(*mut u8, usize)` in `components` must be the pointer and capacity respectively of a
+    /// `Vec<C>` of length `length`, where `C` is the component corresponding to the set bit in
+    /// `identifier_iter`.
+    ///
+    /// When called externally, the `Registry` `R` provided to the method must by the same as the
+    /// `Registry` on which this method is being called.
+    ///
+    /// When called internally, the `identifier_iter` must have the same amount of bits left as
+    /// there are components remaining.
     unsafe fn serialize_components_by_column<R, S>(
         components: &[(*mut u8, usize)],
         length: usize,
@@ -76,15 +89,52 @@ where
         R_: Registry,
         S: SerializeTuple,
     {
-        if unsafe { identifier_iter.next().unwrap_unchecked() } {
-            let component_column = unsafe { components.get_unchecked(0) };
-            tuple.serialize_element(&SerializeColumn(&ManuallyDrop::new(unsafe {
-                Vec::<C>::from_raw_parts(component_column.0.cast::<C>(), length, component_column.1)
-            })))?;
+        if
+        // SAFETY: `identifier_iter` is guaranteed by the safety contract of this method to
+        // return a value for every component within the registry.
+        unsafe { identifier_iter.next().unwrap_unchecked() }
+        {
+            let component_column =
+                // SAFETY: `components` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column.
+                unsafe { components.get_unchecked(0) };
+            tuple.serialize_element(&SerializeColumn(&ManuallyDrop::new(
+                // SAFETY: The pointer, capacity, and length are guaranteed by the safety contract
+                // of this method to define a valid `Vec<C>`.
+                unsafe {
+                    Vec::<C>::from_raw_parts(
+                        component_column.0.cast::<C>(),
+                        length,
+                        component_column.1,
+                    )
+                },
+            )))?;
 
-            components = unsafe { components.get_unchecked(1..) };
+            components =
+                // SAFETY: `components` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column.
+                unsafe { components.get_unchecked(1..) };
         }
 
+        // SAFETY: At this point, one bit of `identifier_iter` has been consumed. There are two
+        // possibilities here: either the bit was set or it was not.
+        //
+        // If the bit was set, then the `components` slice will no longer include the first value,
+        // which means the slice will still contain the same number of pointer and capacity tuples
+        // as there are set bits in `identifier_iter`. Additionally, since the first value was
+        // removed from the slice, which corresponded to the component identified by the consumed
+        // bit, all remaining component values will still correspond to valid `Vec<C>`s identified
+        // by the remaining set bits in `identifier_iter`.
+        //
+        // If the bit was not set, then `components` is unaltered, and there are still the same
+        // number of elements as there are set bits in `identifier_iter`, which still make valid
+        // `Vec<C>`s for each `C` identified by the remaining set bits in `identifier_iter`.
+        //
+        // Furthermore, regardless of whether the bit was set or not, `R` is one component smaller
+        // than `(C, R)`, and since `identifier_iter` has had one bit consumed, it still has the
+        // same number of bits remaining as `R` has components remaining.
         unsafe { R::serialize_components_by_column(components, length, tuple, identifier_iter) }
     }
 
@@ -117,7 +167,7 @@ where
     }
 }
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 pub trait RegistryDeserialize<'de>: Registry + 'de {
     unsafe fn deserialize_components_by_column<R, V>(
         components: &mut Vec<(*mut u8, usize)>,

--- a/src/registry/serde.rs
+++ b/src/registry/serde.rs
@@ -242,7 +242,7 @@ pub trait RegistryDeserialize<'de>: Registry + 'de {
     /// `identifier_iter`.
     ///
     /// Each `(*mut u8, usize)` in `components` must be the pointer and capacity respectively of a
-    /// `Vec<C>` of length `0`, where `C` is the component corresponding to the set bit in
+    /// `Vec<C>` of size `length`, where `C` is the component corresponding to the set bit in
     /// `identifier_iter`.
     ///
     /// When called externally, the `Registry` `R` provided to the method must by the same as the
@@ -343,9 +343,13 @@ where
                 unsafe { components.get_unchecked_mut(0) };
             let mut v = ManuallyDrop::new(
                 // SAFETY: The pointer and capacity are guaranteed by the safety contract of this
-                // method to define a valid `Vec<C>` of length `0`.
+                // method to define a valid `Vec<C>` of length `length`.
                 unsafe {
-                    Vec::<C>::from_raw_parts(component_column.0.cast::<C>(), 0, component_column.1)
+                    Vec::<C>::from_raw_parts(
+                        component_column.0.cast::<C>(),
+                        length,
+                        component_column.1,
+                    )
                 },
             );
 

--- a/src/registry/serde.rs
+++ b/src/registry/serde.rs
@@ -33,6 +33,21 @@ pub trait RegistrySerialize: Registry {
         R: Registry,
         S: SerializeTuple;
 
+    /// # Safety
+    /// `index` must be less than `length`.
+    ///
+    /// `components` must contain the same number of values as there are set bits in the
+    /// `identifier_iter`.
+    ///
+    /// Each `(*mut u8, usize)` in `components` must be the pointer and capacity respectively of a
+    /// `Vec<C>` of length `length`, where `C` is the component corresponding to the set bit in
+    /// `identifier_iter`.
+    ///
+    /// When called externally, the `Registry` `R` provided to the method must by the same as the
+    /// `Registry` on which this method is being called.
+    ///
+    /// When called internally, the `identifier_iter` must have the same amount of bits left as
+    /// there are components remaining.
     unsafe fn serialize_components_by_row<R, S>(
         components: &[(*mut u8, usize)],
         length: usize,
@@ -92,8 +107,7 @@ where
         if
         // SAFETY: `identifier_iter` is guaranteed by the safety contract of this method to
         // return a value for every component within the registry.
-        unsafe { identifier_iter.next().unwrap_unchecked() }
-        {
+        unsafe { identifier_iter.next().unwrap_unchecked() } {
             let component_column =
                 // SAFETY: `components` is guaranteed to have the same number of values as there
                 // set bits in `identifier_iter`. Since a bit must have been set to enter this
@@ -149,20 +163,58 @@ where
         R_: Registry,
         S: SerializeTuple,
     {
-        if unsafe { identifier_iter.next().unwrap_unchecked() } {
-            let component_column = unsafe { components.get_unchecked(0) };
-            tuple.serialize_element(unsafe {
-                ManuallyDrop::new(Vec::<C>::from_raw_parts(
-                    component_column.0.cast::<C>(),
-                    length,
-                    component_column.1,
-                ))
-                .get_unchecked(index)
-            })?;
+        if
+        // SAFETY: `identifier_iter` is guaranteed by the safety contract of this method to
+        // return a value for every component within the registry.
+        unsafe { identifier_iter.next().unwrap_unchecked() } {
+            let component_column =
+                // SAFETY: `components` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column.
+                unsafe { components.get_unchecked(0) };
+            tuple.serialize_element(
+                // SAFETY: The pointer, capacity, and length are guaranteed by the safety contract
+                // of this method to define a valid `Vec<C>`.
+                //
+                // `index` is also guaranteed to be within the `Vec<C>`, since it is less than
+                // `length`.
+                unsafe {
+                    ManuallyDrop::new(Vec::<C>::from_raw_parts(
+                        component_column.0.cast::<C>(),
+                        length,
+                        component_column.1,
+                    ))
+                    .get_unchecked(index)
+                },
+            )?;
 
-            components = unsafe { components.get_unchecked(1..) };
+            components =
+                // SAFETY: `components` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column.
+                unsafe { components.get_unchecked(1..) };
         }
 
+        // // SAFETY: At this point, one bit of `identifier_iter` has been consumed. There are two
+        // possibilities here: either the bit was set or it was not.
+        //
+        // If the bit was set, then the `components` slice will no longer include the first value,
+        // which means the slice will still contain the same number of pointer and capacity tuples
+        // as there are set bits in `identifier_iter`. Additionally, since the first value was
+        // removed from the slice, which corresponded to the component identified by the consumed
+        // bit, all remaining component values will still correspond to valid `Vec<C>`s identified
+        // by the remaining set bits in `identifier_iter`.
+        //
+        // If the bit was not set, then `components` is unaltered, and there are still the same
+        // number of elements as there are set bits in `identifier_iter`, which still make valid
+        // `Vec<C>`s for each `C` identified by the remaining set bits in `identifier_iter`.
+        //
+        // Furthermore, regardless of whether the bit was set or not, `R` is one component smaller
+        // than `(C, R)`, and since `identifier_iter` has had one bit consumed, it still has the
+        // same number of bits remaining as `R` has components remaining.
+        //
+        // Finally, `index` is guaranteed to be less than `length` by the safety contract of this
+        // method.
         unsafe { R::serialize_components_by_row(components, length, index, tuple, identifier_iter) }
     }
 }

--- a/src/system/null.rs
+++ b/src/system/null.rs
@@ -25,6 +25,7 @@ impl<'a> System<'a> for Null {
     where
         R: Registry + 'a,
     {
+        // SAFETY: This type can never be instantiated. Therefore, this method can never be called.
         unsafe { unreachable_unchecked() }
     }
 
@@ -32,6 +33,7 @@ impl<'a> System<'a> for Null {
     where
         R: Registry,
     {
+        // SAFETY: This type can never be instantiated. Therefore, this method can never be called.
         unsafe { unreachable_unchecked() }
     }
 }
@@ -45,6 +47,7 @@ impl<'a> ParSystem<'a> for Null {
     where
         R: Registry + 'a,
     {
+        // SAFETY: This type can never be instantiated. Therefore, this method can never be called.
         unsafe { unreachable_unchecked() }
     }
 
@@ -52,6 +55,7 @@ impl<'a> ParSystem<'a> for Null {
     where
         R: Registry,
     {
+        // SAFETY: This type can never be instantiated. Therefore, this method can never be called.
         unsafe { unreachable_unchecked() }
     }
 }

--- a/src/system/schedule/stage/seal.rs
+++ b/src/system/schedule/stage/seal.rs
@@ -7,6 +7,7 @@ use crate::{
         },
         ParSystem, System,
     },
+    world::World,
 };
 
 pub trait Seal<'a>: Send {
@@ -143,11 +144,19 @@ where
     {
         match &mut self.0 {
             Stage::Start(task) => {
-                task.flush(world);
+                task.flush(
+                    // SAFETY: This is guaranteed to be the only reference to this `World<R>`,
+                    // meaning this cast to a mutable reference is sound.
+                    unsafe { &mut *(world.0 as *const World<R> as *mut World<R>) },
+                );
             }
             Stage::Continue(task) => {
                 self.1.flush(world);
-                task.flush(world);
+                task.flush(
+                    // SAFETY: This is guaranteed to be the only reference to this `World<R>`,
+                    // meaning this cast to a mutable reference is sound.
+                    unsafe { &mut *(world.0 as *const World<R> as *mut World<R>) },
+                );
             }
             Stage::Flush => {}
         }

--- a/src/system/schedule/task.rs
+++ b/src/system/schedule/task.rs
@@ -21,12 +21,15 @@ where
         match self {
             Task::Seq(system) => {
                 // Query world using system.
+                // SAFETY: The `Views` checks were already done when constructing the `Schedule`.
                 let result = unsafe { (*world.0).query_unchecked::<S::Views, S::Filter>() };
                 // Run system using the query result.
                 system.run(result);
             }
             Task::Par(system) => {
                 // Query world using system.
+                // SAFETY: The `ParViews` checks were already done when constructing the
+                // `Schedule`.
                 let result = unsafe { (*world.0).par_query_unchecked::<P::Views, P::Filter>() };
                 // Run system using the query result.
                 system.run(result);

--- a/src/system/schedule/task.rs
+++ b/src/system/schedule/task.rs
@@ -37,15 +37,13 @@ where
         }
     }
 
-    pub(crate) fn flush<R>(&mut self, world: SendableWorld<R>)
+    pub(crate) fn flush<R>(&mut self, world: &mut World<R>)
     where
         R: Registry,
     {
-        let mut_world = unsafe { &mut *(world.0 as *const World<R> as *mut World<R>) };
-
         match self {
-            Task::Seq(system) => system.world_post_processing(mut_world),
-            Task::Par(system) => system.world_post_processing(mut_world),
+            Task::Seq(system) => system.world_post_processing(world),
+            Task::Par(system) => system.world_post_processing(world),
         }
     }
 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -154,11 +154,11 @@ where
     {
         self.len += 1;
 
-        let mut key = vec![0; (R::LEN + 7) / 8];
+        let mut identifier = vec![0; (R::LEN + 7) / 8];
         unsafe {
-            E::to_key(&mut key, &self.component_map);
+            E::to_identifier(&mut identifier, &self.component_map);
         }
-        let identifier_buffer = unsafe { archetype::Identifier::new(key) };
+        let identifier_buffer = unsafe { archetype::Identifier::new(identifier) };
 
         unsafe {
             self.archetypes
@@ -193,11 +193,11 @@ where
     {
         self.len += entities.len();
 
-        let mut key = vec![0; (R::LEN + 7) / 8];
+        let mut identifier = vec![0; (R::LEN + 7) / 8];
         unsafe {
-            E::to_key(&mut key, &self.component_map);
+            E::to_identifier(&mut identifier, &self.component_map);
         }
-        let identifier_buffer = unsafe { archetype::Identifier::new(key) };
+        let identifier_buffer = unsafe { archetype::Identifier::new(identifier) };
 
         unsafe {
             self.archetypes

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -155,9 +155,13 @@ where
         self.len += 1;
 
         let mut identifier = vec![0; (R::LEN + 7) / 8];
+        // SAFETY: `identifier` is a zeroed-out allocation of `R::LEN` bits. `self.component_map`
+        // only contains `usize` values up to the number of components in the registry `R`.
         unsafe {
             E::to_identifier(&mut identifier, &self.component_map);
         }
+        // SAFETY: `identifier` is a properly-initialized buffer of `(R::LEN + 7) / 8` bytes whose
+        // bits correspond to each component in the registry `R`.
         let identifier_buffer = unsafe { archetype::Identifier::new(identifier) };
 
         unsafe {
@@ -194,9 +198,13 @@ where
         self.len += entities.len();
 
         let mut identifier = vec![0; (R::LEN + 7) / 8];
+        // SAFETY: `identifier` is a zeroed-out allocation of `R::LEN` bits. `self.component_map`
+        // only contains `usize` values up to the number of components in the registry `R`.
         unsafe {
             E::to_identifier(&mut identifier, &self.component_map);
         }
+        // SAFETY: `identifier` is a properly-initialized buffer of `(R::LEN + 7) / 8` bytes whose
+        // bits correspond to each component in the registry `R`.
         let identifier_buffer = unsafe { archetype::Identifier::new(identifier) };
 
         unsafe {
@@ -314,6 +322,10 @@ where
     }
 
     /// Performs a query, skipping checks on views.
+    ///
+    /// # Safety
+    /// The [`Views`] `V` must follow Rust's borrowing rules, meaning that a component that is
+    /// mutably borrowed is only borrowed once.
     #[cfg(feature = "parallel")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub(crate) unsafe fn query_unchecked<'a, V, F>(&'a mut self) -> result::Iter<'a, R, F, V>
@@ -325,6 +337,10 @@ where
     }
 
     /// Performs a parallel query, skipping checks on views.
+    ///
+    /// # Safety
+    /// The [`ParViews`] `V` must follow Rust's borrowing rules, meaning that a component that is
+    /// mutably borrowed is only borrowed once.
     #[cfg(feature = "parallel")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
     pub(crate) unsafe fn par_query_unchecked<'a, V, F>(&'a mut self) -> result::ParIter<'a, R, F, V>

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -164,6 +164,11 @@ where
         // bits correspond to each component in the registry `R`.
         let identifier_buffer = unsafe { archetype::Identifier::new(identifier) };
 
+        // SAFETY: Since the archetype was obtained using the `identifier_buffer` created from the
+        // entity `E`, then the entity is guaranteed to be made up of componpents identified by the
+        // archetype's identifier.
+        //
+        // `self.entity_allocator` is guaranteed to live as long as the archetype.
         unsafe {
             self.archetypes
                 .get_mut_or_insert_new(identifier_buffer)
@@ -207,6 +212,11 @@ where
         // bits correspond to each component in the registry `R`.
         let identifier_buffer = unsafe { archetype::Identifier::new(identifier) };
 
+        // SAFETY: Since the archetype was obtained using the `identifier_buffer` created from the
+        // entities `E`, then the entities are guaranteed to be made up of componpents identified
+        // by the archetype's identifier.
+        //
+        // `self.entity_allocator` is guaranteed to live as long as the archetype.
         unsafe {
             self.archetypes
                 .get_mut_or_insert_new(identifier_buffer)
@@ -599,12 +609,17 @@ where
         // Get location of entity.
         if let Some(location) = self.entity_allocator.get(entity_identifier) {
             // Remove row from Archetype.
+            // SAFETY: `self.entity_allocator` contains entries for the entities stored in this
+            // world's archetypes. Also, `location.index` is invariantly guaranteed to be a valid
+            // index in the archetype.
             unsafe {
                 self.archetypes
                     .get_unchecked_mut(location.identifier)
                     .remove_row_unchecked(location.index, &mut self.entity_allocator);
             }
             // Free slot in entity allocator.
+            // SAFETY: It was verified above that `self.entity_allocator` contains a valid slot for
+            // `entity_identifier`.
             unsafe {
                 self.entity_allocator.free_unchecked(entity_identifier);
             }
@@ -632,6 +647,8 @@ where
     /// world.clear();
     /// ```
     pub fn clear(&mut self) {
+        // SAFETY: `self.entity_allocator` contains entries for the entities stored in this world's
+        // archetypes.
         unsafe {
             self.archetypes.clear(&mut self.entity_allocator);
         }

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -2,8 +2,8 @@
 
 macro_rules! trybuild_test {
     ($test_name:ident) => {
-        #[test]
         #[rustversion::attr(not(nightly), ignore)]
+        #[test]
         fn $test_name() {
             trybuild::TestCases::new().compile_fail(concat!(
                 "tests/trybuild/",

--- a/tests/trybuild/entities/length_not_integer.stderr
+++ b/tests/trybuild/entities/length_not_integer.stderr
@@ -1,5 +1,29 @@
 error[E0308]: mismatched types
-  --> tests/trybuild/entities/length_not_integer.rs:10:38
-   |
-10 |     let entities = entities!((A, B); 1.5);
-   |                                      ^^^ expected `usize`, found floating-point number
+    --> tests/trybuild/entities/length_not_integer.rs:10:38
+     |
+10   |     let entities = entities!((A, B); 1.5);
+     |                    ------------------^^^-
+     |                    |                 |
+     |                    |                 expected `usize`, found floating-point number
+     |                    arguments to this function are incorrect
+     |
+note: function defined here
+    --> $RUST/alloc/src/vec/mod.rs
+     |
+     | pub fn from_elem<T: Clone>(elem: T, n: usize) -> Vec<T> {
+     |        ^^^^^^^^^
+
+error[E0308]: mismatched types
+    --> tests/trybuild/entities/length_not_integer.rs:10:38
+     |
+10   |     let entities = entities!((A, B); 1.5);
+     |                    ------------------^^^-
+     |                    |                 |
+     |                    |                 expected `usize`, found floating-point number
+     |                    arguments to this function are incorrect
+     |
+note: function defined here
+    --> $RUST/alloc/src/vec/mod.rs
+     |
+     | pub fn from_elem<T: Clone>(elem: T, n: usize) -> Vec<T> {
+     |        ^^^^^^^^^


### PR DESCRIPTION
This PR contains the safety audit conducted in #70. It also contains a fix to #75, fixing the `trybuild` tests. A few other things are thrown in as well; this one really took a while. Current me is cursing past me for not writing `SAFETY` comments when the code was originally written, especially considering how large and complicated this library has become.