### PR TITLE
Resume using the official trybuild crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,7 @@ claims = "0.7.1"
 rustversion = "1.0.9"
 serde_derive = "1.0.144"
 serde_test = "1.0.144"
-# Temporarily use this fork until https://github.com/dtolnay/trybuild/issues/171 is resolved.
-trybuild = {git = "https://github.com/Anders429/trybuild"}
+trybuild = "1.0.69"
 
 [features]
 rayon = ["dep:rayon", "hashbrown/rayon"]


### PR DESCRIPTION
Now that [trybuild#171](https://github.com/dtolnay/trybuild/issues/171) is resolved, the dependency on the official trybuild crate can be used again instead of the custom fork.