### PR TITLE
Better dependabot settings.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  target-branch: "dev"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
-- package-ecosystem: cargo
+- package-ecosystem: "cargo"
   directory: "/"
   schedule:
-    interval: daily
+    interval: "daily"
   open-pull-requests-limit: 10
   target-branch: "dev"
   labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
   target-branch: "dev"
+  labels:
+    - "C - Dependencies"
+    - "P - Low"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,13 @@ updates:
   labels:
     - "C - Dependencies"
     - "P - Low"
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 10
+  target-branch: "dev"
+  labels:
+    - "C - Continuous Integration"
+    - "P - Low"


### PR DESCRIPTION
Configures dependabot to open PRs for the `dev` branch with the desired labels. Also configures dependabot to update github actions dependencies.

Closes #99.