### PR TITLE
Make type-only `Null`s uninstantiable.

### DIFF
--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -54,4 +54,19 @@ macro_rules! define_null {
     };
 }
 
+macro_rules! define_null_uninstantiable {
+    () => {
+        /// Represents the end of a heterogeneous list.
+        ///
+        /// This enum is used when defining heterogeneous lists. Normally, it will be provided
+        /// by a macro and the user will not have to interact directly with it. `Null` is placed at
+        /// the inner-most level of the nested tuples that make up a heterogeneous list to denote
+        /// the end of the list.
+        ///
+        /// Since this is an empty enum, it is not able to be instantiated.
+        pub enum Null {}
+    };
+}
+
 pub(crate) use define_null;
+pub(crate) use define_null_uninstantiable;

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -59,7 +59,7 @@ pub trait Filter: Seal {}
 /// ```
 ///
 /// [`Views`]: crate::query::view::Views
-pub struct None;
+pub enum None {}
 
 impl Filter for None {}
 

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -55,7 +55,9 @@ pub use par::{ParView, ParViews};
 
 pub(crate) use assertion_buffer::AssertionBuffer;
 
-use crate::{component::Component, doc, entity, hlist::define_null, query::filter::Filter};
+use crate::{
+    component::Component, doc, entity, hlist::define_null_uninstantiable, query::filter::Filter,
+};
 use seal::{ViewSeal, ViewsSeal};
 
 /// A view over a single aspect of an entity.
@@ -114,7 +116,7 @@ impl<'a, C> View<'a> for Option<&mut C> where C: Component {}
 
 impl<'a> View<'a> for entity::Identifier {}
 
-define_null!();
+define_null_uninstantiable!();
 
 /// A heterogeneous list of [`View`]s.
 ///

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -39,10 +39,10 @@ pub(crate) use eq::{RegistryEq, RegistryPartialEq};
 pub(crate) use send::RegistrySend;
 pub(crate) use sync::RegistrySync;
 
-use crate::{component::Component, hlist::define_null};
+use crate::{component::Component, hlist::define_null_uninstantiable};
 use seal::Seal;
 
-define_null!();
+define_null_uninstantiable!();
 
 /// A heterogeneous list of [`Component`]s.
 ///


### PR DESCRIPTION
This resolves #41. It uses a macro to define an uninstantiable `Null` enum for registry and view. It also makes `filter::None` uninstantiable.

I didn't use the macro for `system::Null`, since it's not actually for heterogeneous list purposes, and the macro is for defining heterogeneous list null types.