### PR TITLE
Use `fnv` instead of `ahash`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ all-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
 
 [dependencies]
-ahash = {version = "0.8.0", default-features = false, features = ["compile-time-rng"]}
 either = {version = "1.7.0", default-features = false}
+fnv = {version = "1.0.7", default-features = false}
 hashbrown = {version = "0.12.3", default-features = false, features = ["inline-more", "raw"]}
 rayon = {version = "1.5.3", optional = true}
 serde = {version = "1.0.143", default-features = false, features = ["alloc"], optional = true}

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -325,6 +325,7 @@ mod tests {
     use crate::{archetype::Identifier, registry};
     use alloc::{vec, vec::Vec};
     use core::ptr;
+    use fnv::FnvBuildHasher;
     use hashbrown::HashSet;
 
     macro_rules! create_components {
@@ -473,7 +474,7 @@ mod tests {
         let identifier_a = unsafe { buffer.as_ref() };
         let identifier_b = unsafe { buffer.as_ref() };
 
-        let mut hashset = HashSet::with_hasher(ahash::RandomState::new());
+        let mut hashset = HashSet::with_hasher(FnvBuildHasher::default());
         hashset.insert(identifier_a);
         assert!(hashset.contains(&identifier_b));
     }

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -33,6 +33,7 @@ use core::{
     mem::{ManuallyDrop, MaybeUninit},
     slice,
 };
+use fnv::FnvBuildHasher;
 use hashbrown::HashMap;
 
 pub(crate) struct Archetype<R>
@@ -45,7 +46,7 @@ where
     components: Vec<(*mut u8, usize)>,
     length: usize,
 
-    component_map: HashMap<TypeId, usize, ahash::RandomState>,
+    component_map: HashMap<TypeId, usize, FnvBuildHasher>,
 }
 
 impl<R> Archetype<R>
@@ -64,7 +65,7 @@ where
         components: Vec<(*mut u8, usize)>,
         length: usize,
     ) -> Self {
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         // SAFETY: `identifier.iter()` is generic over the same registry `R` that this associated
         // function is being called on.
         unsafe { R::create_component_map_for_identifier(&mut component_map, 0, identifier.iter()) };

--- a/src/entities/seal/storage.rs
+++ b/src/entities/seal/storage.rs
@@ -1,6 +1,7 @@
 use crate::{component::Component, entities::Null};
 use alloc::vec::Vec;
 use core::{any::TypeId, mem::ManuallyDrop};
+use fnv::FnvBuildHasher;
 use hashbrown::HashMap;
 
 pub trait Storage {
@@ -19,7 +20,7 @@ pub trait Storage {
     /// which `component_map` has an entry whose index references it.
     unsafe fn extend_components(
         self,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
         components: &mut [(*mut u8, usize)],
         length: usize,
     );
@@ -41,14 +42,14 @@ pub trait Storage {
     /// the given `component_map`.
     unsafe fn to_identifier(
         identifier: &mut [u8],
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     );
 }
 
 impl Storage for Null {
     unsafe fn extend_components(
         self,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
         _components: &mut [(*mut u8, usize)],
         _length: usize,
     ) {
@@ -56,7 +57,7 @@ impl Storage for Null {
 
     unsafe fn to_identifier(
         _identifier: &mut [u8],
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) {
     }
 }
@@ -68,7 +69,7 @@ where
 {
     unsafe fn extend_components(
         self,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
         components: &mut [(*mut u8, usize)],
         length: usize,
     ) {
@@ -106,7 +107,7 @@ where
 
     unsafe fn to_identifier(
         identifier: &mut [u8],
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) {
         let component_index = component_map.get(&TypeId::of::<C>()).unwrap();
         let index = component_index / 8;

--- a/src/entity/seal/storage.rs
+++ b/src/entity/seal/storage.rs
@@ -1,6 +1,7 @@
 use crate::{component::Component, entity::Null};
 use alloc::vec::Vec;
 use core::{any::TypeId, mem::ManuallyDrop};
+use fnv::FnvBuildHasher;
 use hashbrown::HashMap;
 
 pub trait Storage {
@@ -19,7 +20,7 @@ pub trait Storage {
     /// which `component_map` has an entry whose index references it.
     unsafe fn push_components(
         self,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
         components: &mut [(*mut u8, usize)],
         length: usize,
     );
@@ -41,14 +42,14 @@ pub trait Storage {
     /// the given `component_map`.
     unsafe fn to_identifier(
         identifier: &mut [u8],
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     );
 }
 
 impl Storage for Null {
     unsafe fn push_components(
         self,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
         _components: &mut [(*mut u8, usize)],
         _length: usize,
     ) {
@@ -56,7 +57,7 @@ impl Storage for Null {
 
     unsafe fn to_identifier(
         _identifier: &mut [u8],
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) {
     }
 }
@@ -68,7 +69,7 @@ where
 {
     unsafe fn push_components(
         self,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
         components: &mut [(*mut u8, usize)],
         length: usize,
     ) {
@@ -97,7 +98,7 @@ where
 
     unsafe fn to_identifier(
         identifier: &mut [u8],
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) {
         let component_index = component_map.get(&TypeId::of::<C>()).unwrap();
         let index = component_index / 8;

--- a/src/query/claim.rs
+++ b/src/query/claim.rs
@@ -1,11 +1,12 @@
 use crate::{component::Component, entity, query::view};
 use core::any::TypeId;
+use fnv::FnvBuildHasher;
 use hashbrown::HashSet;
 
 pub trait Claim {
     fn claim(
-        mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
+        mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
     );
 }
 
@@ -14,8 +15,8 @@ where
     C: Component,
 {
     fn claim(
-        _mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
+        _mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
     ) {
         immutable_claims.insert(TypeId::of::<C>());
     }
@@ -26,8 +27,8 @@ where
     C: Component,
 {
     fn claim(
-        mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        _immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
+        mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        _immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
     ) {
         mutable_claims.insert(TypeId::of::<C>());
     }
@@ -38,8 +39,8 @@ where
     C: Component,
 {
     fn claim(
-        _mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
+        _mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
     ) {
         immutable_claims.insert(TypeId::of::<C>());
     }
@@ -50,8 +51,8 @@ where
     C: Component,
 {
     fn claim(
-        mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        _immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
+        mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        _immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
     ) {
         mutable_claims.insert(TypeId::of::<C>());
     }
@@ -59,16 +60,16 @@ where
 
 impl Claim for entity::Identifier {
     fn claim(
-        _mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        _immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
+        _mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        _immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
     ) {
     }
 }
 
 impl Claim for view::Null {
     fn claim(
-        _mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        _immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
+        _mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        _immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
     ) {
     }
 }
@@ -79,8 +80,8 @@ where
     W: Claim,
 {
     fn claim(
-        mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
+        mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
     ) {
         V::claim(mutable_claims, immutable_claims);
         W::claim(mutable_claims, immutable_claims);

--- a/src/query/filter/seal.rs
+++ b/src/query/filter/seal.rs
@@ -10,6 +10,7 @@ use crate::{
     registry::Registry,
 };
 use core::any::TypeId;
+use fnv::FnvBuildHasher;
 use hashbrown::HashMap;
 
 pub trait Seal {
@@ -20,7 +21,7 @@ pub trait Seal {
     /// Note that the component(s) being viewed do not necessarily need to be in the registry `R`.
     unsafe fn filter<R>(
         identifier: archetype::IdentifierRef<R>,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry;
@@ -29,7 +30,7 @@ pub trait Seal {
 impl Seal for None {
     unsafe fn filter<R>(
         _identifier: archetype::IdentifierRef<R>,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -44,7 +45,7 @@ where
 {
     unsafe fn filter<R>(
         identifier: archetype::IdentifierRef<R>,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -64,7 +65,7 @@ where
 {
     unsafe fn filter<R>(
         identifier: archetype::IdentifierRef<R>,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -82,7 +83,7 @@ where
 {
     unsafe fn filter<R>(
         identifier: archetype::IdentifierRef<R>,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -100,7 +101,7 @@ where
 {
     unsafe fn filter<R>(
         identifier: archetype::IdentifierRef<R>,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -117,7 +118,7 @@ where
 {
     unsafe fn filter<R>(
         identifier: archetype::IdentifierRef<R>,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -134,7 +135,7 @@ where
 {
     unsafe fn filter<R>(
         identifier: archetype::IdentifierRef<R>,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -151,7 +152,7 @@ where
 {
     unsafe fn filter<R>(
         _identifier: archetype::IdentifierRef<R>,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -166,7 +167,7 @@ where
 {
     unsafe fn filter<R>(
         _identifier: archetype::IdentifierRef<R>,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -178,7 +179,7 @@ where
 impl Seal for entity::Identifier {
     unsafe fn filter<R>(
         _identifier: archetype::IdentifierRef<R>,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -190,7 +191,7 @@ impl Seal for entity::Identifier {
 impl Seal for view::Null {
     unsafe fn filter<R>(
         _identifier: archetype::IdentifierRef<R>,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,
@@ -206,7 +207,7 @@ where
 {
     unsafe fn filter<R>(
         identifier: archetype::IdentifierRef<R>,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> bool
     where
         R: Registry,

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -7,6 +7,7 @@ use crate::{
     registry::Registry,
 };
 use core::{any::TypeId, iter::FusedIterator, marker::PhantomData};
+use fnv::FnvBuildHasher;
 use hashbrown::HashMap;
 
 /// An [`Iterator`] over the results of a query.
@@ -57,7 +58,7 @@ where
 
     current_results_iter: Option<V::Results>,
 
-    component_map: &'a HashMap<TypeId, usize, ahash::RandomState>,
+    component_map: &'a HashMap<TypeId, usize, FnvBuildHasher>,
 
     filter: PhantomData<F>,
 }
@@ -70,7 +71,7 @@ where
 {
     pub(crate) fn new(
         archetypes_iter: archetypes::IterMut<'a, R>,
-        component_map: &'a HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &'a HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self {
         Self {
             archetypes_iter,

--- a/src/query/result/par_iter.rs
+++ b/src/query/result/par_iter.rs
@@ -8,6 +8,7 @@ use crate::{
     registry::Registry,
 };
 use core::{any::TypeId, marker::PhantomData};
+use fnv::FnvBuildHasher;
 use hashbrown::HashMap;
 use rayon::iter::{
     plumbing::{Consumer, Folder, Reducer, UnindexedConsumer},
@@ -64,7 +65,7 @@ where
 {
     archetypes_iter: archetypes::ParIterMut<'a, R>,
 
-    component_map: &'a HashMap<TypeId, usize, ahash::RandomState>,
+    component_map: &'a HashMap<TypeId, usize, FnvBuildHasher>,
 
     filter: PhantomData<F>,
     views: PhantomData<V>,
@@ -78,7 +79,7 @@ where
 {
     pub(crate) fn new(
         archetypes_iter: archetypes::ParIterMut<'a, R>,
-        component_map: &'a HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &'a HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self {
         Self {
             archetypes_iter,
@@ -130,14 +131,14 @@ where
 
 struct ResultsConsumer<'a, C, F, V> {
     base: C,
-    component_map: &'a HashMap<TypeId, usize, ahash::RandomState>,
+    component_map: &'a HashMap<TypeId, usize, FnvBuildHasher>,
 
     filter: PhantomData<F>,
     views: PhantomData<V>,
 }
 
 impl<'a, C, F, V> ResultsConsumer<'a, C, F, V> {
-    fn new(base: C, component_map: &'a HashMap<TypeId, usize, ahash::RandomState>) -> Self {
+    fn new(base: C, component_map: &'a HashMap<TypeId, usize, FnvBuildHasher>) -> Self {
         Self {
             base,
             component_map,
@@ -210,7 +211,7 @@ where
 
 struct ResultsFolder<'a, C, P, F, V> {
     base: C,
-    component_map: &'a HashMap<TypeId, usize, ahash::RandomState>,
+    component_map: &'a HashMap<TypeId, usize, FnvBuildHasher>,
     previous: Option<P>,
 
     filter: PhantomData<F>,

--- a/src/query/view/assertion_buffer.rs
+++ b/src/query/view/assertion_buffer.rs
@@ -9,6 +9,7 @@
 
 use crate::component::Component;
 use core::any::{type_name, TypeId};
+use fnv::FnvBuildHasher;
 use hashbrown::HashSet;
 
 /// A buffer for performing assertions on [`Views`].
@@ -28,9 +29,9 @@ use hashbrown::HashSet;
 /// [`Views`]: crate::query::view::Views
 pub struct AssertionBuffer {
     /// Components that are viewed mutably.
-    mutable_claims: HashSet<TypeId, ahash::RandomState>,
+    mutable_claims: HashSet<TypeId, FnvBuildHasher>,
     /// Components that are viewed immutably.
-    immutable_claims: HashSet<TypeId, ahash::RandomState>,
+    immutable_claims: HashSet<TypeId, FnvBuildHasher>,
 }
 
 impl AssertionBuffer {
@@ -55,10 +56,10 @@ impl AssertionBuffer {
     /// [`World`]: crate::world::World
     pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self {
-            mutable_claims: HashSet::with_capacity_and_hasher(capacity, ahash::RandomState::new()),
+            mutable_claims: HashSet::with_capacity_and_hasher(capacity, FnvBuildHasher::default()),
             immutable_claims: HashSet::with_capacity_and_hasher(
                 capacity,
-                ahash::RandomState::new(),
+                FnvBuildHasher::default(),
             ),
         }
     }

--- a/src/query/view/par/seal/mod.rs
+++ b/src/query/view/par/seal/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     },
 };
 use core::any::TypeId;
+use fnv::FnvBuildHasher;
 use hashbrown::HashMap;
 use rayon::{
     iter,
@@ -39,7 +40,7 @@ pub trait ParViewSeal<'a>: View<'a> {
         columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::ParResult;
 }
 
@@ -53,7 +54,7 @@ where
         columns: &[(*mut u8, usize)],
         _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::ParResult {
         // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of size
         // `length`. Since `component_map` contains an entry for the given component `C`'s entry in
@@ -82,7 +83,7 @@ where
         columns: &[(*mut u8, usize)],
         _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::ParResult {
         // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of size
         // `length`. Since `component_map` contains an entry for the given component `C`'s entry in
@@ -119,7 +120,7 @@ where
         columns: &[(*mut u8, usize)],
         _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::ParResult {
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
@@ -151,7 +152,7 @@ where
         columns: &[(*mut u8, usize)],
         _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::ParResult {
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
@@ -180,7 +181,7 @@ impl<'a> ParViewSeal<'a> for entity::Identifier {
         _columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::ParResult {
         // SAFETY: `entity_identifiers` is guaranteed to contain the raw parts for a valid
         // `Vec<entity::Identifier>` of size `length`.
@@ -209,7 +210,7 @@ pub trait ParViewsSeal<'a>: Views<'a> {
         columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::ParResults;
 }
 
@@ -220,7 +221,7 @@ impl<'a> ParViewsSeal<'a> for Null {
         _columns: &[(*mut u8, usize)],
         _entity_identifiers: (*mut entity::Identifier, usize),
         _length: usize,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::ParResults {
         iter::repeatn(result::Null, usize::MAX)
     }
@@ -237,7 +238,7 @@ where
         columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::ParResults {
         // SAFETY: The safety guarantees of this method are the exact what are required by the
         // safety guarantees of both `V::par_view()` and `W::par_view()`.

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use core::{any::TypeId, iter, slice};
 use either::Either;
+use fnv::FnvBuildHasher;
 use hashbrown::HashMap;
 
 pub trait ViewSeal<'a>: Claim {
@@ -30,7 +31,7 @@ pub trait ViewSeal<'a>: Claim {
         columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Result;
 
     fn assert_claim(buffer: &mut AssertionBuffer);
@@ -46,7 +47,7 @@ where
         columns: &[(*mut u8, usize)],
         _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Result {
         // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of size
         // `length`. Since `component_map` contains an entry for the given component `C`'s entry in
@@ -79,7 +80,7 @@ where
         columns: &[(*mut u8, usize)],
         _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Result {
         // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of size
         // `length`. Since `component_map` contains an entry for the given component `C`'s entry in
@@ -120,7 +121,7 @@ where
         columns: &[(*mut u8, usize)],
         _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Result {
         match component_map.get(&TypeId::of::<C>()) {
             Some(index) => Either::Right(
@@ -156,7 +157,7 @@ where
         columns: &[(*mut u8, usize)],
         _entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Result {
         fn none<'a, C>() -> Option<&'a mut C> {
             None
@@ -190,7 +191,7 @@ impl<'a> ViewSeal<'a> for entity::Identifier {
         _columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Result {
         // SAFETY: `entity_identifiers` is guaranteed to contain the raw parts for a valid
         // `Vec<entity::Identifier>` of size `length`.
@@ -221,7 +222,7 @@ pub trait ViewsSeal<'a>: Claim {
         columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Results;
 
     fn assert_claims(buffer: &mut AssertionBuffer);
@@ -234,7 +235,7 @@ impl<'a> ViewsSeal<'a> for Null {
         _columns: &[(*mut u8, usize)],
         _entity_identifiers: (*mut entity::Identifier, usize),
         _length: usize,
-        _component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Results {
         iter::repeat(result::Null)
     }
@@ -253,7 +254,7 @@ where
         columns: &[(*mut u8, usize)],
         entity_identifiers: (*mut entity::Identifier, usize),
         length: usize,
-        component_map: &HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Results {
         // SAFETY: The safety guarantees of this method are the exact what are required by the
         // safety guarantees of both `V::view()` and `W::view()`.

--- a/src/registry/seal/assertions.rs
+++ b/src/registry/seal/assertions.rs
@@ -8,6 +8,7 @@
 
 use crate::{component::Component, registry::Null};
 use core::any::TypeId;
+use fnv::FnvBuildHasher;
 use hashbrown::HashSet;
 
 /// Assertions that can be run on a registry to verify that certain invariants are upheld.
@@ -20,11 +21,11 @@ pub trait Assertions {
     /// registry code internally is sound.
     ///
     /// [`World`]: crate::world::World
-    fn assert_no_duplicates(components: &mut HashSet<TypeId, ahash::RandomState>);
+    fn assert_no_duplicates(components: &mut HashSet<TypeId, FnvBuildHasher>);
 }
 
 impl Assertions for Null {
-    fn assert_no_duplicates(_components: &mut HashSet<TypeId, ahash::RandomState>) {}
+    fn assert_no_duplicates(_components: &mut HashSet<TypeId, FnvBuildHasher>) {}
 }
 
 impl<C, R> Assertions for (C, R)
@@ -32,7 +33,7 @@ where
     C: Component,
     R: Assertions,
 {
-    fn assert_no_duplicates(components: &mut HashSet<TypeId, ahash::RandomState>) {
+    fn assert_no_duplicates(components: &mut HashSet<TypeId, FnvBuildHasher>) {
         assert!(components.insert(TypeId::of::<C>()));
         R::assert_no_duplicates(components);
     }
@@ -42,6 +43,7 @@ where
 mod tests {
     use super::Assertions;
     use crate::registry;
+    use fnv::FnvBuildHasher;
     use hashbrown::HashSet;
 
     struct A;
@@ -52,14 +54,14 @@ mod tests {
     fn no_duplicates() {
         type NoDuplicates = registry!(A, B, C);
 
-        NoDuplicates::assert_no_duplicates(&mut HashSet::with_hasher(ahash::RandomState::new()));
+        NoDuplicates::assert_no_duplicates(&mut HashSet::with_hasher(FnvBuildHasher::default()));
     }
 
     #[test]
     fn empty_no_duplicates() {
         type Empty = registry!();
 
-        Empty::assert_no_duplicates(&mut HashSet::with_hasher(ahash::RandomState::new()));
+        Empty::assert_no_duplicates(&mut HashSet::with_hasher(FnvBuildHasher::default()));
     }
 
     #[test]
@@ -67,6 +69,6 @@ mod tests {
     fn has_duplicates() {
         type HasDuplicates = registry!(A, B, A, C);
 
-        HasDuplicates::assert_no_duplicates(&mut HashSet::with_hasher(ahash::RandomState::new()));
+        HasDuplicates::assert_no_duplicates(&mut HashSet::with_hasher(FnvBuildHasher::default()));
     }
 }

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -25,6 +25,7 @@ use core::{
     mem::{drop, size_of, ManuallyDrop, MaybeUninit},
     ptr,
 };
+use fnv::FnvBuildHasher;
 use hashbrown::HashMap;
 
 pub trait Storage {
@@ -32,7 +33,7 @@ pub trait Storage {
     ///
     /// [`TypeId`]: core::any::TypeId
     fn create_component_map(
-        component_map: &mut HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &mut HashMap<TypeId, usize, FnvBuildHasher>,
         index: usize,
     );
 
@@ -48,7 +49,7 @@ pub trait Storage {
     ///
     /// [`TypeId`]: core::any::TypeId
     unsafe fn create_component_map_for_identifier<R>(
-        component_map: &mut HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &mut HashMap<TypeId, usize, FnvBuildHasher>,
         index: usize,
         identifier_iter: archetype::identifier::Iter<R>,
     ) where
@@ -333,13 +334,13 @@ pub trait Storage {
 
 impl Storage for Null {
     fn create_component_map(
-        _component_map: &mut HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &mut HashMap<TypeId, usize, FnvBuildHasher>,
         _index: usize,
     ) {
     }
 
     unsafe fn create_component_map_for_identifier<R>(
-        _component_map: &mut HashMap<TypeId, usize, ahash::RandomState>,
+        _component_map: &mut HashMap<TypeId, usize, FnvBuildHasher>,
         _index: usize,
         _identifier_iter: archetype::identifier::Iter<R>,
     ) where
@@ -452,7 +453,7 @@ where
     R: Storage,
 {
     fn create_component_map(
-        component_map: &mut HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &mut HashMap<TypeId, usize, FnvBuildHasher>,
         index: usize,
     ) {
         component_map.insert(TypeId::of::<C>(), index);
@@ -460,7 +461,7 @@ where
     }
 
     unsafe fn create_component_map_for_identifier<R_>(
-        component_map: &mut HashMap<TypeId, usize, ahash::RandomState>,
+        component_map: &mut HashMap<TypeId, usize, FnvBuildHasher>,
         mut index: usize,
         mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
@@ -1068,13 +1069,14 @@ mod tests {
         marker::PhantomData,
         mem::{size_of, ManuallyDrop, MaybeUninit},
     };
+    use fnv::FnvBuildHasher;
     use hashbrown::HashMap;
 
     #[test]
     fn create_component_map_for_empty_registry() {
         type Registry = registry!();
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         Registry::create_component_map(&mut component_map, 0);
 
         assert!(component_map.is_empty());
@@ -1087,7 +1089,7 @@ mod tests {
         struct C;
         type Registry = registry!(A, B, C);
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         Registry::create_component_map(&mut component_map, 0);
 
         assert_some_eq!(component_map.get(&TypeId::of::<A>()), &0);
@@ -1102,7 +1104,7 @@ mod tests {
         struct C;
         type Registry = registry!(A, B, C);
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         Registry::create_component_map(&mut component_map, 42);
 
         assert_some_eq!(component_map.get(&TypeId::of::<A>()), &42);
@@ -1118,7 +1120,7 @@ mod tests {
         struct C;
         type Registry = registry!(A, B, C);
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         Registry::create_component_map(&mut component_map, usize::MAX);
     }
 
@@ -1127,7 +1129,7 @@ mod tests {
         type Registry = registry!();
         let identifier = unsafe { Identifier::<Registry>::new(Vec::new()) };
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         unsafe {
             Registry::create_component_map_for_identifier(&mut component_map, 0, identifier.iter())
         };
@@ -1143,7 +1145,7 @@ mod tests {
         type Registry = registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         unsafe {
             Registry::create_component_map_for_identifier(&mut component_map, 0, identifier.iter())
         };
@@ -1161,7 +1163,7 @@ mod tests {
         type Registry = registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![3]) };
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         unsafe {
             Registry::create_component_map_for_identifier(&mut component_map, 0, identifier.iter())
         };
@@ -1179,7 +1181,7 @@ mod tests {
         type Registry = registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![0]) };
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         unsafe {
             Registry::create_component_map_for_identifier(&mut component_map, 0, identifier.iter())
         };
@@ -1197,7 +1199,7 @@ mod tests {
         type Registry = registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![5]) };
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         unsafe {
             Registry::create_component_map_for_identifier(&mut component_map, 42, identifier.iter())
         };
@@ -1216,7 +1218,7 @@ mod tests {
         type Registry = registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![5]) };
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         unsafe {
             Registry::create_component_map_for_identifier(
                 &mut component_map,

--- a/src/system/schedule/builder.rs
+++ b/src/system/schedule/builder.rs
@@ -11,6 +11,7 @@ use crate::{
         ParSystem, System,
     },
 };
+use fnv::FnvBuildHasher;
 use hashbrown::HashSet;
 
 /// A [`Schedule`] builder.
@@ -137,10 +138,10 @@ where
     pub fn build(self) -> Schedule<T::Stages> {
         Schedule {
             stages: self.raw_tasks.into_stages(
-                &mut HashSet::with_hasher(ahash::RandomState::new()),
-                &mut HashSet::with_hasher(ahash::RandomState::new()),
-                &mut HashSet::with_hasher(ahash::RandomState::new()),
-                &mut HashSet::with_hasher(ahash::RandomState::new()),
+                &mut HashSet::with_hasher(FnvBuildHasher::default()),
+                &mut HashSet::with_hasher(FnvBuildHasher::default()),
+                &mut HashSet::with_hasher(FnvBuildHasher::default()),
+                &mut HashSet::with_hasher(FnvBuildHasher::default()),
                 &mut view::AssertionBuffer::new(),
             ),
         }

--- a/src/system/schedule/raw_task/seal.rs
+++ b/src/system/schedule/raw_task/seal.rs
@@ -10,6 +10,7 @@ use crate::{
     },
 };
 use core::any::TypeId;
+use fnv::FnvBuildHasher;
 use hashbrown::HashSet;
 
 pub trait Seal<'a> {
@@ -17,10 +18,10 @@ pub trait Seal<'a> {
 
     fn into_stages(
         self,
-        mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        mutable_buffer: &mut HashSet<TypeId, ahash::RandomState>,
-        immutable_buffer: &mut HashSet<TypeId, ahash::RandomState>,
+        mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        mutable_buffer: &mut HashSet<TypeId, FnvBuildHasher>,
+        immutable_buffer: &mut HashSet<TypeId, FnvBuildHasher>,
         view_assertion_buffer: &mut view::AssertionBuffer,
     ) -> Self::Stages;
 }
@@ -30,10 +31,10 @@ impl<'a> Seal<'a> for Null {
 
     fn into_stages(
         self,
-        _mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        _immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        _mutable_buffer: &mut HashSet<TypeId, ahash::RandomState>,
-        _immutable_buffer: &mut HashSet<TypeId, ahash::RandomState>,
+        _mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        _immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        _mutable_buffer: &mut HashSet<TypeId, FnvBuildHasher>,
+        _immutable_buffer: &mut HashSet<TypeId, FnvBuildHasher>,
         _view_assertion_buffer: &mut view::AssertionBuffer,
     ) -> Self::Stages {
         stage::Null
@@ -50,10 +51,10 @@ where
 
     fn into_stages(
         self,
-        mutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        immutable_claims: &mut HashSet<TypeId, ahash::RandomState>,
-        mutable_buffer: &mut HashSet<TypeId, ahash::RandomState>,
-        immutable_buffer: &mut HashSet<TypeId, ahash::RandomState>,
+        mutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        immutable_claims: &mut HashSet<TypeId, FnvBuildHasher>,
+        mutable_buffer: &mut HashSet<TypeId, FnvBuildHasher>,
+        immutable_buffer: &mut HashSet<TypeId, FnvBuildHasher>,
         view_assertion_buffer: &mut view::AssertionBuffer,
     ) -> Self::Stages {
         let prev_stages = self.1.into_stages(
@@ -68,8 +69,8 @@ where
             RawTask::Task(task) => {
                 // Helper function to check whether the intersection betwen two sets is nonempty.
                 fn intersects(
-                    a: &HashSet<TypeId, ahash::RandomState>,
-                    b: &HashSet<TypeId, ahash::RandomState>,
+                    a: &HashSet<TypeId, FnvBuildHasher>,
+                    b: &HashSet<TypeId, FnvBuildHasher>,
                 ) -> bool {
                     a.intersection(b).next().is_some()
                 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -34,6 +34,7 @@ use crate::{
 };
 use alloc::{vec, vec::Vec};
 use core::any::TypeId;
+use fnv::FnvBuildHasher;
 use hashbrown::{HashMap, HashSet};
 
 /// A container of entities.
@@ -75,7 +76,7 @@ where
     entity_allocator: entity::Allocator<R>,
     len: usize,
 
-    component_map: HashMap<TypeId, usize, ahash::RandomState>,
+    component_map: HashMap<TypeId, usize, FnvBuildHasher>,
 
     view_assertion_buffer: view::AssertionBuffer,
 }
@@ -91,10 +92,10 @@ where
     ) -> Self {
         R::assert_no_duplicates(&mut HashSet::with_capacity_and_hasher(
             R::LEN,
-            ahash::RandomState::new(),
+            FnvBuildHasher::default(),
         ));
 
-        let mut component_map = HashMap::with_hasher(ahash::RandomState::new());
+        let mut component_map = HashMap::with_hasher(FnvBuildHasher::default());
         R::create_component_map(&mut component_map, 0);
 
         Self {


### PR DESCRIPTION
Resolves #86. This reduces the dependency tree quite a bit, since randomness is not actually needed. All of the hashing is done internally, unrelated to user input, so HashDoS attacks are not a concern. See #86 for more details on the reasoning behind this.