### PR TITLE
More lints

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
+comment_width = 100
 format_code_in_doc_comments = true
 imports_granularity = "Crate"
 imports_layout = "Vertical"
+wrap_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 format_code_in_doc_comments = true
 imports_granularity = "Crate"
+imports_layout = "Vertical"

--- a/src/archetype/identifier/impl_serde.rs
+++ b/src/archetype/identifier/impl_serde.rs
@@ -1,11 +1,28 @@
-use crate::{archetype::Identifier, registry::Registry};
-use alloc::{format, vec::Vec};
-use core::{fmt, marker::PhantomData, mem::ManuallyDrop};
+use crate::{
+    archetype::Identifier,
+    registry::Registry,
+};
+use alloc::{
+    format,
+    vec::Vec,
+};
+use core::{
+    fmt,
+    marker::PhantomData,
+    mem::ManuallyDrop,
+};
 use serde::{
     de,
-    de::{SeqAccess, Unexpected, Visitor},
+    de::{
+        SeqAccess,
+        Unexpected,
+        Visitor,
+    },
     ser::SerializeTuple,
-    Deserialize, Deserializer, Serialize, Serializer,
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
 };
 
 impl<R> Serialize for Identifier<R>
@@ -104,7 +121,11 @@ mod tests {
     use super::*;
     use crate::registry;
     use alloc::vec;
-    use serde_test::{assert_de_tokens_error, assert_tokens, Token};
+    use serde_test::{
+        assert_de_tokens_error,
+        assert_tokens,
+        Token,
+    };
 
     macro_rules! create_components {
         ($( $variants:ident ),*) => {

--- a/src/archetype/identifier/impl_serde.rs
+++ b/src/archetype/identifier/impl_serde.rs
@@ -84,8 +84,8 @@ where
 
                 // Check that trailing bits are not set.
                 if R::LEN != 0 {
-                    // SAFETY: `buffer` is guaranteed to have `(R::LEN + 7) / 8` elements, so this will
-                    // always be within the bounds of `buffer.`
+                    // SAFETY: `buffer` is guaranteed to have `(R::LEN + 7) / 8` elements, so this
+                    // will always be within the bounds of `buffer.`
                     let byte = unsafe { buffer.get_unchecked((R::LEN + 7) / 8 - 1) };
                     let bit = R::LEN % 8;
                     if bit != 0 && byte & (255 << bit) != 0 {

--- a/src/archetype/identifier/iter.rs
+++ b/src/archetype/identifier/iter.rs
@@ -103,8 +103,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{archetype::Identifier, registry};
-    use alloc::{vec, vec::Vec};
+    use crate::{
+        archetype::Identifier,
+        registry,
+    };
+    use alloc::{
+        vec,
+        vec::Vec,
+    };
 
     macro_rules! create_components {
         ($( $variants:ident ),*) => {

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -10,9 +10,15 @@ use alloc::vec::Vec;
 use core::{
     fmt,
     fmt::Debug,
-    hash::{Hash, Hasher},
+    hash::{
+        Hash,
+        Hasher,
+    },
     marker::PhantomData,
-    mem::{drop, ManuallyDrop},
+    mem::{
+        drop,
+        ManuallyDrop,
+    },
     slice,
 };
 
@@ -343,8 +349,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{archetype::Identifier, registry};
-    use alloc::{vec, vec::Vec};
+    use crate::{
+        archetype::Identifier,
+        registry,
+    };
+    use alloc::{
+        vec,
+        vec::Vec,
+    };
     use core::ptr;
     use fnv::FnvBuildHasher;
     use hashbrown::HashSet;

--- a/src/archetype/impl_debug.rs
+++ b/src/archetype/impl_debug.rs
@@ -1,7 +1,15 @@
-use crate::{archetype, archetype::Archetype, entity, registry::RegistryDebug};
+use crate::{
+    archetype,
+    archetype::Archetype,
+    entity,
+    registry::RegistryDebug,
+};
 use alloc::vec::Vec;
 use core::{
-    fmt::{self, Debug},
+    fmt::{
+        self,
+        Debug,
+    },
     mem::ManuallyDrop,
 };
 

--- a/src/archetype/impl_drop.rs
+++ b/src/archetype/impl_drop.rs
@@ -1,4 +1,7 @@
-use crate::{archetype::Archetype, registry::Registry};
+use crate::{
+    archetype::Archetype,
+    registry::Registry,
+};
 use alloc::vec::Vec;
 use core::mem::drop;
 

--- a/src/archetype/impl_eq.rs
+++ b/src/archetype/impl_eq.rs
@@ -1,6 +1,9 @@
 use crate::{
     archetype::Archetype,
-    registry::{RegistryEq, RegistryPartialEq},
+    registry::{
+        RegistryEq,
+        RegistryPartialEq,
+    },
 };
 use alloc::vec::Vec;
 use core::mem::ManuallyDrop;

--- a/src/archetype/impl_send.rs
+++ b/src/archetype/impl_send.rs
@@ -1,4 +1,7 @@
-use crate::{archetype::Archetype, registry::Registry};
+use crate::{
+    archetype::Archetype,
+    registry::Registry,
+};
 
 // SAFETY: This type is safe to send between threads, since the pointers to its columns are
 // uniquely owned and cannot be mutated without mutable access to the type.

--- a/src/archetype/impl_serde.rs
+++ b/src/archetype/impl_serde.rs
@@ -3,20 +3,37 @@ use crate::{
     archetype::Archetype,
     component::Component,
     entity,
-    registry::{RegistryDeserialize, RegistrySerialize},
+    registry::{
+        RegistryDeserialize,
+        RegistrySerialize,
+    },
 };
-use alloc::{string::String, vec::Vec};
+use alloc::{
+    string::String,
+    vec::Vec,
+};
 use core::{
     any::type_name,
     fmt,
     marker::PhantomData,
-    mem::{drop, ManuallyDrop},
+    mem::{
+        drop,
+        ManuallyDrop,
+    },
     write,
 };
 use serde::{
-    de::{self, DeserializeSeed, SeqAccess, Visitor},
+    de::{
+        self,
+        DeserializeSeed,
+        SeqAccess,
+        Visitor,
+    },
     ser::SerializeTuple,
-    Deserialize, Deserializer, Serialize, Serializer,
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
 };
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
@@ -819,11 +836,28 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{archetype::Identifier, entity, registry};
-    use alloc::{format, vec};
+    use crate::{
+        archetype::Identifier,
+        entity,
+        registry,
+    };
+    use alloc::{
+        format,
+        vec,
+    };
     use core::any::type_name;
-    use serde_derive::{Deserialize, Serialize};
-    use serde_test::{assert_de_tokens_error, assert_tokens, Compact, Configure, Readable, Token};
+    use serde_derive::{
+        Deserialize,
+        Serialize,
+    };
+    use serde_test::{
+        assert_de_tokens_error,
+        assert_tokens,
+        Compact,
+        Configure,
+        Readable,
+        Token,
+    };
 
     #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
     struct A(u32);

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -8,9 +8,15 @@ mod impl_serde;
 
 pub(crate) mod identifier;
 
-pub(crate) use identifier::{Identifier, IdentifierRef};
+pub(crate) use identifier::{
+    Identifier,
+    IdentifierRef,
+};
 #[cfg(feature = "serde")]
-pub(crate) use impl_serde::{DeserializeColumn, SerializeColumn};
+pub(crate) use impl_serde::{
+    DeserializeColumn,
+    SerializeColumn,
+};
 
 use crate::{
     component::Component,
@@ -18,15 +24,28 @@ use crate::{
     entities::Entities,
     entity,
     entity::{
-        allocator::{Location, Locations},
+        allocator::{
+            Location,
+            Locations,
+        },
         Entity,
     },
-    query::view::{Views, ViewsSeal},
-    registry::{ContainsComponent, ContainsViews, Registry},
+    query::view::{
+        Views,
+        ViewsSeal,
+    },
+    registry::{
+        ContainsComponent,
+        ContainsViews,
+        Registry,
+    },
 };
 #[cfg(feature = "rayon")]
 use crate::{
-    query::view::{ParViews, ParViewsSeal},
+    query::view::{
+        ParViews,
+        ParViewsSeal,
+    },
     registry::ContainsParViews,
 };
 use alloc::vec::Vec;
@@ -34,7 +53,10 @@ use alloc::vec::Vec;
 use core::slice;
 use core::{
     marker::PhantomData,
-    mem::{ManuallyDrop, MaybeUninit},
+    mem::{
+        ManuallyDrop,
+        MaybeUninit,
+    },
 };
 
 pub(crate) struct Archetype<R>

--- a/src/archetypes/impl_debug.rs
+++ b/src/archetypes/impl_debug.rs
@@ -1,5 +1,11 @@
-use crate::{archetypes::Archetypes, registry::RegistryDebug};
-use core::{fmt, fmt::Debug};
+use crate::{
+    archetypes::Archetypes,
+    registry::RegistryDebug,
+};
+use core::{
+    fmt,
+    fmt::Debug,
+};
 
 impl<R> Debug for Archetypes<R>
 where

--- a/src/archetypes/impl_eq.rs
+++ b/src/archetypes/impl_eq.rs
@@ -1,6 +1,9 @@
 use crate::{
     archetypes::Archetypes,
-    registry::{RegistryEq, RegistryPartialEq},
+    registry::{
+        RegistryEq,
+        RegistryPartialEq,
+    },
 };
 
 impl<R> PartialEq for Archetypes<R>

--- a/src/archetypes/impl_serde.rs
+++ b/src/archetypes/impl_serde.rs
@@ -255,7 +255,8 @@ mod tests {
 
         assert_tokens(
             &SeededArchetypes { archetypes, len: 6 }.compact(),
-            // The order here should stay constant, because the fnv hasher uses the same seed every time.
+            // The order here should stay constant, because the fnv hasher uses the same seed every
+            // time.
             &[
                 Token::Seq { len: Some(4) },
                 // B Archetype

--- a/src/archetypes/impl_serde.rs
+++ b/src/archetypes/impl_serde.rs
@@ -1,13 +1,28 @@
 use crate::{
     archetype::Archetype,
     archetypes::Archetypes,
-    registry::{RegistryDeserialize, RegistrySerialize},
+    registry::{
+        RegistryDeserialize,
+        RegistrySerialize,
+    },
 };
-use core::{cmp, fmt, format_args, marker::PhantomData};
+use core::{
+    cmp,
+    fmt,
+    format_args,
+    marker::PhantomData,
+};
 use serde::{
     de,
-    de::{DeserializeSeed, Expected, SeqAccess, Visitor},
-    Deserializer, Serialize, Serializer,
+    de::{
+        DeserializeSeed,
+        Expected,
+        SeqAccess,
+        Visitor,
+    },
+    Deserializer,
+    Serialize,
+    Serializer,
 };
 
 impl<R> Serialize for Archetypes<R>
@@ -97,15 +112,41 @@ mod tests {
     use super::*;
     use crate::{
         archetype::Identifier,
-        entity, registry,
-        registry::{RegistryDebug, RegistryEq, RegistryPartialEq},
+        entity,
+        registry,
+        registry::{
+            RegistryDebug,
+            RegistryEq,
+            RegistryPartialEq,
+        },
     };
-    use alloc::{format, vec};
+    use alloc::{
+        format,
+        vec,
+    };
     use claims::assert_ok;
-    use core::{any::type_name, fmt, fmt::Debug};
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use serde_derive::{Deserialize, Serialize};
-    use serde_test::{assert_de_tokens_error, assert_tokens, Compact, Configure, Token};
+    use core::{
+        any::type_name,
+        fmt,
+        fmt::Debug,
+    };
+    use serde::{
+        Deserialize,
+        Deserializer,
+        Serialize,
+        Serializer,
+    };
+    use serde_derive::{
+        Deserialize,
+        Serialize,
+    };
+    use serde_test::{
+        assert_de_tokens_error,
+        assert_tokens,
+        Compact,
+        Configure,
+        Token,
+    };
 
     struct SeededArchetypes<R>
     where

--- a/src/archetypes/iter.rs
+++ b/src/archetypes/iter.rs
@@ -1,4 +1,7 @@
-use crate::{archetype::Archetype, registry::Registry};
+use crate::{
+    archetype::Archetype,
+    registry::Registry,
+};
 use core::marker::PhantomData;
 use hashbrown::raw::RawIter;
 

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -83,7 +83,8 @@ where
     fn make_hasher(hash_builder: &FnvBuildHasher) -> impl Fn(&Archetype<R>) -> u64 + '_ {
         move |archetype| {
             Self::make_hash(
-                // SAFETY: The `IdentifierRef` obtained here does not live longer than the `archetype`.
+                // SAFETY: The `IdentifierRef` obtained here does not live longer than the
+                // `archetype`.
                 unsafe { archetype.identifier() },
                 hash_builder,
             )

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -16,16 +16,29 @@ pub(crate) use par_iter::ParIterMut;
 use crate::{
     archetype,
     archetype::Archetype,
-    entity::{self, Entity},
-    registry::{Canonical, Registry},
+    entity::{
+        self,
+        Entity,
+    },
+    registry::{
+        Canonical,
+        Registry,
+    },
 };
 use core::{
     any::TypeId,
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{
+        BuildHasher,
+        Hash,
+        Hasher,
+    },
     hint::unreachable_unchecked,
 };
 use fnv::FnvBuildHasher;
-use hashbrown::{raw::RawTable, HashMap};
+use hashbrown::{
+    raw::RawTable,
+    HashMap,
+};
 use iter::Iter;
 
 pub(crate) struct Archetypes<R>
@@ -268,7 +281,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{archetype, archetypes::Archetypes, registry};
+    use crate::{
+        archetype,
+        archetypes::Archetypes,
+        registry,
+    };
     use alloc::vec;
 
     macro_rules! create_components {

--- a/src/archetypes/par_iter.rs
+++ b/src/archetypes/par_iter.rs
@@ -1,7 +1,14 @@
-use crate::{archetype::Archetype, archetypes::Archetypes, registry::Registry};
+use crate::{
+    archetype::Archetype,
+    archetypes::Archetypes,
+    registry::Registry,
+};
 use core::marker::PhantomData;
 use hashbrown::raw::rayon::RawParIter;
-use rayon::iter::{plumbing::UnindexedConsumer, ParallelIterator};
+use rayon::iter::{
+    plumbing::UnindexedConsumer,
+    ParallelIterator,
+};
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub(crate) struct ParIterMut<'a, R>

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -15,7 +15,11 @@
 //!
 //! # Example
 //! ``` rust
-//! use brood::{entities, registry, World};
+//! use brood::{
+//!     entities,
+//!     registry,
+//!     World,
+//! };
 //!
 //! // Define components.
 //! struct Foo(usize);
@@ -41,7 +45,10 @@ mod seal;
 pub(crate) use get::Get;
 pub(crate) use seal::Contains;
 
-use crate::{component::Component, hlist::define_null};
+use crate::{
+    component::Component,
+    hlist::define_null,
+};
 use alloc::vec::Vec;
 use seal::Seal;
 
@@ -128,7 +135,10 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entities, entities::Batch};
+    /// use brood::{
+    ///     entities,
+    ///     entities::Batch,
+    /// };
     ///
     /// // Define components.
     /// struct Foo(usize);
@@ -160,7 +170,10 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entities, entities::Batch};
+    /// use brood::{
+    ///     entities,
+    ///     entities::Batch,
+    /// };
     ///
     /// // Define components.
     /// struct Foo(usize);

--- a/src/entities/seal/contains.rs
+++ b/src/entities/seal/contains.rs
@@ -1,7 +1,12 @@
 //! Provides the `Contains` trait to indicate what entity type is contained in a heterogeneous list
 //! implementing `Entities`.
 
-use crate::{component::Component, entities::Null, entity, entity::Entity};
+use crate::{
+    component::Component,
+    entities::Null,
+    entity,
+    entity::Entity,
+};
 use alloc::vec::Vec;
 
 /// Defines the entity type contained by `Entities`.

--- a/src/entities/seal/length.rs
+++ b/src/entities/seal/length.rs
@@ -1,4 +1,7 @@
-use crate::{component::Component, entities::Null};
+use crate::{
+    component::Component,
+    entities::Null,
+};
 use alloc::vec::Vec;
 
 pub trait Length {

--- a/src/entities/seal/mod.rs
+++ b/src/entities/seal/mod.rs
@@ -4,7 +4,10 @@ mod storage;
 
 pub(crate) use contains::Contains;
 
-use crate::{component::Component, entities::Null};
+use crate::{
+    component::Component,
+    entities::Null,
+};
 use alloc::vec::Vec;
 use length::Length;
 use storage::Storage;

--- a/src/entities/seal/storage.rs
+++ b/src/entities/seal/storage.rs
@@ -42,8 +42,8 @@ where
             let mut v = ManuallyDrop::new(
                 // SAFETY: The `component_column` extracted from `components` is guaranteed to,
                 // together with `length`, define a valid `Vec<C>` for the current `C`, because the
-                // `component_column` extracted is guaranteed by the safety contract to correspond to
-                // the column for component `C`.
+                // `component_column` extracted is guaranteed by the safety contract to correspond
+                // to the column for component `C`.
                 unsafe {
                     Vec::<C>::from_raw_parts(
                         component_column.0.cast::<C>(),

--- a/src/entities/seal/storage.rs
+++ b/src/entities/seal/storage.rs
@@ -1,4 +1,7 @@
-use crate::{component::Component, entities::Null};
+use crate::{
+    component::Component,
+    entities::Null,
+};
 use alloc::vec::Vec;
 use core::mem::ManuallyDrop;
 

--- a/src/entity/allocator/impl_serde.rs
+++ b/src/entity/allocator/impl_serde.rs
@@ -280,7 +280,7 @@ where
         // Convert to completed EntityAllocator.
         for (i, slot) in slots.iter().enumerate() {
             if slot.is_none() {
-                return Err(de::Error::custom(format!("missing entity index {}", i)));
+                return Err(de::Error::custom(format!("missing entity index {i}")));
             }
         }
         Ok(Self {

--- a/src/entity/allocator/impl_serde.rs
+++ b/src/entity/allocator/impl_serde.rs
@@ -1,12 +1,38 @@
-use super::{Allocator, Location, Slot};
-use crate::{archetypes::Archetypes, entity, registry::Registry};
-use alloc::{format, vec, vec::Vec};
-use core::{fmt, marker::PhantomData};
+use super::{
+    Allocator,
+    Location,
+    Slot,
+};
+use crate::{
+    archetypes::Archetypes,
+    entity,
+    registry::Registry,
+};
+use alloc::{
+    format,
+    vec,
+    vec::Vec,
+};
+use core::{
+    fmt,
+    marker::PhantomData,
+};
 use serde::{
     de,
-    de::{DeserializeSeed, MapAccess, SeqAccess, Visitor},
-    ser::{SerializeSeq, SerializeStruct},
-    Deserialize, Deserializer, Serialize, Serializer,
+    de::{
+        DeserializeSeed,
+        MapAccess,
+        SeqAccess,
+        Visitor,
+    },
+    ser::{
+        SerializeSeq,
+        SerializeStruct,
+    },
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
 };
 
 struct SerializeFree<'a, R>(&'a Allocator<R>)
@@ -279,15 +305,32 @@ mod tests {
     use crate::{
         archetype,
         archetype::Archetype,
-        entity, registry,
+        entity,
+        registry,
         registry::{
-            RegistryDebug, RegistryDeserialize, RegistryEq, RegistryPartialEq, RegistrySerialize,
+            RegistryDebug,
+            RegistryDeserialize,
+            RegistryEq,
+            RegistryPartialEq,
+            RegistrySerialize,
         },
     };
     use claims::assert_ok;
-    use core::{fmt, fmt::Debug, marker::PhantomData};
-    use serde_derive::{Deserialize, Serialize};
-    use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
+    use core::{
+        fmt,
+        fmt::Debug,
+        marker::PhantomData,
+    };
+    use serde_derive::{
+        Deserialize,
+        Serialize,
+    };
+    use serde_test::{
+        assert_de_tokens,
+        assert_de_tokens_error,
+        assert_tokens,
+        Token,
+    };
 
     #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
     struct A;

--- a/src/entity/allocator/location.rs
+++ b/src/entity/allocator/location.rs
@@ -1,5 +1,11 @@
-use crate::{archetype, registry::Registry};
-use core::{fmt, fmt::Debug};
+use crate::{
+    archetype,
+    registry::Registry,
+};
+use core::{
+    fmt,
+    fmt::Debug,
+};
 
 /// Defines an entity's location.
 ///
@@ -62,7 +68,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::Location;
-    use crate::{archetype::Identifier, registry};
+    use crate::{
+        archetype::Identifier,
+        registry,
+    };
     use alloc::vec;
 
     macro_rules! create_components {

--- a/src/entity/allocator/locations.rs
+++ b/src/entity/allocator/locations.rs
@@ -1,4 +1,8 @@
-use crate::{archetype, entity::allocator::Location, registry::Registry};
+use crate::{
+    archetype,
+    entity::allocator::Location,
+    registry::Registry,
+};
 use core::ops::Range;
 
 /// A batch of [`Location`]s, all sharing the same [`archetype::Identifier`].

--- a/src/entity/allocator/mod.rs
+++ b/src/entity/allocator/mod.rs
@@ -11,9 +11,18 @@ pub(crate) use location::Location;
 pub(crate) use locations::Locations;
 pub(crate) use slot::Slot;
 
-use crate::{entity, registry::Registry};
-use alloc::{collections::VecDeque, vec::Vec};
-use core::{fmt, fmt::Debug};
+use crate::{
+    entity,
+    registry::Registry,
+};
+use alloc::{
+    collections::VecDeque,
+    vec::Vec,
+};
+use core::{
+    fmt,
+    fmt::Debug,
+};
 
 pub struct Allocator<R>
 where

--- a/src/entity/allocator/slot.rs
+++ b/src/entity/allocator/slot.rs
@@ -1,5 +1,11 @@
-use crate::{entity::allocator::Location, registry::Registry};
-use core::{fmt, fmt::Debug};
+use crate::{
+    entity::allocator::Location,
+    registry::Registry,
+};
+use core::{
+    fmt,
+    fmt::Debug,
+};
 
 /// An entry for a possibly allocated entity.
 ///
@@ -93,9 +99,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{archetype::Identifier, registry};
+    use crate::{
+        archetype::Identifier,
+        registry,
+    };
     use alloc::vec;
-    use claims::{assert_none, assert_some_eq};
+    use claims::{
+        assert_none,
+        assert_some_eq,
+    };
 
     macro_rules! create_components {
         ($( $variants:ident ),*) => {

--- a/src/entity/identifier/impl_serde.rs
+++ b/src/entity/identifier/impl_serde.rs
@@ -1,9 +1,17 @@
 use super::Identifier;
 use core::fmt;
 use serde::{
-    de::{self, MapAccess, SeqAccess, Visitor},
+    de::{
+        self,
+        MapAccess,
+        SeqAccess,
+        Visitor,
+    },
     ser::SerializeStruct,
-    Deserialize, Deserializer, Serialize, Serializer,
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
 };
 
 impl Serialize for Identifier {
@@ -117,7 +125,12 @@ impl<'de> Deserialize<'de> for Identifier {
 #[cfg(test)]
 mod tests {
     use crate::entity::Identifier;
-    use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
+    use serde_test::{
+        assert_de_tokens,
+        assert_de_tokens_error,
+        assert_tokens,
+        Token,
+    };
 
     #[test]
     fn serialize_deserialize() {

--- a/src/entity/identifier/mod.rs
+++ b/src/entity/identifier/mod.rs
@@ -10,7 +10,11 @@ mod impl_serde;
 ///
 /// # Example
 /// ``` rust
-/// use brood::{entity, registry, World};
+/// use brood::{
+///     entity,
+///     registry,
+///     World,
+/// };
 ///
 /// // Define components.
 /// struct Foo(usize);

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -11,7 +11,11 @@
 //!
 //! # Example
 //! ``` rust
-//! use brood::{entity, registry, World};
+//! use brood::{
+//!     entity,
+//!     registry,
+//!     World,
+//! };
 //!
 //! // Define components.
 //! struct Foo(usize);
@@ -48,7 +52,10 @@ pub use identifier::Identifier;
 pub(crate) use allocator::Allocator;
 pub(crate) use get::Get;
 
-use crate::{component::Component, hlist::define_null};
+use crate::{
+    component::Component,
+    hlist::define_null,
+};
 use seal::Seal;
 
 define_null!();

--- a/src/entity/seal/mod.rs
+++ b/src/entity/seal/mod.rs
@@ -1,6 +1,9 @@
 mod storage;
 
-use crate::{component::Component, entity::Null};
+use crate::{
+    component::Component,
+    entity::Null,
+};
 use storage::Storage;
 
 pub trait Seal: Storage {}

--- a/src/entity/seal/storage.rs
+++ b/src/entity/seal/storage.rs
@@ -1,4 +1,7 @@
-use crate::{component::Component, entity::Null};
+use crate::{
+    component::Component,
+    entity::Null,
+};
 use alloc::vec::Vec;
 use core::mem::ManuallyDrop;
 

--- a/src/hlist.rs
+++ b/src/hlist.rs
@@ -14,7 +14,14 @@ macro_rules! define_null {
         mod impl_serde {
             use super::Null;
             use core::fmt;
-            use serde::{de, de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+            use serde::{
+                de,
+                de::Visitor,
+                Deserialize,
+                Deserializer,
+                Serialize,
+                Serializer,
+            };
 
             impl Serialize for Null {
                 fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -75,7 +82,12 @@ pub(crate) use define_null_uninstantiable;
 mod tests {
     use super::*;
     #[cfg(feature = "serde")]
-    use serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
+    use serde_test::{
+        assert_de_tokens,
+        assert_de_tokens_error,
+        assert_tokens,
+        Token,
+    };
 
     define_null!();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,10 @@
 //! #
 //! # type Registry = registry!(Position, Velocity);
 //! #
-//! use brood::{entity, World};
+//! use brood::{
+//!     entity,
+//!     World,
+//! };
 //!
 //! let mut world = World::<Registry>::new();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@
 //!
 //! # Key Features
 //! - Entities made up of an arbitrary number of components.
-//! - Built-in support for [`serde`](https://crates.io/crates/serde), providing pain-free serialization and deserialization of `World` containers.
+//! - Built-in support for [`serde`](https://crates.io/crates/serde), providing pain-free
+//!   serialization and deserialization of `World` containers.
 //! - Inner- and outer-parallelism using [`rayon`](https://crates.io/crates/rayon).
 //! - Minimal boilerplate.
 //! - `no_std` compatible.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,12 @@
 #![no_std]
 #![cfg_attr(doc_cfg, feature(doc_cfg, decl_macro))]
 #![warn(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
     clippy::pedantic,
     clippy::undocumented_unsafe_blocks,
+    clippy::unwrap_used,
     missing_docs,
     unsafe_op_in_unsafe_fn
 )]

--- a/src/query/claim.rs
+++ b/src/query/claim.rs
@@ -1,4 +1,8 @@
-use crate::{component::Component, entity, query::view};
+use crate::{
+    component::Component,
+    entity,
+    query::view,
+};
 use core::any::TypeId;
 use fnv::FnvBuildHasher;
 use hashbrown::HashSet;

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -18,7 +18,13 @@ mod seal;
 
 pub(crate) use seal::Seal;
 
-use crate::{component::Component, entity, query::view, registry, registry::Registry};
+use crate::{
+    component::Component,
+    entity,
+    query::view,
+    registry,
+    registry::Registry,
+};
 use core::marker::PhantomData;
 
 /// A filter for entities.

--- a/src/query/filter/seal.rs
+++ b/src/query/filter/seal.rs
@@ -3,10 +3,20 @@ use crate::{
     component::Component,
     entity,
     query::{
-        filter::{And, Filter, Has, None, Not, Or},
+        filter::{
+            And,
+            Filter,
+            Has,
+            None,
+            Not,
+            Or,
+        },
         view,
     },
-    registry::{self, Registry},
+    registry::{
+        self,
+        Registry,
+    },
 };
 
 pub trait Seal<R, I>
@@ -139,7 +149,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{query::views, registry};
+    use crate::{
+        query::views,
+        registry,
+    };
     use alloc::vec;
 
     struct A;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -15,8 +15,14 @@
 //! ``` rust
 //! use brood::{
 //!     entity,
-//!     query::{filter, result, views},
-//!     registry, Query, World,
+//!     query::{
+//!         filter,
+//!         result,
+//!         views,
+//!     },
+//!     registry,
+//!     Query,
+//!     World,
 //! };
 //!
 //! // Define components.
@@ -63,8 +69,14 @@ use core::marker::PhantomData;
 /// ``` rust
 /// use brood::{
 ///     entity,
-///     query::{filter, result, views},
-///     registry, Query, World,
+///     query::{
+///         filter,
+///         result,
+///         views,
+///     },
+///     registry,
+///     Query,
+///     World,
 /// };
 ///
 /// // Define components.

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -1,13 +1,26 @@
 use crate::{
     archetypes,
     query::{
-        filter::{And, Filter, Seal},
-        result::{Reshape, Results},
+        filter::{
+            And,
+            Filter,
+            Seal,
+        },
+        result::{
+            Reshape,
+            Results,
+        },
         view::Views,
     },
-    registry::{ContainsViews, Registry},
+    registry::{
+        ContainsViews,
+        Registry,
+    },
 };
-use core::{iter::FusedIterator, marker::PhantomData};
+use core::{
+    iter::FusedIterator,
+    marker::PhantomData,
+};
 
 /// An [`Iterator`] over the results of a query.
 ///
@@ -22,8 +35,14 @@ use core::{iter::FusedIterator, marker::PhantomData};
 /// ``` rust
 /// use brood::{
 ///     entity,
-///     query::{filter, result, views},
-///     registry, Query, World,
+///     query::{
+///         filter,
+///         result,
+///         views,
+///     },
+///     registry,
+///     Query,
+///     World,
 /// };
 ///
 /// struct Foo(u32);

--- a/src/query/result/mod.rs
+++ b/src/query/result/mod.rs
@@ -18,8 +18,14 @@
 //! ``` rust
 //! use brood::{
 //!     entity,
-//!     query::{filter, result, views},
-//!     registry, Query, World,
+//!     query::{
+//!         filter,
+//!         result,
+//!         views,
+//!     },
+//!     registry,
+//!     Query,
+//!     World,
 //! };
 //!
 //! struct Foo(u32);

--- a/src/query/result/par_iter.rs
+++ b/src/query/result/par_iter.rs
@@ -2,15 +2,33 @@ use crate::{
     archetype::Archetype,
     archetypes,
     query::{
-        filter::{And, Filter, Seal},
-        result::{ParResults, Reshape},
-        view::{ParViews, ParViewsSeal},
+        filter::{
+            And,
+            Filter,
+            Seal,
+        },
+        result::{
+            ParResults,
+            Reshape,
+        },
+        view::{
+            ParViews,
+            ParViewsSeal,
+        },
     },
-    registry::{ContainsParViews, Registry},
+    registry::{
+        ContainsParViews,
+        Registry,
+    },
 };
 use core::marker::PhantomData;
 use rayon::iter::{
-    plumbing::{Consumer, Folder, Reducer, UnindexedConsumer},
+    plumbing::{
+        Consumer,
+        Folder,
+        Reducer,
+        UnindexedConsumer,
+    },
     ParallelIterator,
 };
 
@@ -26,8 +44,14 @@ use rayon::iter::{
 /// ``` rust
 /// use brood::{
 ///     entity,
-///     query::{filter, result, views},
-///     registry, Query, World,
+///     query::{
+///         filter,
+///         result,
+///         views,
+///     },
+///     registry,
+///     Query,
+///     World,
 /// };
 /// use rayon::iter::ParallelIterator;
 ///

--- a/src/query/result/reshape.rs
+++ b/src/query/result/reshape.rs
@@ -1,6 +1,9 @@
 use crate::{
     hlist::define_null_uninstantiable,
-    query::{result::Get, view},
+    query::{
+        result::Get,
+        view,
+    },
 };
 use core::iter;
 

--- a/src/query/result/seal/par.rs
+++ b/src/query/result/seal/par.rs
@@ -1,5 +1,8 @@
 use crate::query::view;
-use rayon::{iter, iter::IndexedParallelIterator};
+use rayon::{
+    iter,
+    iter::IndexedParallelIterator,
+};
 
 pub trait ParResults {
     type View: Send;

--- a/src/query/view/get.rs
+++ b/src/query/view/get.rs
@@ -2,7 +2,10 @@ use crate::{
     entity,
     query::{
         result::get::Index,
-        view::{View, Views},
+        view::{
+            View,
+            Views,
+        },
     },
 };
 

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -21,7 +21,10 @@
 //!
 //! # Example
 //! ``` rust
-//! use brood::{entity, query::views};
+//! use brood::{
+//!     entity,
+//!     query::views,
+//! };
 //!
 //! // Define components.
 //! struct Foo(u32);
@@ -51,15 +54,26 @@ mod reshape;
 mod seal;
 
 #[cfg(feature = "rayon")]
-pub use par::{ParView, ParViews};
+pub use par::{
+    ParView,
+    ParViews,
+};
 
 pub(crate) use get::Get;
 #[cfg(feature = "rayon")]
-pub(crate) use par::{ParViewsSeal, RepeatNone};
+pub(crate) use par::{
+    ParViewsSeal,
+    RepeatNone,
+};
 pub(crate) use reshape::Reshape;
 pub(crate) use seal::ViewsSeal;
 
-use crate::{component::Component, doc, entity, hlist::define_null};
+use crate::{
+    component::Component,
+    doc,
+    entity,
+    hlist::define_null,
+};
 use seal::ViewSeal;
 
 /// A view over a single aspect of an entity.

--- a/src/query/view/par/mod.rs
+++ b/src/query/view/par/mod.rs
@@ -1,8 +1,15 @@
 mod seal;
 
-pub(crate) use seal::{ParViewsSeal, RepeatNone};
+pub(crate) use seal::{
+    ParViewsSeal,
+    RepeatNone,
+};
 
-use crate::{component::Component, entity, query::view::Null};
+use crate::{
+    component::Component,
+    entity,
+    query::view::Null,
+};
 use seal::ParViewSeal;
 
 /// A parallel view over a single aspect of an entity.

--- a/src/query/view/par/seal/mod.rs
+++ b/src/query/view/par/seal/mod.rs
@@ -7,12 +7,19 @@ use crate::{
     entity,
     query::{
         result::ParResults,
-        view::{Null, View, Views},
+        view::{
+            Null,
+            View,
+            Views,
+        },
     },
 };
 use rayon::{
     iter,
-    iter::{Either, IndexedParallelIterator},
+    iter::{
+        Either,
+        IndexedParallelIterator,
+    },
     slice,
 };
 

--- a/src/query/view/par/seal/repeat.rs
+++ b/src/query/view/par/seal/repeat.rs
@@ -1,7 +1,14 @@
 use core::marker::PhantomData;
 use rayon::iter::{
-    plumbing::{bridge, Consumer, Producer, ProducerCallback, UnindexedConsumer},
-    IndexedParallelIterator, ParallelIterator,
+    plumbing::{
+        bridge,
+        Consumer,
+        Producer,
+        ProducerCallback,
+        UnindexedConsumer,
+    },
+    IndexedParallelIterator,
+    ParallelIterator,
 };
 
 pub struct RepeatNone<T> {

--- a/src/query/view/reshape.rs
+++ b/src/query/view/reshape.rs
@@ -1,4 +1,8 @@
-use crate::query::{result::reshape::Null, view, view::Get};
+use crate::query::{
+    result::reshape::Null,
+    view,
+    view::Get,
+};
 
 pub trait Reshape<'a, R, I> {
     fn reshape(self) -> R;

--- a/src/query/view/seal.rs
+++ b/src/query/view/seal.rs
@@ -1,9 +1,16 @@
 use crate::{
     component::Component,
     entity,
-    query::{claim::Claim, result::Results, view::Null},
+    query::{
+        claim::Claim,
+        result::Results,
+        view::Null,
+    },
 };
-use core::{iter, slice};
+use core::{
+    iter,
+    slice,
+};
 use either::Either;
 
 pub trait ViewSeal<'a>: Claim {

--- a/src/registry/contains.rs
+++ b/src/registry/contains.rs
@@ -12,21 +12,36 @@ use crate::{
     entity,
     entity::Entity,
     query::{
-        result, view,
-        view::{Views, ViewsSeal},
+        result,
+        view,
+        view::{
+            Views,
+            ViewsSeal,
+        },
     },
     registry,
-    registry::{Canonical, CanonicalViews, Length, Registry},
+    registry::{
+        Canonical,
+        CanonicalViews,
+        Length,
+        Registry,
+    },
 };
 #[cfg(feature = "rayon")]
 use crate::{
-    query::view::{ParViews, ParViewsSeal},
+    query::view::{
+        ParViews,
+        ParViewsSeal,
+    },
     registry::CanonicalParViews,
 };
 use alloc::vec::Vec;
 use core::slice;
 #[cfg(feature = "rayon")]
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{
+    IntoParallelRefIterator,
+    ParallelIterator,
+};
 
 /// Type marker for a component contained in an entity.
 ///
@@ -812,7 +827,10 @@ mod component_tests {
 #[cfg(test)]
 mod entity_tests {
     use super::ContainsEntity;
-    use crate::{entity, registry};
+    use crate::{
+        entity,
+        registry,
+    };
 
     #[derive(Debug, Eq, PartialEq)]
     struct A;
@@ -857,7 +875,10 @@ mod entity_tests {
 #[cfg(test)]
 mod entities_tests {
     use super::ContainsEntities;
-    use crate::{entities, registry};
+    use crate::{
+        entities,
+        registry,
+    };
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     struct A;

--- a/src/registry/debug.rs
+++ b/src/registry/debug.rs
@@ -8,12 +8,18 @@
 use crate::{
     archetype,
     component::Component,
-    registry::{Null, Registry},
+    registry::{
+        Null,
+        Registry,
+    },
 };
 use alloc::vec::Vec;
 use core::{
     any::type_name,
-    fmt::{Debug, DebugMap},
+    fmt::{
+        Debug,
+        DebugMap,
+    },
     mem::size_of,
 };
 

--- a/src/registry/eq.rs
+++ b/src/registry/eq.rs
@@ -11,7 +11,10 @@
 use crate::{
     archetype,
     component::Component,
-    registry::{Null, Registry},
+    registry::{
+        Null,
+        Registry,
+    },
 };
 use alloc::vec::Vec;
 use core::mem::ManuallyDrop;
@@ -173,7 +176,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::RegistryPartialEq;
-    use crate::{archetype::Identifier, registry};
+    use crate::{
+        archetype::Identifier,
+        registry,
+    };
     use alloc::vec;
 
     #[test]

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -8,7 +8,10 @@
 //!
 //! # Example
 //! ``` rust
-//! use brood::{registry, World};
+//! use brood::{
+//!     registry,
+//!     World,
+//! };
 //!
 //! // Define components.
 //! struct Foo(usize);
@@ -38,17 +41,35 @@ pub use contains::ContainsParViews;
 pub use contains::ContainsViews;
 
 #[cfg(feature = "serde")]
-pub(crate) use self::serde::{RegistryDeserialize, RegistrySerialize};
-pub(crate) use contains::{ContainsComponent, ContainsEntities, ContainsEntity};
+pub(crate) use self::serde::{
+    RegistryDeserialize,
+    RegistrySerialize,
+};
+pub(crate) use contains::{
+    ContainsComponent,
+    ContainsEntities,
+    ContainsEntity,
+};
 pub(crate) use debug::RegistryDebug;
-pub(crate) use eq::{RegistryEq, RegistryPartialEq};
+pub(crate) use eq::{
+    RegistryEq,
+    RegistryPartialEq,
+};
 #[cfg(feature = "rayon")]
 pub(crate) use seal::CanonicalParViews;
-pub(crate) use seal::{Canonical, CanonicalViews, Filter, Length};
+pub(crate) use seal::{
+    Canonical,
+    CanonicalViews,
+    Filter,
+    Length,
+};
 pub(crate) use send::RegistrySend;
 pub(crate) use sync::RegistrySync;
 
-use crate::{component::Component, hlist::define_null_uninstantiable};
+use crate::{
+    component::Component,
+    hlist::define_null_uninstantiable,
+};
 use seal::Seal;
 
 define_null_uninstantiable!();
@@ -99,7 +120,10 @@ where
 ///
 /// # Example
 /// ``` rust
-/// use brood::{registry, World};
+/// use brood::{
+///     registry,
+///     World,
+/// };
 ///
 /// // Define components `Foo` and `Bar`.
 /// struct Foo(u16);

--- a/src/registry/seal/assertions.rs
+++ b/src/registry/seal/assertions.rs
@@ -6,7 +6,10 @@
 //!
 //! [`Registry`]: crate::registry::Registry
 
-use crate::{component::Component, registry::Null};
+use crate::{
+    component::Component,
+    registry::Null,
+};
 use core::any::TypeId;
 use fnv::FnvBuildHasher;
 use hashbrown::HashSet;

--- a/src/registry/seal/canonical.rs
+++ b/src/registry/seal/canonical.rs
@@ -8,10 +8,17 @@
 use crate::{
     archetype,
     component::Component,
-    entity, registry,
-    registry::{seal::Length, Registry},
+    entity,
+    registry,
+    registry::{
+        seal::Length,
+        Registry,
+    },
 };
-use alloc::{vec, vec::Vec};
+use alloc::{
+    vec,
+    vec::Vec,
+};
 
 /// Type marker for a component contained in an entity.
 pub enum Contained {}
@@ -123,7 +130,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{archetype, entity, registry};
+    use crate::{
+        archetype,
+        entity,
+        registry,
+    };
     use alloc::vec::Vec;
 
     struct A;

--- a/src/registry/seal/filter.rs
+++ b/src/registry/seal/filter.rs
@@ -3,7 +3,10 @@
 //! This allows archetype identifiers that are generic over this registry to be safely queried for
 //! a component.
 
-use crate::{archetype, registry::Registry};
+use crate::{
+    archetype,
+    registry::Registry,
+};
 
 /// Type marker component's index in registry.
 pub enum Index {}
@@ -47,7 +50,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{archetype, registry};
+    use crate::{
+        archetype,
+        registry,
+    };
     use alloc::vec;
 
     struct A;

--- a/src/registry/seal/length.rs
+++ b/src/registry/seal/length.rs
@@ -2,7 +2,10 @@
 //!
 //! [`Registry`]: crate::registry::Registry
 
-use crate::{component::Component, registry::Null};
+use crate::{
+    component::Component,
+    registry::Null,
+};
 
 /// Defines a length for the given heterogeneous list.
 pub trait Length {

--- a/src/registry/seal/mod.rs
+++ b/src/registry/seal/mod.rs
@@ -29,7 +29,10 @@ pub(crate) use view::CanonicalViews;
 
 use crate::{
     component::Component,
-    registry::{contains::EntityIdentifierMarker, Null},
+    registry::{
+        contains::EntityIdentifierMarker,
+        Null,
+    },
 };
 use assertions::Assertions;
 use storage::Storage;

--- a/src/registry/seal/par_view.rs
+++ b/src/registry/seal/par_view.rs
@@ -147,9 +147,10 @@ where
             if unsafe { archetype_identifier.next().unwrap_unchecked() } {
                 Either::Right(
                     // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of
-                    // size `length`. Since `component_map` contains an entry for the given component
-                    // `C`'s entry in `columns`, then the column obtained here can be interpreted as a
-                    // slice of type `C` of size `length`.
+                    // size `length`. Since `component_map` contains an entry for the given
+                    // component `C`'s entry in `columns`, then the column
+                    // obtained here can be interpreted as a slice of type `C`
+                    // of size `length`.
                     unsafe {
                         core::slice::from_raw_parts(
                             {
@@ -196,9 +197,10 @@ where
             if unsafe { archetype_identifier.next().unwrap_unchecked() } {
                 Either::Right(
                     // SAFETY: `columns` is guaranteed to contain raw parts for a valid `Vec<C>` of
-                    // size `length`. Since `component_map` contains an entry for the given component
-                    // `C`'s entry in `columns`, then the column obtained here can be interpreted as a
-                    // slice of type `C` of size `length`.
+                    // size `length`. Since `component_map` contains an entry for the given
+                    // component `C`'s entry in `columns`, then the column
+                    // obtained here can be interpreted as a slice of type `C`
+                    // of size `length`.
                     unsafe {
                         core::slice::from_raw_parts_mut(
                             {

--- a/src/registry/seal/par_view.rs
+++ b/src/registry/seal/par_view.rs
@@ -3,17 +3,30 @@ use crate::{
     component::Component,
     query::{
         view,
-        view::{ParViews, ParViewsSeal, RepeatNone},
+        view::{
+            ParViews,
+            ParViewsSeal,
+            RepeatNone,
+        },
     },
     registry,
     registry::{
-        contains::{Contained, NotContained, Null},
+        contains::{
+            Contained,
+            NotContained,
+            Null,
+        },
         Registry,
     },
 };
 use rayon::{
     iter,
-    iter::{Either, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator},
+    iter::{
+        Either,
+        IntoParallelRefIterator,
+        IntoParallelRefMutIterator,
+        ParallelIterator,
+    },
 };
 
 pub trait CanonicalParViews<'a, V, P>

--- a/src/registry/seal/storage.rs
+++ b/src/registry/seal/storage.rs
@@ -15,14 +15,25 @@
 use crate::{
     archetype,
     component::Component,
-    registry::{Null, Registry},
+    registry::{
+        Null,
+        Registry,
+    },
 };
 use alloc::vec::Vec;
 use core::{
-    any::{type_name, TypeId},
+    any::{
+        type_name,
+        TypeId,
+    },
     fmt::DebugList,
     marker::PhantomData,
-    mem::{drop, size_of, ManuallyDrop, MaybeUninit},
+    mem::{
+        drop,
+        size_of,
+        ManuallyDrop,
+        MaybeUninit,
+    },
     ptr,
 };
 
@@ -990,11 +1001,21 @@ where
 #[cfg(test)]
 mod tests {
     use super::Storage;
-    use crate::{archetype::Identifier, registry};
-    use alloc::{vec, vec::Vec};
+    use crate::{
+        archetype::Identifier,
+        registry,
+    };
+    use alloc::{
+        vec,
+        vec::Vec,
+    };
     use core::{
         marker::PhantomData,
-        mem::{size_of, ManuallyDrop, MaybeUninit},
+        mem::{
+            size_of,
+            ManuallyDrop,
+            MaybeUninit,
+        },
     };
 
     #[test]

--- a/src/registry/seal/view.rs
+++ b/src/registry/seal/view.rs
@@ -3,15 +3,25 @@ use crate::{
     component::Component,
     query::{
         view,
-        view::{Views, ViewsSeal},
+        view::{
+            Views,
+            ViewsSeal,
+        },
     },
     registry,
     registry::{
-        contains::{Contained, NotContained, Null},
+        contains::{
+            Contained,
+            NotContained,
+            Null,
+        },
         Registry,
     },
 };
-use core::{iter, slice};
+use core::{
+    iter,
+    slice,
+};
 use either::Either;
 
 pub trait CanonicalViews<'a, V, P>

--- a/src/registry/send.rs
+++ b/src/registry/send.rs
@@ -1,6 +1,9 @@
 use crate::{
     component::Component,
-    registry::{Null, Registry},
+    registry::{
+        Null,
+        Registry,
+    },
 };
 
 pub trait RegistrySend: Registry {}

--- a/src/registry/serde.rs
+++ b/src/registry/serde.rs
@@ -1,12 +1,31 @@
 use crate::{
     archetype,
-    archetype::{DeserializeColumn, SerializeColumn},
+    archetype::{
+        DeserializeColumn,
+        SerializeColumn,
+    },
     component::Component,
-    registry::{Null, Registry},
+    registry::{
+        Null,
+        Registry,
+    },
 };
-use alloc::{format, string::String, vec::Vec};
-use core::{any::type_name, mem::ManuallyDrop};
-use serde::{de, de::SeqAccess, ser::SerializeTuple, Deserialize, Serialize};
+use alloc::{
+    format,
+    string::String,
+    vec::Vec,
+};
+use core::{
+    any::type_name,
+    mem::ManuallyDrop,
+};
+use serde::{
+    de,
+    de::SeqAccess,
+    ser::SerializeTuple,
+    Deserialize,
+    Serialize,
+};
 
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 pub trait RegistrySerialize: Registry {

--- a/src/registry/sync.rs
+++ b/src/registry/sync.rs
@@ -1,6 +1,9 @@
 use crate::{
     component::Component,
-    registry::{Null, Registry},
+    registry::{
+        Null,
+        Registry,
+    },
 };
 
 pub trait RegistrySync: Registry {}

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -6,8 +6,16 @@
 //! # Example
 //! ``` rust
 //! use brood::{
-//!     query::{filter, filter::Filter, result, views},
-//!     registry::{ContainsViews, Registry},
+//!     query::{
+//!         filter,
+//!         filter::Filter,
+//!         result,
+//!         views,
+//!     },
+//!     registry::{
+//!         ContainsViews,
+//!         Registry,
+//!     },
 //!     system::System,
 //! };
 //!
@@ -63,8 +71,15 @@ pub use par::ParSystem;
 pub use schedule::Schedule;
 
 use crate::{
-    query::{filter::Filter, result, view::Views},
-    registry::{ContainsViews, Registry},
+    query::{
+        filter::Filter,
+        result,
+        view::Views,
+    },
+    registry::{
+        ContainsViews,
+        Registry,
+    },
     world::World,
 };
 
@@ -82,8 +97,16 @@ use crate::{
 /// # Example
 /// ``` rust
 /// use brood::{
-///     query::{filter, filter::Filter, result, views},
-///     registry::{ContainsViews, Registry},
+///     query::{
+///         filter,
+///         filter::Filter,
+///         result,
+///         views,
+///     },
+///     registry::{
+///         ContainsViews,
+///         Registry,
+///     },
 ///     system::System,
 /// };
 ///
@@ -134,8 +157,16 @@ pub trait System<'a> {
     /// # Example
     /// ``` rust
     /// use brood::{
-    ///     query::{filter, filter::Filter, result, views},
-    ///     registry::{ContainsViews, Registry},
+    ///     query::{
+    ///         filter,
+    ///         filter::Filter,
+    ///         result,
+    ///         views,
+    ///     },
+    ///     registry::{
+    ///         ContainsViews,
+    ///         Registry,
+    ///     },
     ///     system::System,
     /// };
     ///

--- a/src/system/null.rs
+++ b/src/system/null.rs
@@ -1,11 +1,22 @@
 use crate::{
-    query::{filter, filter::Filter, result, view},
-    registry::{ContainsViews, Registry},
+    query::{
+        filter,
+        filter::Filter,
+        result,
+        view,
+    },
+    registry::{
+        ContainsViews,
+        Registry,
+    },
     system::System,
     world::World,
 };
 #[cfg(feature = "rayon")]
-use crate::{registry::ContainsParViews, system::ParSystem};
+use crate::{
+    registry::ContainsParViews,
+    system::ParSystem,
+};
 use core::hint::unreachable_unchecked;
 
 /// A null system.

--- a/src/system/par.rs
+++ b/src/system/par.rs
@@ -1,6 +1,13 @@
 use crate::{
-    query::{filter::Filter, result, view::ParViews},
-    registry::{ContainsParViews, Registry},
+    query::{
+        filter::Filter,
+        result,
+        view::ParViews,
+    },
+    registry::{
+        ContainsParViews,
+        Registry,
+    },
     world::World,
 };
 
@@ -13,8 +20,16 @@ use crate::{
 /// # Example
 /// ``` rust
 /// use brood::{
-///     query::{filter, filter::Filter, result, views},
-///     registry::{ContainsParViews, Registry},
+///     query::{
+///         filter,
+///         filter::Filter,
+///         result,
+///         views,
+///     },
+///     registry::{
+///         ContainsParViews,
+///         Registry,
+///     },
 ///     system::ParSystem,
 /// };
 /// use rayon::iter::ParallelIterator;
@@ -70,8 +85,16 @@ pub trait ParSystem<'a> {
     /// # Example
     /// ``` rust
     /// use brood::{
-    ///     query::{filter, filter::Filter, result, views},
-    ///     registry::{ContainsParViews, Registry},
+    ///     query::{
+    ///         filter,
+    ///         filter::Filter,
+    ///         result,
+    ///         views,
+    ///     },
+    ///     registry::{
+    ///         ContainsParViews,
+    ///         Registry,
+    ///     },
     ///     system::ParSystem,
     /// };
     /// use rayon::iter::ParallelIterator;

--- a/src/system/schedule/builder.rs
+++ b/src/system/schedule/builder.rs
@@ -3,11 +3,15 @@ use crate::{
     system::{
         schedule::{
             raw_task,
-            raw_task::{RawTask, RawTasks},
+            raw_task::{
+                RawTask,
+                RawTasks,
+            },
             task::Task,
             Schedule,
         },
-        ParSystem, System,
+        ParSystem,
+        System,
     },
 };
 use fnv::FnvBuildHasher;
@@ -28,9 +32,20 @@ use hashbrown::HashSet;
 ///
 /// ``` rust
 /// use brood::{
-///     query::{filter, filter::Filter, result, views},
-///     registry::{ContainsViews, Registry},
-///     system::{Schedule, System},
+///     query::{
+///         filter,
+///         filter::Filter,
+///         result,
+///         views,
+///     },
+///     registry::{
+///         ContainsViews,
+///         Registry,
+///     },
+///     system::{
+///         Schedule,
+///         System,
+///     },
 /// };
 ///
 /// // Define components.

--- a/src/system/schedule/builder.rs
+++ b/src/system/schedule/builder.rs
@@ -155,7 +155,8 @@ where
         }
     }
 
-    /// Create a [`Schedule`] containing all [`Stages`] added to the `Builder`, consuming the `Builder`.
+    /// Create a [`Schedule`] containing all [`Stages`] added to the `Builder`, consuming the
+    /// `Builder`.
     ///
     /// [`Schedule`]: crate::system::schedule::Schedule
     /// [`Stages`]: crate::system::schedule::stage::Stages

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -12,9 +12,20 @@
 //!
 //! ``` rust
 //! use brood::{
-//!     query::{filter, filter::Filter, result, views},
-//!     registry::{ContainsViews, Registry},
-//!     system::{Schedule, System},
+//!     query::{
+//!         filter,
+//!         filter::Filter,
+//!         result,
+//!         views,
+//!     },
+//!     registry::{
+//!         ContainsViews,
+//!         Registry,
+//!     },
+//!     system::{
+//!         Schedule,
+//!         System,
+//!     },
 //! };
 //!
 //! // Define components.
@@ -83,7 +94,10 @@ mod builder;
 pub use builder::Builder;
 pub use stage::stages;
 
-use crate::{registry::Registry, world::World};
+use crate::{
+    registry::Registry,
+    world::World,
+};
 use sendable::SendableWorld;
 use stage::Stages;
 
@@ -99,9 +113,20 @@ use stage::Stages;
 ///
 /// ``` rust
 /// use brood::{
-///     query::{filter, filter::Filter, result, views},
-///     registry::{ContainsViews, Registry},
-///     system::{Schedule, System},
+///     query::{
+///         filter,
+///         filter::Filter,
+///         result,
+///         views,
+///     },
+///     registry::{
+///         ContainsViews,
+///         Registry,
+///     },
+///     system::{
+///         Schedule,
+///         System,
+///     },
 /// };
 ///
 /// // Define components.

--- a/src/system/schedule/raw_task/mod.rs
+++ b/src/system/schedule/raw_task/mod.rs
@@ -10,7 +10,11 @@ mod seal;
 
 use crate::{
     hlist::define_null,
-    system::{schedule::task::Task, ParSystem, System},
+    system::{
+        schedule::task::Task,
+        ParSystem,
+        System,
+    },
 };
 use seal::Seal;
 

--- a/src/system/schedule/raw_task/seal.rs
+++ b/src/system/schedule/raw_task/seal.rs
@@ -2,11 +2,15 @@ use crate::{
     query::claim::Claim,
     system::{
         schedule::{
-            raw_task::{Null, RawTask},
+            raw_task::{
+                Null,
+                RawTask,
+            },
             stage,
             stage::Stage,
         },
-        ParSystem, System,
+        ParSystem,
+        System,
     },
 };
 use core::any::TypeId;

--- a/src/system/schedule/sendable.rs
+++ b/src/system/schedule/sendable.rs
@@ -1,4 +1,7 @@
-use crate::{registry::Registry, world::World};
+use crate::{
+    registry::Registry,
+    world::World,
+};
 
 pub struct SendableWorld<R>(*mut World<R>)
 where

--- a/src/system/schedule/stage/mod.rs
+++ b/src/system/schedule/stage/mod.rs
@@ -16,8 +16,16 @@ use crate::{
     doc,
     hlist::define_null,
     query::filter::Filter,
-    registry::{ContainsParViews, ContainsViews, Registry},
-    system::{schedule::task::Task, ParSystem, System},
+    registry::{
+        ContainsParViews,
+        ContainsViews,
+        Registry,
+    },
+    system::{
+        schedule::task::Task,
+        ParSystem,
+        System,
+    },
 };
 use seal::Seal;
 

--- a/src/system/schedule/stage/seal.rs
+++ b/src/system/schedule/stage/seal.rs
@@ -1,12 +1,20 @@
 use crate::{
     query::filter::Filter,
-    registry::{ContainsParViews, ContainsViews, Registry},
+    registry::{
+        ContainsParViews,
+        ContainsViews,
+        Registry,
+    },
     system::{
         schedule::{
             sendable::SendableWorld,
-            stage::{Null, Stage},
+            stage::{
+                Null,
+                Stage,
+            },
         },
-        ParSystem, System,
+        ParSystem,
+        System,
     },
     world::World,
 };

--- a/src/system/schedule/task.rs
+++ b/src/system/schedule/task.rs
@@ -1,7 +1,18 @@
 use crate::{
-    query::{filter::Filter, Query},
-    registry::{ContainsParViews, ContainsViews, Registry},
-    system::{schedule::sendable::SendableWorld, ParSystem, System},
+    query::{
+        filter::Filter,
+        Query,
+    },
+    registry::{
+        ContainsParViews,
+        ContainsViews,
+        Registry,
+    },
+    system::{
+        schedule::sendable::SendableWorld,
+        ParSystem,
+        System,
+    },
     world::World,
 };
 

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -3,14 +3,29 @@ use crate::{
     component::Component,
     entity::allocator::Location,
     query::{
-        filter::{And, Filter, Seal},
-        view::{Reshape, Views},
+        filter::{
+            And,
+            Filter,
+            Seal,
+        },
+        view::{
+            Reshape,
+            Views,
+        },
         Query,
     },
-    registry::{ContainsComponent, ContainsViews, Registry, RegistryDebug},
+    registry::{
+        ContainsComponent,
+        ContainsViews,
+        Registry,
+        RegistryDebug,
+    },
     world::World,
 };
-use core::{fmt, fmt::Debug};
+use core::{
+    fmt,
+    fmt::Debug,
+};
 
 /// A view into a single entity in a [`World`].
 ///
@@ -20,7 +35,11 @@ use core::{fmt, fmt::Debug};
 /// An entry for an entity can be obtained from an [`entity::Identifier`] as follows:
 ///
 /// ``` rust
-/// use brood::{entity, registry, World};
+/// use brood::{
+///     entity,
+///     registry,
+///     World,
+/// };
 ///
 /// struct Foo(u32);
 /// struct Bar(bool);
@@ -58,7 +77,11 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entity, registry, World};
+    /// use brood::{
+    ///     entity,
+    ///     registry,
+    ///     World,
+    /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
@@ -162,7 +185,11 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entity, registry, World};
+    /// use brood::{
+    ///     entity,
+    ///     registry,
+    ///     World,
+    /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
@@ -255,8 +282,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     query::{filter, result, views},
-    ///     registry, Query, World,
+    ///     query::{
+    ///         filter,
+    ///         result,
+    ///         views,
+    ///     },
+    ///     registry,
+    ///     Query,
+    ///     World,
     /// };
     ///
     /// struct Foo(u32);

--- a/src/world/impl_debug.rs
+++ b/src/world/impl_debug.rs
@@ -1,6 +1,9 @@
 use super::World;
 use crate::registry::RegistryDebug;
-use core::fmt::{self, Debug};
+use core::fmt::{
+    self,
+    Debug,
+};
 
 impl<R> Debug for World<R>
 where

--- a/src/world/impl_default.rs
+++ b/src/world/impl_default.rs
@@ -1,4 +1,7 @@
-use crate::{registry::Registry, World};
+use crate::{
+    registry::Registry,
+    World,
+};
 
 impl<R> Default for World<R>
 where

--- a/src/world/impl_eq.rs
+++ b/src/world/impl_eq.rs
@@ -1,5 +1,8 @@
 use super::World;
-use crate::registry::{RegistryEq, RegistryPartialEq};
+use crate::registry::{
+    RegistryEq,
+    RegistryPartialEq,
+};
 
 impl<R> PartialEq for World<R>
 where
@@ -17,7 +20,10 @@ impl<R> Eq for World<R> where R: RegistryEq {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{entity, registry};
+    use crate::{
+        entity,
+        registry,
+    };
 
     #[derive(Debug, Eq, PartialEq)]
     struct A(u32);

--- a/src/world/impl_send.rs
+++ b/src/world/impl_send.rs
@@ -1,4 +1,7 @@
-use crate::{registry::RegistrySend, world::World};
+use crate::{
+    registry::RegistrySend,
+    world::World,
+};
 
 // SAFETY: This type is safe to send between threads, since all pointers are owned and cannot be
 // mutated without mutable access.

--- a/src/world/impl_serde.rs
+++ b/src/world/impl_serde.rs
@@ -1,15 +1,27 @@
 use crate::{
     archetypes::DeserializeArchetypes,
     entity::allocator::DeserializeAllocator,
-    registry::{RegistryDeserialize, RegistrySerialize},
+    registry::{
+        RegistryDeserialize,
+        RegistrySerialize,
+    },
     World,
 };
-use core::{fmt, marker::PhantomData};
+use core::{
+    fmt,
+    marker::PhantomData,
+};
 use serde::{
     de,
-    de::{SeqAccess, Visitor},
+    de::{
+        SeqAccess,
+        Visitor,
+    },
     ser::SerializeTuple,
-    Deserialize, Deserializer, Serialize, Serializer,
+    Deserialize,
+    Deserializer,
+    Serialize,
+    Serializer,
 };
 
 impl<R> Serialize for World<R>
@@ -79,9 +91,21 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{entity, registry};
-    use serde_derive::{Deserialize, Serialize};
-    use serde_test::{assert_de_tokens_error, assert_tokens, Compact, Configure, Token};
+    use crate::{
+        entity,
+        registry,
+    };
+    use serde_derive::{
+        Deserialize,
+        Serialize,
+    };
+    use serde_test::{
+        assert_de_tokens_error,
+        assert_tokens,
+        Compact,
+        Configure,
+        Token,
+    };
 
     #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
     struct A(u32);

--- a/src/world/impl_sync.rs
+++ b/src/world/impl_sync.rs
@@ -1,4 +1,7 @@
-use crate::{registry::RegistrySync, world::World};
+use crate::{
+    registry::RegistrySync,
+    world::World,
+};
 
 // SAFETY: This type is safe to share between multiple threads as you can't mutate it without a
 // &mut reference.

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -181,7 +181,8 @@ where
         }
     }
 
-    /// Insert multiple entities made from the same components, returning a [`Vec`] of [`entity::Identifier`]s.
+    /// Insert multiple entities made from the same components, returning a [`Vec`] of
+    /// [`entity::Identifier`]s.
     ///
     /// # Example
     /// ``` rust

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -22,15 +22,29 @@ use crate::{
     entities::Entities,
     entity,
     entity::Entity,
-    query::{filter::Filter, result, view::Views, Query},
-    registry::{ContainsEntities, ContainsEntity, ContainsViews, Registry},
+    query::{
+        filter::Filter,
+        result,
+        view::Views,
+        Query,
+    },
+    registry::{
+        ContainsEntities,
+        ContainsEntity,
+        ContainsViews,
+        Registry,
+    },
     system::System,
 };
 #[cfg(feature = "rayon")]
 use crate::{
     query::view::ParViews,
     registry::ContainsParViews,
-    system::{schedule::stage::Stages, ParSystem, Schedule},
+    system::{
+        schedule::stage::Stages,
+        ParSystem,
+        Schedule,
+    },
 };
 use alloc::vec::Vec;
 use fnv::FnvBuildHasher;
@@ -44,7 +58,11 @@ use hashbrown::HashSet;
 /// identified using an `entity::Identifier`.
 ///
 /// ``` rust
-/// use brood::{entity, registry, World};
+/// use brood::{
+///     entity,
+///     registry,
+///     World,
+/// };
 ///
 /// // Define components.
 /// struct Foo(u32);
@@ -104,7 +122,10 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{registry, World};
+    /// use brood::{
+    ///     registry,
+    ///     World,
+    /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
@@ -124,7 +145,11 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entity, registry, World};
+    /// use brood::{
+    ///     entity,
+    ///     registry,
+    ///     World,
+    /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
@@ -160,7 +185,11 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entities, registry, World};
+    /// use brood::{
+    ///     entities,
+    ///     registry,
+    ///     World,
+    /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
@@ -206,8 +235,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     query::{filter, result, views},
-    ///     registry, Query, World,
+    ///     query::{
+    ///         filter,
+    ///         result,
+    ///         views,
+    ///     },
+    ///     registry,
+    ///     Query,
+    ///     World,
     /// };
     ///
     /// struct Foo(u32);
@@ -261,8 +296,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     query::{filter, result, views},
-    ///     registry, Query, World,
+    ///     query::{
+    ///         filter,
+    ///         result,
+    ///         views,
+    ///     },
+    ///     registry,
+    ///     Query,
+    ///     World,
     /// };
     /// use rayon::iter::ParallelIterator;
     ///
@@ -316,9 +357,17 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     query::{filter, filter::Filter, result, views},
+    ///     query::{
+    ///         filter,
+    ///         filter::Filter,
+    ///         result,
+    ///         views,
+    ///     },
     ///     registry,
-    ///     registry::{ContainsViews, Registry},
+    ///     registry::{
+    ///         ContainsViews,
+    ///         Registry,
+    ///     },
     ///     system::System,
     ///     World,
     /// };
@@ -375,9 +424,17 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     query::{filter, filter::Filter, result, views},
+    ///     query::{
+    ///         filter,
+    ///         filter::Filter,
+    ///         result,
+    ///         views,
+    ///     },
     ///     registry,
-    ///     registry::{ContainsParViews, Registry},
+    ///     registry::{
+    ///         ContainsParViews,
+    ///         Registry,
+    ///     },
     ///     system::ParSystem,
     ///     World,
     /// };
@@ -434,10 +491,21 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     query::{filter, filter::Filter, result, views},
+    ///     query::{
+    ///         filter,
+    ///         filter::Filter,
+    ///         result,
+    ///         views,
+    ///     },
     ///     registry,
-    ///     registry::{ContainsViews, Registry},
-    ///     system::{Schedule, System},
+    ///     registry::{
+    ///         ContainsViews,
+    ///         Registry,
+    ///     },
+    ///     system::{
+    ///         Schedule,
+    ///         System,
+    ///     },
     ///     World,
     /// };
     ///
@@ -514,7 +582,11 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entity, registry, World};
+    /// use brood::{
+    ///     entity,
+    ///     registry,
+    ///     World,
+    /// };
     ///
     /// struct Foo(usize);
     /// struct Bar(bool);
@@ -540,7 +612,11 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entity, registry, World};
+    /// use brood::{
+    ///     entity,
+    ///     registry,
+    ///     World,
+    /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
@@ -570,7 +646,11 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entity, registry, World};
+    /// use brood::{
+    ///     entity,
+    ///     registry,
+    ///     World,
+    /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
@@ -611,7 +691,11 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entity, registry, World};
+    /// use brood::{
+    ///     entity,
+    ///     registry,
+    ///     World,
+    /// };
     ///
     /// struct Foo(usize);
     /// struct Bar(bool);
@@ -659,7 +743,11 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entity, registry, World};
+    /// use brood::{
+    ///     entity,
+    ///     registry,
+    ///     World,
+    /// };
     ///
     /// struct Foo(usize);
     /// struct Bar(bool);
@@ -684,12 +772,20 @@ where
 mod tests {
     use super::*;
     use crate::{
-        entities, entity,
-        query::{filter, result, views},
+        entities,
+        entity,
+        query::{
+            filter,
+            result,
+            views,
+        },
         registry,
     };
     use alloc::vec;
-    use claims::{assert_none, assert_some};
+    use claims::{
+        assert_none,
+        assert_some,
+    };
     #[cfg(feature = "rayon")]
     use rayon::iter::ParallelIterator;
 


### PR DESCRIPTION
Enables some additional `rustfmt` and `clippy` checks. Specifically, adjusts the way imports are formatted to be more friendly with commits (a changed import will only affect one line), specifies the length of comments (sets to 100, which was already the standard I was using when making comments anyway), and sets `clippy` lints to restrict panicking. 