### PR TITLE
Disable rayon feature in valgrind workflow.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -198,7 +198,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: hack
-        args: valgrind test --feature-powerset --optional-deps
+        args: valgrind test --feature-powerset --optional-deps --exclude-features rayon
       env:
         RUSTFLAGS: --cfg skip_trybuild
 


### PR DESCRIPTION
It seems that `rayon` leaks this memory intentionally. It's not a bad leak, but I'm just going to disable the valgrind run over `rayon` for now, similar to how we disable the `trybuild` tests for valgrind and miri.

The valgrind tests really are there to ensure that memory is being freed correctly from the `World`, which is still being checked, since that freeing has nothing to do with the `rayon` feature.