### PR TITLE
Update dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ either = {version = "1.8.0", default-features = false}
 fnv = {version = "1.0.7", default-features = false}
 hashbrown = {version = "0.12.3", default-features = false, features = ["inline-more", "raw"]}
 rayon = {version = "1.5.3", optional = true}
-serde = {version = "1.0.143", default-features = false, features = ["alloc"], optional = true}
+serde = {version = "1.0.144", default-features = false, features = ["alloc"], optional = true}
 
 [dev-dependencies]
 claim = "0.5.0"
 rustversion = "1.0.9"
-serde_derive = "1.0.143"
-serde_test = "1.0.143"
+serde_derive = "1.0.144"
+serde_test = "1.0.144"
 # Temporarily use this fork until https://github.com/dtolnay/trybuild/issues/171 is resolved.
 trybuild = {git = "https://github.com/Anders429/trybuild"}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
 
 [dependencies]
-either = {version = "1.7.0", default-features = false}
+either = {version = "1.8.0", default-features = false}
 fnv = {version = "1.0.7", default-features = false}
 hashbrown = {version = "0.12.3", default-features = false, features = ["inline-more", "raw"]}
 rayon = {version = "1.5.3", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rayon = {version = "1.5.3", optional = true}
 serde = {version = "1.0.144", default-features = false, features = ["alloc"], optional = true}
 
 [dev-dependencies]
-claim = "0.5.0"
+claims = "0.7.1"
 rustversion = "1.0.9"
 serde_derive = "1.0.144"
 serde_test = "1.0.144"

--- a/src/archetypes/impl_serde.rs
+++ b/src/archetypes/impl_serde.rs
@@ -101,7 +101,7 @@ mod tests {
         registry::{RegistryDebug, RegistryEq, RegistryPartialEq},
     };
     use alloc::{format, vec};
-    use claim::assert_ok;
+    use claims::assert_ok;
     use core::{any::type_name, fmt, fmt::Debug};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_derive::{Deserialize, Serialize};

--- a/src/entity/allocator/impl_serde.rs
+++ b/src/entity/allocator/impl_serde.rs
@@ -284,7 +284,7 @@ mod tests {
             RegistryDebug, RegistryDeserialize, RegistryEq, RegistryPartialEq, RegistrySerialize,
         },
     };
-    use claim::assert_ok;
+    use claims::assert_ok;
     use core::{fmt, fmt::Debug, marker::PhantomData};
     use serde_derive::{Deserialize, Serialize};
     use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};

--- a/src/entity/allocator/slot.rs
+++ b/src/entity/allocator/slot.rs
@@ -95,7 +95,7 @@ mod tests {
     use super::*;
     use crate::{archetype::Identifier, registry};
     use alloc::vec;
-    use claim::{assert_none, assert_some_eq};
+    use claims::{assert_none, assert_some_eq};
 
     macro_rules! create_components {
         ($( $variants:ident ),*) => {

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -689,7 +689,7 @@ mod tests {
         registry,
     };
     use alloc::vec;
-    use claim::{assert_none, assert_some};
+    use claims::{assert_none, assert_some};
     #[cfg(feature = "rayon")]
     use rayon::iter::ParallelIterator;
 


### PR DESCRIPTION
Updates current dependencies.

For most dependencies, the version number is simply updated to ensure the most recent version is used. This PR also replaces `claim` with `claims`, resolving #109.