### PR TITLE
Rename `parallel` feature to `rayon`.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: hack
-        args: build --feature-powerset --optional-deps --exclude-features parallel --exclude-features rayon --target thumbv6m-none-eabi
+        args: build --feature-powerset --optional-deps --exclude-features rayon --target thumbv6m-none-eabi
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.58.0
+          - 1.60.0
           - stable
           - beta
           - nightly
@@ -38,10 +38,11 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.58.0
+          - 1.60.0
           - stable
           - beta
           - nightly
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ serde = {version = "1.0.133", default-features = false, features = ["alloc"], op
 claim = "0.5.0"
 rustversion = "1.0.6"
 serde_test = "1.0.133"
-# Temporarily use this fork until https://github.com/dtolnay/trybuild/issues/171 is resolved.
-trybuild = {git = "https://github.com/Anders429/trybuild"}
+trybuild = "1.0.61"
 
 [features]
 rayon = ["dep:rayon", "hashbrown/rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "brood"
 version = "0.1.0"
 authors = ["Anders Evensen"]
 edition = "2021"
-rust-version = "1.58.0"
+rust-version = "1.60.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Anders429/brood"
@@ -28,8 +28,7 @@ serde = {version = "1.0.133", default-features = false, features = ["alloc"], op
 claim = "0.5.0"
 rustversion = "1.0.6"
 serde_test = "1.0.133"
-# trybuild = "1.0.61"
-trybuild = {path = "../trybuild"}
+trybuild = "1.0.61"
 
 [features]
 rayon = ["dep:rayon", "hashbrown/rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ serde = {version = "1.0.133", default-features = false, features = ["alloc"], op
 claim = "0.5.0"
 rustversion = "1.0.6"
 serde_test = "1.0.133"
-trybuild = "1.0.61"
+# Temporarily use this fork until https://github.com/dtolnay/trybuild/issues/171 is resolved.
+trybuild = {git = "https://github.com/Anders429/trybuild"}
 
 [features]
 rayon = ["dep:rayon", "hashbrown/rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,4 @@ serde_test = "1.0.133"
 trybuild = "1.0.61"
 
 [features]
-# TODO: Rename this to "rayon" when namespaced dependencies are stabilized in 1.60.0.
-parallel = ["rayon", "hashbrown/rayon"]
+rayon = ["dep:rayon", "hashbrown/rayon"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ serde = {version = "1.0.133", default-features = false, features = ["alloc"], op
 claim = "0.5.0"
 rustversion = "1.0.6"
 serde_test = "1.0.133"
-trybuild = "1.0.61"
+# trybuild = "1.0.61"
+trybuild = {path = "../trybuild"}
 
 [features]
 rayon = ["dep:rayon", "hashbrown/rayon"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov.io](https://img.shields.io/codecov/c/gh/Anders429/brood)](https://codecov.io/gh/Anders429/brood)
 [![crates.io](https://img.shields.io/crates/v/brood)](https://crates.io/crates/brood)
 [![docs.rs](https://docs.rs/brood/badge.svg)](https://docs.rs/brood)
-[![MSRV](https://img.shields.io/badge/rustc-1.58.0+-yellow.svg)](#minimum-supported-rust-version)
+[![MSRV](https://img.shields.io/badge/rustc-1.60.0+-yellow.svg)](#minimum-supported-rust-version)
 [![License](https://img.shields.io/crates/l/brood)](#license)
 
 A fast and flexible [entity component system](https://en.wikipedia.org/wiki/Entity_component_system) library.
@@ -281,7 +281,7 @@ world.run_schedule(&mut schedule);
 Note that stages are determined by the `Views` of each `System`. `System`s whose `Views` do not contain conflicting mutable borrows of components are grouped together into a single stage.
 
 ## Minimum Supported Rust Version
-This crate is guaranteed to compile on stable `rustc 1.58.0` and up.
+This crate is guaranteed to compile on stable `rustc 1.60.0` and up.
 
 ## License
 This project is licensed under either of

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use identifier::{Identifier, IdentifierRef};
 #[cfg(feature = "serde")]
 pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
 
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 use crate::query::view::ParViews;
 use crate::{
     component::Component,
@@ -245,8 +245,8 @@ where
 
     /// # Safety
     /// Each component viewed by `V` must also be identified by this archetype's `Identifier`.
-    #[cfg(feature = "parallel")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+    #[cfg(feature = "rayon")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     pub(crate) unsafe fn par_view<'a, V>(&mut self) -> V::ParResults
     where
         V: ParViews<'a>,

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -4,13 +4,13 @@ mod impl_eq;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod impl_serde;
 mod iter;
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 mod par_iter;
 
 #[cfg(feature = "serde")]
 pub(crate) use impl_serde::DeserializeArchetypes;
 pub(crate) use iter::IterMut;
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 pub(crate) use par_iter::ParIterMut;
 
 use crate::{archetype, archetype::Archetype, entity, registry::Registry};

--- a/src/archetypes/par_iter.rs
+++ b/src/archetypes/par_iter.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use hashbrown::raw::rayon::RawParIter;
 use rayon::iter::{plumbing::UnindexedConsumer, ParallelIterator};
 
-#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub(crate) struct ParIterMut<'a, R>
 where
     R: Registry,
@@ -50,7 +50,7 @@ impl<R> Archetypes<R>
 where
     R: Registry,
 {
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     pub(crate) fn par_iter_mut(&mut self) -> ParIterMut<R> {
         ParIterMut::new(
             // SAFETY: The `ParIterMut` containing this `RawIter` is guaranteed to not outlive

--- a/src/query/result/mod.rs
+++ b/src/query/result/mod.rs
@@ -44,11 +44,11 @@
 //! [`World`]: crate::world::World
 
 mod iter;
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 mod par_iter;
 
 pub use iter::Iter;
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 pub use par_iter::ParIter;
 
 use crate::{doc, hlist::define_null};

--- a/src/query/result/par_iter.rs
+++ b/src/query/result/par_iter.rs
@@ -55,7 +55,7 @@ use rayon::iter::{
 /// [`ParViews`]: crate::query::view::ParViews
 /// [`result!`]: crate::query::result!
 /// [`World`]: crate::world::World
-#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub struct ParIter<'a, R, F, V>
 where
     R: Registry,

--- a/src/query/view/assertion_buffer.rs
+++ b/src/query/view/assertion_buffer.rs
@@ -39,7 +39,7 @@ impl AssertionBuffer {
     /// It is recommended to use [`with_capacity`] if possible, as it will save allocations.
     ///
     /// [`with_capacity`]: AssertionBuffer::with_capacity()
-    #[cfg(feature = "parallel")]
+    #[cfg(feature = "rayon")]
     pub(crate) fn new() -> Self {
         Self::with_capacity(0)
     }
@@ -118,7 +118,7 @@ mod tests {
     struct A;
     struct B;
 
-    #[cfg(feature = "parallel")]
+    #[cfg(feature = "rayon")]
     #[test]
     fn new() {
         let buffer = AssertionBuffer::new();

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -45,12 +45,12 @@
 //! [`World`]: crate::world::World.
 
 mod assertion_buffer;
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 mod par;
 
 pub(crate) mod seal;
 
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 pub use par::{ParView, ParViews};
 
 pub(crate) use assertion_buffer::AssertionBuffer;

--- a/src/query/view/par/mod.rs
+++ b/src/query/view/par/mod.rs
@@ -32,7 +32,7 @@ use seal::{ParViewSeal, ParViewsSeal};
 /// [`ParSystem`]: crate::system::ParSystem
 /// [`par_query`]: crate::world::World::par_query()
 /// [`View`]: crate::query::view::View
-#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub trait ParView<'a>: Filter + ParViewSeal<'a> {}
 
 impl<'a, C> ParView<'a> for &C where C: Component + Sync {}
@@ -74,7 +74,7 @@ impl<'a> ParView<'a> for entity::Identifier {}
 /// [`ParView`]: crate::query::view::ParView
 /// [`par_query`]: crate::world::World::par_query()
 /// [`Views`]: crate::query::view::Views
-#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub trait ParViews<'a>: Filter + ParViewsSeal<'a> {}
 
 impl<'a> ParViews<'a> for Null {}

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -42,18 +42,18 @@
 //! [`System`]: crate::system::System
 //! [`World`]: crate::world::World
 
-#[cfg(feature = "parallel")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+#[cfg(feature = "rayon")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub mod schedule;
 
 mod null;
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 mod par;
 
 pub use null::Null;
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 pub use par::ParSystem;
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 #[doc(inline)]
 pub use schedule::Schedule;
 

--- a/src/system/null.rs
+++ b/src/system/null.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 use crate::system::ParSystem;
 use crate::{
     query::{filter, result, view},
@@ -38,7 +38,7 @@ impl<'a> System<'a> for Null {
     }
 }
 
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 impl<'a> ParSystem<'a> for Null {
     type Filter = filter::None;
     type Views = view::Null;

--- a/src/system/par.rs
+++ b/src/system/par.rs
@@ -49,7 +49,7 @@ use crate::{
 /// [`run`]: crate::system::ParSystem::run()
 /// [`System`]: crate::system::System
 /// [`World`]: crate::world::World
-#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub trait ParSystem<'a> {
     type Filter: Filter;
     type Views: ParViews<'a>;

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -137,7 +137,7 @@ use stage::Stages;
 /// [`schedule::Builder`]: crate::system::schedule::Builder
 /// [`Stages`]: crate::system::schedule::stage::Stages
 /// [`System`]: crate::system::System
-#[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub struct Schedule<S> {
     stages: S,
 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     registry::Registry,
     system::System,
 };
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 use crate::{
     query::view::ParViews,
     system::{schedule::stage::Stages, ParSystem, Schedule},
@@ -318,8 +318,8 @@ where
     /// [`ParViews`]: crate::query::view::ParViews
     /// [`query`]: crate::query
     /// [`query()`]: World::query()
-    #[cfg(feature = "parallel")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+    #[cfg(feature = "rayon")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     pub fn par_query<'a, V, F>(&'a mut self) -> result::ParIter<'a, R, F, V>
     where
         V: ParViews<'a>,
@@ -336,8 +336,8 @@ where
     /// # Safety
     /// The [`Views`] `V` must follow Rust's borrowing rules, meaning that a component that is
     /// mutably borrowed is only borrowed once.
-    #[cfg(feature = "parallel")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+    #[cfg(feature = "rayon")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     pub(crate) unsafe fn query_unchecked<'a, V, F>(&'a mut self) -> result::Iter<'a, R, F, V>
     where
         V: Views<'a>,
@@ -351,8 +351,8 @@ where
     /// # Safety
     /// The [`ParViews`] `V` must follow Rust's borrowing rules, meaning that a component that is
     /// mutably borrowed is only borrowed once.
-    #[cfg(feature = "parallel")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+    #[cfg(feature = "rayon")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     pub(crate) unsafe fn par_query_unchecked<'a, V, F>(&'a mut self) -> result::ParIter<'a, R, F, V>
     where
         V: ParViews<'a>,
@@ -454,8 +454,8 @@ where
     /// ```
     ///
     /// [`ParSystem`]: crate::system::ParSystem
-    #[cfg(feature = "parallel")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+    #[cfg(feature = "rayon")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     pub fn run_par_system<'a, S>(&'a mut self, par_system: &mut S)
     where
         S: ParSystem<'a>,
@@ -524,8 +524,8 @@ where
     /// ```
     ///
     /// [`Schedule`]: crate::system::Schedule
-    #[cfg(feature = "parallel")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "parallel")))]
+    #[cfg(feature = "rayon")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     pub fn run_schedule<'a, S>(&'a mut self, schedule: &mut Schedule<S>)
     where
         S: Stages<'a>,

--- a/tests/trybuild.rs
+++ b/tests/trybuild.rs
@@ -18,6 +18,6 @@ trybuild_test!(entities);
 trybuild_test!(entity);
 trybuild_test!(registry);
 trybuild_test!(result);
-#[cfg(feature = "parallel")]
+#[cfg(feature = "rayon")]
 trybuild_test!(stages);
 trybuild_test!(views);


### PR DESCRIPTION
This is now possible because of namespaced dependencies, introduced in rustc 1.60.0. 

This PR contains a temporary workaround for trybuild issue [#171](https://github.com/dtolnay/trybuild/issues/171).