### PR TITLE
Make continuous integration faster.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,18 +23,12 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        override: true
         components: rust-src
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-hack
-    - uses: actions-rs/cargo@v1
-      with:
-        command: hack
-        args: test --feature-powerset --optional-deps
+    - run: cargo install cargo-hack
+    - run: cargo hack test --feature-powerset --optional-deps
 
   no_std:
     runs-on: ubuntu-latest
@@ -48,78 +42,46 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        target: thumbv6m-none-eabi
-        override: true
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-hack
-    - uses: actions-rs/cargo@v1
-      with:
-        command: hack
-        args: build --feature-powerset --optional-deps --exclude-features rayon --target thumbv6m-none-eabi
+        targets: thumbv6m-none-eabi
+    - run: cargo install cargo-hack
+    - run: cargo hack build --feature-powerset --optional-deps --exclude-features rayon --target thumbv6m-none-eabi
 
   fmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly
-        override: true
         components: rustfmt
-    - uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: -- --check
+    - run: cargo fmt -- --check
 
   check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-hack
-    - uses: actions-rs/cargo@v1
-      with:
-        command: hack
-        args: check --feature-powerset --optional-deps
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: cargo install cargo-hack
+    - run: cargo hack check --feature-powerset --optional-deps
 
   clippy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly
-        override: true
         components: clippy
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-hack
-    - uses: actions-rs/cargo@v1
-      with:
-        command: hack
-        args: clippy --feature-powerset --optional-deps -- --deny warnings
+    - run: cargo install cargo-hack
+    - run: cargo hack clippy --feature-powerset --optional-deps -- --deny warnings
 
   doc:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: doc
-        args: --no-deps --all-features
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: cargo doc --no-deps --all-features
       env:
         RUSTDOCFLAGS: --cfg doc_cfg -D warnings
 
@@ -127,14 +89,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: doc
-        args: --no-deps --all-features --document-private-items
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: cargo doc --no-deps --all-features --document-private-items
       env:
         RUSTDOCFLAGS: --cfg doc_cfg -D warnings
 
@@ -142,34 +98,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-msrv
-    - uses: actions-rs/cargo@v1
-      with:
-        command: msrv
-        args: --verify
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: cargo install cargo-msrv
+    - run: cargo msrv --verify
 
   miri:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly
-        override: true
         components: miri
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-hack
-    - uses: actions-rs/cargo@v1
-      with:
-        command: hack
-        args: miri test --feature-powerset --optional-deps
+    - run: cargo install cargo-hack
+    - run: cargo hack miri test --feature-powerset --optional-deps
       env:
         MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks
         RUSTFLAGS: --cfg skip_trybuild
@@ -188,20 +129,10 @@ jobs:
       working-directory: ./valgrind-3.19.0
     - run: sudo apt-get update
     - run: sudo apt-get install libc6-dbg
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-valgrind
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-hack
-    - uses: actions-rs/cargo@v1
-      with:
-        command: hack
-        args: valgrind test --feature-powerset --optional-deps --exclude-features rayon
+    - uses: dtolnay/rust-toolchain@nightly
+    - run: cargo install cargo-valgrind
+    - run: cargo install cargo-hack
+    - run: cargo hack valgrind test --feature-powerset --optional-deps --exclude-features rayon
       env:
         RUSTFLAGS: --cfg skip_trybuild
 
@@ -209,18 +140,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
+    - uses: dtolnay/rust-toolchain@nightly
         components: llvm-tools-preview, rust-src
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-llvm-cov
-    - uses: actions-rs/cargo@v1
-      with:
-        command: llvm-cov
-        args: --all-features --lcov --output-path lcov.info
+    - run: cargo install cargo-llvm-cov
+    - run: cargo llvm-cov --all-features --lcov --output-path lcov.info
     - uses: codecov/codecov-action@v2
       with:
         files: lcov.info

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -141,6 +141,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: dtolnay/rust-toolchain@nightly
+      with:
         components: llvm-tools-preview, rust-src
     - run: cargo install cargo-llvm-cov
     - run: cargo llvm-cov --all-features --lcov --output-path lcov.info

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -119,16 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: wget https://sourceware.org/pub/valgrind/valgrind-3.19.0.tar.bz2
-    - run: tar xvf valgrind-3.19.0.tar.bz2
-    - run: ./configure
-      working-directory: ./valgrind-3.19.0
-    - run: make
-      working-directory: ./valgrind-3.19.0
-    - run: sudo make install
-      working-directory: ./valgrind-3.19.0
-    - run: sudo apt-get update
-    - run: sudo apt-get install libc6-dbg
+    - run: sudo apt install valgrind
     - uses: dtolnay/rust-toolchain@nightly
     - run: curl -LsSf https://github.com/jfrimmel/cargo-valgrind/releases/latest/download/cargo-valgrind-2.1.0-x86_64-unknown-linux-musl.tar.gz | tar xzf - -C ~/.cargo/bin
     - run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,7 +143,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
       with:
         components: llvm-tools-preview, rust-src
-    - run: cargo install cargo-llvm-cov
+    - run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - run: cargo llvm-cov --all-features --lcov --output-path lcov.info
     - uses: codecov/codecov-action@v2
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         targets: thumbv6m-none-eabi
-    - run: cargo install cargo-hack
+    - run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - run: cargo hack build --feature-powerset --optional-deps --exclude-features rayon --target thumbv6m-none-eabi
 
   fmt:
@@ -63,7 +63,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: dtolnay/rust-toolchain@nightly
-    - run: cargo install cargo-hack
+    - run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - run: cargo hack check --feature-powerset --optional-deps
 
   clippy:
@@ -73,7 +73,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
       with:
         components: clippy
-    - run: cargo install cargo-hack
+    - run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - run: cargo hack clippy --feature-powerset --optional-deps -- --deny warnings
 
   doc:
@@ -109,7 +109,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
       with:
         components: miri
-    - run: cargo install cargo-hack
+    - run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - run: cargo hack miri test --feature-powerset --optional-deps
       env:
         MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks
@@ -131,7 +131,7 @@ jobs:
     - run: sudo apt-get install libc6-dbg
     - uses: dtolnay/rust-toolchain@nightly
     - run: cargo install cargo-valgrind
-    - run: cargo install cargo-hack
+    - run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - run: cargo hack valgrind test --feature-powerset --optional-deps --exclude-features rayon
       env:
         RUSTFLAGS: --cfg skip_trybuild

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         components: rust-src
-    - run: cargo install cargo-hack
+    - run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - run: cargo hack test --feature-powerset --optional-deps
 
   no_std:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: dtolnay/rust-toolchain@nightly
-    - run: cargo install cargo-msrv
+    - run: curl -LsSf https://github.com/foresterre/cargo-msrv/releases/latest/download/cargo-msrv_v0.15.1_Linux_x86_64.tar | tar xzf - -C ~/.cargo/bin
     - run: cargo msrv --verify
 
   miri:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -130,7 +130,7 @@ jobs:
     - run: sudo apt-get update
     - run: sudo apt-get install libc6-dbg
     - uses: dtolnay/rust-toolchain@nightly
-    - run: cargo install cargo-valgrind
+    - run: curl -LsSf https://github.com/jfrimmel/cargo-valgrind/releases/latest/download/cargo-valgrind-2.1.0-x86_64-unknown-linux-musl.tar.gz | tar xzf - -C ~/.cargo/bin
     - run: curl -LsSf https://github.com/taiki-e/cargo-hack/releases/latest/download/cargo-hack-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
     - run: cargo hack valgrind test --feature-powerset --optional-deps --exclude-features rayon
       env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: dtolnay/rust-toolchain@nightly
-    - run: curl -LsSf https://github.com/foresterre/cargo-msrv/releases/latest/download/cargo-msrv_v0.15.1_Linux_x86_64.tar | tar xzf - -C ~/.cargo/bin
+    - run: curl -LsSf https://github.com/foresterre/cargo-msrv/releases/latest/download/cargo-msrv_v0.15.1_Linux_x86_64.tar | tar xf - -C ~/.cargo/bin
     - run: cargo msrv --verify
 
   miri:


### PR DESCRIPTION
Fixes #103.

Well, technically it doesn't do what #103 stated. But it solves the problem either way. Turns out, easier than caching the tools, I can just download each of the `cargo-*` binaries directly from their release pages on GitHub. Saves tons of time. Also, I switched back to using `apt` to install `valgrind`, because that's what `cargo-valgrind`'s CI does. Not sure why it wasn't working before, perhaps a new version fixed some problems? Apparently it works with `valgrind 3.15` again.

As far as time saves go, it looks like this:

| Job         | Old Time | New Time | Savings |
| -------- | --------- | ---------- | -------- |
| test         | 4:56        | 3:16           | 1:40      |
| no_std    | 2:11         | 0:59           | 1:12       |
| check     | 1:54         | 0:49           | 1:05      |
| clippy     | 2:19         | 0:53           | 1:26      |
| msrv       | 5:54        | 0:57           | 4:57      |
| miri         | 6:36        | 3:59           | 2:37      |
| valgrind  | 6:58        | 2:07           | 4:51      |
| codecov | 2:35        | 1:44            | 0:49     |

I think these savings are significant. Overall, it saves minutes for every push and pull request, which helps a lot. 