### PR TITLE
`World::shrink_to_fit()` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Added
+- `shrink_to_fit()` method on `World` for shrinking the `World`'s current allocation to the minimum required for the current data.
 ### Changed
 - Removed unnecessary generic bounds on `result::Iter`, `result::ParIter`, and `entities::Batch`.
 ### Fixed

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -633,9 +633,11 @@ where
         unsafe { slice::from_raw_parts(self.entity_identifiers.0, self.length) }.iter()
     }
 
-    #[cfg(feature = "serde")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
     pub(crate) fn len(&self) -> usize {
         self.length
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 }

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -585,6 +585,38 @@ where
         self.length = 0;
     }
 
+    /// Decrease the allocated capacity for the component columns and entity identifier column.
+    ///
+    /// This may not decrease to the most optimal capacity, as it is dependent on the allocator.
+    pub(crate) fn shrink_to_fit(&mut self) {
+        // SAFETY: `self.components` has the same number of values as there are set bits in
+        // `self.identifier`. Also, each element in `self.components` defines a `Vec<C>` of size
+        // `self.length` for each `C` identified by `self.identifier`.
+        //
+        // The `R` over which `self.identifier` is generic is the same `R` on which this function
+        // is being called.
+        unsafe {
+            R::shrink_components_to_fit(&mut self.components, self.length, self.identifier.iter());
+        }
+
+        let mut entity_identifiers = ManuallyDrop::new(
+            // SAFETY: `self.entity_identifiers` is guaranteed to contain the raw parts for a valid
+            // `Vec` of size `self.length`.
+            unsafe {
+                Vec::from_raw_parts(
+                    self.entity_identifiers.0,
+                    self.length,
+                    self.entity_identifiers.1,
+                )
+            },
+        );
+        entity_identifiers.shrink_to_fit();
+        self.entity_identifiers = (
+            entity_identifiers.as_mut_ptr(),
+            entity_identifiers.capacity(),
+        );
+    }
+
     /// # Safety
     /// The `Archetype` must outlive the returned `IdentifierRef`.
     pub(crate) unsafe fn identifier(&self) -> IdentifierRef<R> {

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -270,6 +270,8 @@ where
     /// This may not decrease to the most optimal value, as the shrinking is dependent on the
     /// allocator.
     pub(crate) fn shrink_to_fit(&mut self) {
+        self.raw_archetypes
+            .shrink_to(0, Self::make_hasher(&self.hash_builder));
         for archetype in self.iter_mut() {
             archetype.shrink_to_fit();
         }

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -264,6 +264,16 @@ where
             unsafe { archetype.clear(entity_allocator) };
         }
     }
+
+    /// Decrease the allocated capacity to the smallest amount required for the stored data.
+    ///
+    /// This may not decrease to the most optimal value, as the shrinking is dependent on the
+    /// allocator.
+    pub(crate) fn shrink_to_fit(&mut self) {
+        for archetype in self.iter_mut() {
+            archetype.shrink_to_fit();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/entity/allocator/mod.rs
+++ b/src/entity/allocator/mod.rs
@@ -167,7 +167,7 @@ where
     ///
     /// This may not decrease to the most optimal value, as the shrinking is dependent on the
     /// allocator.
-    /// 
+    ///
     /// Note that this only affects the list of currently free indexes. Slots are never removed, so
     /// there is no need to shrink them.
     pub(crate) fn shrink_to_fit(&mut self) {

--- a/src/entity/allocator/mod.rs
+++ b/src/entity/allocator/mod.rs
@@ -162,6 +162,17 @@ where
         }
         .index = index;
     }
+
+    /// Decrease the allocated capacity to the smallest amount required for the stored data.
+    ///
+    /// This may not decrease to the most optimal value, as the shrinking is dependent on the
+    /// allocator.
+    /// 
+    /// Note that this only affects the list of currently free indexes. Slots are never removed, so
+    /// there is no need to shrink them.
+    pub(crate) fn shrink_to_fit(&mut self) {
+        self.free.shrink_to_fit();
+    }
 }
 
 impl<R> Debug for Allocator<R>

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -283,6 +283,31 @@ pub trait Storage {
     ) where
         R: Registry;
 
+    /// Shrink the component columns to the smallest required allocation.
+    ///
+    /// This isn't guaranteed to shrink to the most optimal allocation, as it is dependent on the
+    /// allocator. The logic here relies on the implementation of `Vec::shrink_to_fit()`.
+    ///
+    /// # Safety
+    /// `components` must contain the same number of values as there are set bits in the
+    /// `identifier_iter`.
+    ///
+    /// Each `(*mut u8, usize)` in `components` must be the pointer and capacity respectively of a
+    /// `Vec<C>` of length `length`, where `C` is the component corresponding to the set bit in
+    /// `identifier_iter`.
+    ///
+    /// When called externally, the `Registry` `R` provided to the method must by the same as the
+    /// `Registry` on which this method is being called.
+    ///
+    /// When called internally, the `identifier_iter` must have the same amount of bits left as
+    /// there are components remaining.
+    unsafe fn shrink_components_to_fit<R>(
+        components: &mut [(*mut u8, usize)],
+        length: usize,
+        identifier_iter: archetype::identifier::Iter<R>,
+    ) where
+        R: Registry;
+
     /// Populate a [`DebugList`] with string forms of the names of every component type identified
     /// by `identifier_iter`.
     ///
@@ -387,6 +412,15 @@ impl Storage for Null {
     }
 
     unsafe fn clear_components<R>(
+        _components: &mut [(*mut u8, usize)],
+        _length: usize,
+        _identifier_iter: archetype::identifier::Iter<R>,
+    ) where
+        R: Registry,
+    {
+    }
+
+    unsafe fn shrink_components_to_fit<R>(
         _components: &mut [(*mut u8, usize)],
         _length: usize,
         _identifier_iter: archetype::identifier::Iter<R>,
@@ -965,6 +999,62 @@ where
         // than `(C, R)`, and since `identifier_iter` has had one bit consumed, it still has the
         // same number of bits remaining as `R` has components remaining.
         unsafe { R::clear_components(components, length, identifier_iter) };
+    }
+
+    unsafe fn shrink_components_to_fit<R_>(
+        mut components: &mut [(*mut u8, usize)],
+        length: usize,
+        mut identifier_iter: archetype::identifier::Iter<R_>,
+    ) where
+        R_: Registry,
+    {
+        if
+        // SAFETY: `identifier_iter` is guaranteed by the safety contract of this method to
+        // return a value for every component within the registry.
+        unsafe { identifier_iter.next().unwrap_unchecked() } {
+            let component_column =
+                // SAFETY: `components` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column.
+                unsafe { components.get_unchecked_mut(0) };
+            let mut v = ManuallyDrop::new(
+                // SAFETY: The pointer, capacity, and length are guaranteed by the safety
+                // contract of this method to define a valid `Vec<C>`.
+                unsafe {
+                    Vec::<C>::from_raw_parts(
+                        component_column.0.cast::<C>(),
+                        length,
+                        component_column.1,
+                    )
+                },
+            );
+            v.shrink_to_fit();
+            *component_column = (v.as_mut_ptr().cast::<u8>(), v.capacity());
+            components =
+                // SAFETY: `components` is guaranteed to have the same number of values as there
+                // set bits in `identifier_iter`. Since a bit must have been set to enter this
+                // block, there must be at least one component column.
+                unsafe { components.get_unchecked_mut(1..) };
+        }
+
+        // SAFETY: At this point, one bit of `identifier_iter` has been consumed. There are two
+        // possibilities here: either the bit was set or it was not.
+        //
+        // If the bit was set, then the `components` slice will no longer include the first value,
+        // which means the slice will still contain up to the number of pointer and capacity tuples
+        // as there are set bits in `identifier_iter`. Additionally, since the first value was
+        // removed from the slice, which corresponded to the component identified by the consumed
+        // bit, all remaining component values will still correspond to valid `Vec<C>`s identified
+        // by the remaining set bits in `identifier_iter`.
+        //
+        // If the bit was not set, then `components` is unaltered, and there are still up to the
+        // same number of elements as there are set bits in `identifier_iter`, which still make
+        // valid `Vec<C>`s for each `C` identified by the remaining set bits in `identifier_iter`.
+        //
+        // Furthermore, regardless of whether the bit was set or not, `R` is one component smaller
+        // than `(C, R)`, and since `identifier_iter` has had one bit consumed, it still has the
+        // same number of bits remaining as `R` has components remaining.
+        unsafe { R::shrink_components_to_fit(components, length, identifier_iter) }
     }
 
     unsafe fn debug_identifier<R_>(
@@ -1751,5 +1841,141 @@ mod tests {
         };
         assert!(new_a_column.is_empty());
         assert!(new_c_column.is_empty());
+    }
+
+    #[test]
+    fn shrink_components_to_fit_empty_registry() {
+        type Registry = registry!();
+        let identifier = unsafe { Identifier::<Registry>::new(Vec::new()) };
+        let mut components = Vec::new();
+
+        unsafe { Registry::shrink_components_to_fit(&mut components, 0, identifier.iter()) };
+
+        assert!(components.is_empty());
+    }
+
+    #[test]
+    fn shrink_components_to_fit_all() {
+        struct A(usize);
+        struct B(bool);
+        struct C;
+        type Registry = registry!(A, B, C);
+        let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
+        let mut a_column = ManuallyDrop::new(vec![
+            A(0),
+            A(1),
+            A(2),
+            A(10),
+            A(10),
+            A(10),
+            A(10),
+            A(10),
+            A(10),
+            A(10),
+        ]);
+        a_column.clear();
+        a_column.extend(vec![A(0), A(1), A(2)]);
+        let mut b_column = ManuallyDrop::new(vec![
+            B(false),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+        ]);
+        b_column.clear();
+        b_column.extend(vec![B(false), B(true), B(true)]);
+        let mut c_column = ManuallyDrop::new(vec![C, C, C, C, C, C, C, C, C, C]);
+        c_column.clear();
+        c_column.extend(vec![C, C, C]);
+        let mut components = vec![
+            (a_column.as_mut_ptr().cast::<u8>(), a_column.capacity()),
+            (b_column.as_mut_ptr().cast::<u8>(), b_column.capacity()),
+            (c_column.as_mut_ptr().cast::<u8>(), c_column.capacity()),
+        ];
+
+        unsafe { Registry::shrink_components_to_fit(&mut components, 3, identifier.iter()) };
+
+        // Only check columns A and B, because C is zero-sized.
+        let new_a_column = unsafe {
+            Vec::from_raw_parts(
+                components.get(0).unwrap().0.cast::<A>(),
+                0,
+                components.get(0).unwrap().1,
+            )
+        };
+        let new_b_column = unsafe {
+            Vec::from_raw_parts(
+                components.get(1).unwrap().0.cast::<B>(),
+                0,
+                components.get(1).unwrap().1,
+            )
+        };
+        assert_eq!(new_a_column.capacity(), 3);
+        assert_eq!(new_b_column.capacity(), 3);
+    }
+
+    #[test]
+    fn shrink_components_to_fit_some() {
+        struct A(usize);
+        struct B(bool);
+        struct C;
+        type Registry = registry!(A, B, C);
+        let identifier = unsafe { Identifier::<Registry>::new(vec![3]) };
+        let mut a_column = ManuallyDrop::new(vec![
+            A(0),
+            A(1),
+            A(2),
+            A(10),
+            A(10),
+            A(10),
+            A(10),
+            A(10),
+            A(10),
+            A(10),
+        ]);
+        a_column.clear();
+        a_column.extend(vec![A(0), A(1), A(2)]);
+        let mut b_column = ManuallyDrop::new(vec![
+            B(false),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+            B(true),
+        ]);
+        b_column.clear();
+        b_column.extend(vec![B(false), B(true), B(true)]);
+        let mut components = vec![
+            (a_column.as_mut_ptr().cast::<u8>(), a_column.capacity()),
+            (b_column.as_mut_ptr().cast::<u8>(), b_column.capacity()),
+        ];
+
+        unsafe { Registry::shrink_components_to_fit(&mut components, 3, identifier.iter()) };
+
+        let new_a_column = unsafe {
+            Vec::from_raw_parts(
+                components.get(0).unwrap().0.cast::<A>(),
+                0,
+                components.get(0).unwrap().1,
+            )
+        };
+        let new_b_column = unsafe {
+            Vec::from_raw_parts(
+                components.get(1).unwrap().0.cast::<B>(),
+                0,
+                components.get(1).unwrap().1,
+            )
+        };
+        assert_eq!(new_a_column.capacity(), 3);
+        assert_eq!(new_b_column.capacity(), 3);
     }
 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -703,6 +703,7 @@ where
     /// ```
     pub fn shrink_to_fit(&mut self) {
         self.archetypes.shrink_to_fit();
+        self.entity_allocator.shrink_to_fit();
     }
 }
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -678,6 +678,32 @@ where
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Shrinks the allocated capacity of the internal storage as much as possible.
+    ///
+    /// # Example
+    /// ``` rust
+    /// use brood::{entities, registry, World};
+    ///
+    /// #[derive(Clone)]
+    /// struct Foo(usize);
+    /// #[derive(Clone)]
+    /// struct Bar(bool);
+    ///
+    /// type Registry = registry!(Foo, Bar);
+    ///
+    /// let mut world = World::<Registry>::new();
+    ///
+    /// world.extend(entities!((Foo(42), Bar(false)); 10));
+    /// world.clear();
+    /// world.extend(entities!((Foo(42), Bar(false)); 3));
+    ///
+    /// // This will reduce the current allocation.
+    /// world.shrink_to_fit();
+    /// ```
+    pub fn shrink_to_fit(&mut self) {
+        self.archetypes.shrink_to_fit();
+    }
 }
 
 #[cfg(test)]
@@ -2015,5 +2041,16 @@ mod tests {
         world.insert(entity!());
 
         assert!(!world.is_empty());
+    }
+
+    #[test]
+    fn shrink_to_fit() {
+        let mut world = World::<Registry>::new();
+
+        world.extend(entities!((A(1), B('a')); 10));
+        world.clear();
+        world.extend(entities!((A(2), B('b')); 3));
+
+        world.shrink_to_fit();
     }
 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -2053,4 +2053,15 @@ mod tests {
 
         world.shrink_to_fit();
     }
+
+    #[test]
+    fn shrink_to_fit_removes_table() {
+        let mut world = World::<Registry>::new();
+
+        world.insert(entity!(A(1)));
+        let entity_identifier = world.insert(entity!(B('a')));
+        world.remove(entity_identifier);
+
+        world.shrink_to_fit();
+    }
 }


### PR DESCRIPTION
This checks off another box in #59. 

Provides a method for shrinking the world's allocation down to the smallest amount possible. Though this won't always be the exactly optimal amount (the allocator can still return with a larger value than requested), it does allow for optimizations, especially in the cases of archetypes no longer being used after a certain point in a program.