### PR TITLE
Expand entry API.

### DIFF
--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -271,10 +271,10 @@ where
     }
 
     /// View a single entity in this archetype without doing bounds checking.
-    /// 
+    ///
     /// # Safety
     /// Each component viewed by `V` must also be identified by this archetype's `Identifier`.
-    /// 
+    ///
     /// The index `index` must be a valid index into this archetype.
     pub(crate) unsafe fn view_row_unchecked<'a, V>(
         &mut self,

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -74,8 +74,24 @@ where
         }
     }
 
+    /// Returns a reference to the `Archetype` identified by the given identifier.
+    /// 
+    /// If no `Archetype` exists for the identifier, `None` is returned.
     pub(crate) fn get(&self, identifier: archetype::IdentifierRef<R>) -> Option<&Archetype<R>> {
         self.raw_archetypes.get(
+            Self::make_hash(identifier, &self.hash_builder),
+            Self::equivalent_identifier(identifier),
+        )
+    }
+
+    /// Returns a mutable reference to the `Archetype` identified by the given identifier.
+    /// 
+    /// If no `Archetype` exists for the identifier, `None` is returned.
+    pub(crate) fn get_mut(
+        &mut self,
+        identifier: archetype::IdentifierRef<R>,
+    ) -> Option<&mut Archetype<R>> {
+        self.raw_archetypes.get_mut(
             Self::make_hash(identifier, &self.hash_builder),
             Self::equivalent_identifier(identifier),
         )

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -75,7 +75,7 @@ where
     }
 
     /// Returns a reference to the `Archetype` identified by the given identifier.
-    /// 
+    ///
     /// If no `Archetype` exists for the identifier, `None` is returned.
     pub(crate) fn get(&self, identifier: archetype::IdentifierRef<R>) -> Option<&Archetype<R>> {
         self.raw_archetypes.get(
@@ -85,7 +85,7 @@ where
     }
 
     /// Returns a mutable reference to the `Archetype` identified by the given identifier.
-    /// 
+    ///
     /// If no `Archetype` exists for the identifier, `None` is returned.
     pub(crate) fn get_mut(
         &mut self,

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -35,7 +35,7 @@ pub trait ViewSeal<'a>: Claim {
     ) -> Self::Result;
 
     /// View a specific row of an `Archetype`.
-    /// 
+    ///
     /// # Safety
     /// Each tuple in `columns` must contain the raw parts for a valid `Vec<C>` of size `length`
     /// for components `C`. Each of those components `C` must have an entry in `component_map`,
@@ -48,7 +48,7 @@ pub trait ViewSeal<'a>: Claim {
     /// `View`, and that entry must contain the index for the column of type `C` in `columns`. Note
     /// that it is not required for optionally viewed components to be contained in the
     /// `component_map`.
-    /// 
+    ///
     /// `index` must be a valid index in the `Vec<entity::Identifier>` and each component column
     /// `Vec<C>`.
     unsafe fn view_one(
@@ -333,8 +333,8 @@ impl<'a> ViewSeal<'a> for entity::Identifier {
         // SAFETY: `entity_identifiers` is guaranteed to contain the raw parts for a valid
         // `Vec<entity::Identifier>` of size `length`. `index` is guaranteed to be a valid index
         // into the `Vec<entity::Identifier>`.
-        *unsafe { slice::from_raw_parts_mut::<'a, Self>(entity_identifiers.0, length) 
-            .get_unchecked(index)
+        *unsafe {
+            slice::from_raw_parts_mut::<'a, Self>(entity_identifiers.0, length).get_unchecked(index)
         }
     }
 
@@ -364,7 +364,7 @@ pub trait ViewsSeal<'a>: Claim {
     ) -> Self::Results;
 
     /// View a specific row of an `Archetype`.
-    /// 
+    ///
     /// # Safety
     /// Each tuple in `columns` must contain the raw parts for a valid `Vec<C>` of size `length`
     /// for components `C`. Each of those components `C` must have an entry in `component_map`,
@@ -377,7 +377,7 @@ pub trait ViewsSeal<'a>: Claim {
     /// `View`, and that entry must contain the index for the column of type `C` in `columns`. Note
     /// that it is not required for optionally viewed components to be contained in the
     /// `component_map`.
-    /// 
+    ///
     /// `index` must be a valid index in the `Vec<entity::Identifier>` and each component column
     /// `Vec<C>`.
     unsafe fn view_one(

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -34,6 +34,31 @@ pub trait ViewSeal<'a>: Claim {
         component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Result;
 
+    /// View a specific row of an `Archetype`.
+    /// 
+    /// # Safety
+    /// Each tuple in `columns` must contain the raw parts for a valid `Vec<C>` of size `length`
+    /// for components `C`. Each of those components `C` must have an entry in `component_map`,
+    /// paired with the correct index corresponding to that component's entry in `columns`.
+    ///
+    /// `entity_identifiers` must contain the raw parts for a valid `Vec<entity::Identifier` of
+    /// size `length`.
+    ///
+    /// `component_map` must contain an entry for every component `C` that is viewed by this
+    /// `View`, and that entry must contain the index for the column of type `C` in `columns`. Note
+    /// that it is not required for optionally viewed components to be contained in the
+    /// `component_map`.
+    /// 
+    /// `index` must be a valid index in the `Vec<entity::Identifier>` and each component column
+    /// `Vec<C>`.
+    unsafe fn view_one(
+        index: usize,
+        columns: &[(*mut u8, usize)],
+        entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
+    ) -> <Self::Result as Iterator>::Item;
+
     fn assert_claim(buffer: &mut AssertionBuffer);
 }
 
@@ -63,6 +88,29 @@ where
             )
         }
         .iter()
+    }
+
+    unsafe fn view_one(
+        index: usize,
+        columns: &[(*mut u8, usize)],
+        _entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
+    ) -> <Self::Result as Iterator>::Item {
+        // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of size
+        // `length`. Since `component_map` contains an entry for the given component `C`'s entry in
+        // `columns`, then the column obtained here can be interpreted as a slice of type `C` of
+        // size `length`. `index` is guaranteed to be a valid index into the `Vec<C>`.
+        unsafe {
+            slice::from_raw_parts::<'a, C>(
+                columns
+                    .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
+                    .0
+                    .cast::<C>(),
+                length,
+            )
+            .get_unchecked(index)
+        }
     }
 
     fn assert_claim(buffer: &mut AssertionBuffer) {
@@ -96,6 +144,29 @@ where
             )
         }
         .iter_mut()
+    }
+
+    unsafe fn view_one(
+        index: usize,
+        columns: &[(*mut u8, usize)],
+        _entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
+    ) -> <Self::Result as Iterator>::Item {
+        // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of size
+        // `length`. Since `component_map` contains an entry for the given component `C`'s entry in
+        // `columns`, then the column obtained here can be interpreted as a slice of type `C` of
+        // size `length`. `index` is guaranteed to be a valid index into the `Vec<C>`.
+        unsafe {
+            slice::from_raw_parts_mut::<'a, C>(
+                columns
+                    .get_unchecked(*component_map.get(&TypeId::of::<C>()).unwrap_unchecked())
+                    .0
+                    .cast::<C>(),
+                length,
+            )
+            .get_unchecked_mut(index)
+        }
     }
 
     fn assert_claim(buffer: &mut AssertionBuffer) {
@@ -139,6 +210,32 @@ where
         }
     }
 
+    unsafe fn view_one(
+        index: usize,
+        columns: &[(*mut u8, usize)],
+        _entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
+    ) -> <Self::Result as Iterator>::Item {
+        match component_map.get(&TypeId::of::<C>()) {
+            Some(component_index) => Some(
+                // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of
+                // size `length`. Since `component_map` contains an entry for the given component
+                // `C`'s entry in `columns`, then the column obtained here can be interpreted as a
+                // slice of type `C` of size `length`. `index` is guaranteed to be a valid index
+                // into the `Vec<C>`.
+                unsafe {
+                    slice::from_raw_parts(
+                        columns.get_unchecked(*component_index).0.cast::<C>(),
+                        length,
+                    )
+                    .get_unchecked(index)
+                },
+            ),
+            None => None,
+        }
+    }
+
     fn assert_claim(buffer: &mut AssertionBuffer) {
         buffer.claim_immutable::<C>();
     }
@@ -179,6 +276,32 @@ where
         }
     }
 
+    unsafe fn view_one(
+        index: usize,
+        columns: &[(*mut u8, usize)],
+        _entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
+    ) -> <Self::Result as Iterator>::Item {
+        match component_map.get(&TypeId::of::<C>()) {
+            Some(component_index) => Some(
+                // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of
+                // size `length`. Since `component_map` contains an entry for the given component
+                // `C`'s entry in `columns`, then the column obtained here can be interpreted as a
+                // slice of type `C` of size `length`. `index` is guaranteed to be a valid index
+                // into the `Vec<C>`.
+                unsafe {
+                    slice::from_raw_parts_mut(
+                        columns.get_unchecked(*component_index).0.cast::<C>(),
+                        length,
+                    )
+                    .get_unchecked_mut(index)
+                },
+            ),
+            None => None,
+        }
+    }
+
     fn assert_claim(buffer: &mut AssertionBuffer) {
         buffer.claim_mutable::<C>();
     }
@@ -198,6 +321,21 @@ impl<'a> ViewSeal<'a> for entity::Identifier {
         unsafe { slice::from_raw_parts_mut::<'a, Self>(entity_identifiers.0, length) }
             .iter()
             .copied()
+    }
+
+    unsafe fn view_one(
+        index: usize,
+        _columns: &[(*mut u8, usize)],
+        entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
+    ) -> <Self::Result as Iterator>::Item {
+        // SAFETY: `entity_identifiers` is guaranteed to contain the raw parts for a valid
+        // `Vec<entity::Identifier>` of size `length`. `index` is guaranteed to be a valid index
+        // into the `Vec<entity::Identifier>`.
+        *unsafe { slice::from_raw_parts_mut::<'a, Self>(entity_identifiers.0, length) 
+            .get_unchecked(index)
+        }
     }
 
     fn assert_claim(_buffer: &mut AssertionBuffer) {}
@@ -225,6 +363,31 @@ pub trait ViewsSeal<'a>: Claim {
         component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Results;
 
+    /// View a specific row of an `Archetype`.
+    /// 
+    /// # Safety
+    /// Each tuple in `columns` must contain the raw parts for a valid `Vec<C>` of size `length`
+    /// for components `C`. Each of those components `C` must have an entry in `component_map`,
+    /// paired with the correct index corresponding to that component's entry in `columns`.
+    ///
+    /// `entity_identifiers` must contain the raw parts for a valid `Vec<entity::Identifier` of
+    /// size `length`.
+    ///
+    /// `component_map` must contain an entry for every component `C` that is viewed by this
+    /// `View`, and that entry must contain the index for the column of type `C` in `columns`. Note
+    /// that it is not required for optionally viewed components to be contained in the
+    /// `component_map`.
+    /// 
+    /// `index` must be a valid index in the `Vec<entity::Identifier>` and each component column
+    /// `Vec<C>`.
+    unsafe fn view_one(
+        index: usize,
+        columns: &[(*mut u8, usize)],
+        entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
+    ) -> <Self::Results as Iterator>::Item;
+
     fn assert_claims(buffer: &mut AssertionBuffer);
 }
 
@@ -238,6 +401,16 @@ impl<'a> ViewsSeal<'a> for Null {
         _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> Self::Results {
         iter::repeat(result::Null)
+    }
+
+    unsafe fn view_one(
+        _index: usize,
+        _columns: &[(*mut u8, usize)],
+        _entity_identifiers: (*mut entity::Identifier, usize),
+        _length: usize,
+        _component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
+    ) -> <Self::Results as Iterator>::Item {
+        result::Null
     }
 
     fn assert_claims(_buffer: &mut AssertionBuffer) {}
@@ -265,6 +438,23 @@ where
                 length,
                 component_map,
             ))
+        }
+    }
+
+    unsafe fn view_one(
+        index: usize,
+        columns: &[(*mut u8, usize)],
+        entity_identifiers: (*mut entity::Identifier, usize),
+        length: usize,
+        component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
+    ) -> <Self::Results as Iterator>::Item {
+        // SAFETY: The safety guarantees of this method are the exact what are required by the
+        // safety guarantees of both `V::view_one()` and `W::view_one()`.
+        unsafe {
+            (
+                V::view_one(index, columns, entity_identifiers, length, component_map),
+                W::view_one(index, columns, entity_identifiers, length, component_map),
+            )
         }
     }
 

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -279,23 +279,19 @@ where
         length: usize,
         component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> <Self::Result as Iterator>::Item {
-        match component_map.get(&TypeId::of::<C>()) {
-            Some(component_index) => Some(
-                // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of
-                // size `length`. Since `component_map` contains an entry for the given component
-                // `C`'s entry in `columns`, then the column obtained here can be interpreted as a
-                // slice of type `C` of size `length`. `index` is guaranteed to be a valid index
-                // into the `Vec<C>`.
-                unsafe {
-                    slice::from_raw_parts_mut(
-                        columns.get_unchecked(*component_index).0.cast::<C>(),
-                        length,
-                    )
-                    .get_unchecked_mut(index)
-                },
-            ),
-            None => None,
-        }
+        component_map.get(&TypeId::of::<C>()).map(|component_index|
+            // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of size
+            //  `length`. Since `component_map` contains an entry for the given component `C`'s
+            // entry in `columns`, then the column obtained here can be interpreted as a slice of
+            // type `C` of size `length`. `index` is guaranteed to be a valid index into the
+            // `Vec<C>`.
+            unsafe {
+                slice::from_raw_parts_mut(
+                    columns.get_unchecked(*component_index).0.cast::<C>(),
+                    length,
+                )
+                .get_unchecked_mut(index)
+            })
     }
 
     fn assert_claim(buffer: &mut AssertionBuffer) {

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -217,23 +217,19 @@ where
         length: usize,
         component_map: &HashMap<TypeId, usize, FnvBuildHasher>,
     ) -> <Self::Result as Iterator>::Item {
-        match component_map.get(&TypeId::of::<C>()) {
-            Some(component_index) => Some(
-                // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of
-                // size `length`. Since `component_map` contains an entry for the given component
-                // `C`'s entry in `columns`, then the column obtained here can be interpreted as a
-                // slice of type `C` of size `length`. `index` is guaranteed to be a valid index
-                // into the `Vec<C>`.
-                unsafe {
-                    slice::from_raw_parts(
-                        columns.get_unchecked(*component_index).0.cast::<C>(),
-                        length,
-                    )
-                    .get_unchecked(index)
-                },
-            ),
-            None => None,
-        }
+        component_map.get(&TypeId::of::<C>()).map(|component_index|
+            // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of size
+            //  `length`. Since `component_map` contains an entry for the given component `C`'s
+            // entry in `columns`, then the column obtained here can be interpreted as a slice of
+            // type `C` of size `length`. `index` is guaranteed to be a valid index into the
+            // `Vec<C>`.
+            unsafe {
+                slice::from_raw_parts(
+                    columns.get_unchecked(*component_index).0.cast::<C>(),
+                    length,
+                )
+                .get_unchecked(index)
+            })
     }
 
     fn assert_claim(buffer: &mut AssertionBuffer) {

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -297,11 +297,12 @@ where
                 // valid index to a row within this archetype, since they share the same archetype
                 // identifier.
                 unsafe {
-                self.world
-                    .archetypes
-                    .get_mut(self.location.identifier)?
-                    .view_row_unchecked::<V>(self.location.index)
-            })
+                    self.world
+                        .archetypes
+                        .get_mut(self.location.identifier)?
+                        .view_row_unchecked::<V>(self.location.index)
+                },
+            )
         } else {
             None
         }

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -2,6 +2,10 @@ use crate::{
     archetype,
     component::Component,
     entity::allocator::Location,
+    query::{
+        filter::{And, Filter, Seal},
+        view::Views,
+    },
     registry::{Registry, RegistryDebug},
     world::World,
 };
@@ -244,13 +248,64 @@ where
         }
     }
 
-    // pub fn query<'a, V, F>(&'a mut self) -> iter::Flatten<vec::IntoIter<V::Results>>
-    // where
-    //     V: Views<'a>,
-    //     F: Filter,
-    // {
-    //     todo!()
-    // }
+    /// Query for components contained within this entity using the given [`Views`] `V` and
+    /// [`Filter`] `F`.
+    ///
+    /// Returns a `Some` value if the entity matches the views and filter combination, and returns
+    /// a `None` value otherwise.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{
+    ///     entity,
+    ///     query::{filter, result, views},
+    ///     registry, World,
+    /// };
+    ///
+    /// struct Foo(u32);
+    /// struct Bar(bool);
+    ///
+    /// type Registry = registry!(Foo, Bar);
+    ///
+    /// let mut world = World::<Registry>::new();
+    /// let entity_identifier = world.insert(entity!(Foo(42), Bar(true)));
+    /// let mut entry = world.entry(entity_identifier).unwrap();
+    ///
+    /// let result = entry.query::<views!(&Foo, &Bar), filter::None>();
+    /// assert!(result.is_some());
+    /// let result!(foo, bar) = result.unwrap();
+    /// assert_eq!(foo.0, 42);
+    /// assert_eq!(bar.0, true);
+    /// ```
+    pub fn query<V, F>(&mut self) -> Option<<V::Results as Iterator>::Item>
+    where
+        V: Views<'a>,
+        F: Filter,
+    {
+        self.world.view_assertion_buffer.clear();
+        V::assert_claims(&mut self.world.view_assertion_buffer);
+
+        // SAFETY: `self.component_map` contains an entry for each `TypeId<C>` per
+        // component `C` in the registry `R`.
+        if unsafe { And::<V, F>::filter(self.location.identifier, &self.world.component_map) } {
+            Some(
+                // SAFETY: Since the archetype wasn't filtered out by the views, then each
+                // component viewed by `V` is also identified by the archetype's identifier.
+                //
+                // `self.world.entity_allocator` contains entries for entities stored in
+                // `self.world.archetypes`. As such, `self.location.index` is guaranteed to be a
+                // valid index to a row within this archetype, since they share the same archetype
+                // identifier.
+                unsafe {
+                self.world
+                    .archetypes
+                    .get_mut(self.location.identifier)?
+                    .view_row_unchecked::<V>(self.location.index)
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl<'a, R> Debug for Entry<'a, R>

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1768,6 +1768,38 @@ mod tests {
     }
 
     #[test]
+    fn entry_query_mut() {
+        let mut world = World::<Registry>::new();
+
+        let entity_identifier = world.insert(entity!(A(1), B('a')));
+        world.insert(entity!(A(2)));
+        world.insert(entity!(B('b')));
+        world.insert(entity!());
+
+        let mut entry = assert_some!(world.entry(entity_identifier));
+
+        let result!(a, b) =
+            assert_some!(entry.query::<views!(&mut A, Option<&mut B>), filter::None>());
+        assert_eq!(a.0, 1);
+        let b = assert_some!(b);
+        assert_eq!(b.0, 'a');
+    }
+
+    #[test]
+    fn entry_query_fails() {
+        let mut world = World::<Registry>::new();
+
+        world.insert(entity!(A(1), B('a')));
+        let entity_identifier = world.insert(entity!(A(2)));
+        world.insert(entity!(B('b')));
+        world.insert(entity!());
+
+        let mut entry = assert_some!(world.entry(entity_identifier));
+
+        assert_none!(entry.query::<views!(entity::Identifier, &A, &B), filter::None>());
+    }
+
+    #[test]
     fn no_entry_found() {
         let mut world = World::<Registry>::new();
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1749,6 +1749,24 @@ mod tests {
     }
 
     #[test]
+    fn entry_query() {
+        let mut world = World::<Registry>::new();
+
+        let entity_identifier = world.insert(entity!(A(1), B('a')));
+        world.insert(entity!(A(2)));
+        world.insert(entity!(B('b')));
+        world.insert(entity!());
+
+        let mut entry = assert_some!(world.entry(entity_identifier));
+
+        let result!(queried_identifier, a, b) = assert_some!(entry.query::<views!(entity::Identifier, &A, Option<&B>), filter::None>());
+        assert_eq!(queried_identifier, entity_identifier);
+        assert_eq!(a.0, 1);
+        let b = assert_some!(b);
+        assert_eq!(b.0, 'a');
+    }
+
+    #[test]
     fn no_entry_found() {
         let mut world = World::<Registry>::new();
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1759,7 +1759,8 @@ mod tests {
 
         let mut entry = assert_some!(world.entry(entity_identifier));
 
-        let result!(queried_identifier, a, b) = assert_some!(entry.query::<views!(entity::Identifier, &A, Option<&B>), filter::None>());
+        let result!(queried_identifier, a, b) =
+            assert_some!(entry.query::<views!(entity::Identifier, &A, Option<&B>), filter::None>());
         assert_eq!(queried_identifier, entity_identifier);
         assert_eq!(a.0, 1);
         let b = assert_some!(b);


### PR DESCRIPTION
Fixes #94.

This implements a `query()` method on `Entry`, allowing a user to query components on just that specific entity.