### PR TITLE
Fix potential `non_root_macro` compilation issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - `schedule` module has been overhauled. A builder API is no longer required to create a `Schedule`. Instead, a `Schedule` is defined as a heterogeneous list of tasks using the `schedule!` macro. Stages are defined at compile time using type-level recursion.
 ### Removed
 - `system::Null` is removed, since it is no longer needed for defining a `Schedule`.
+### Fixed
+- Mitigated potential bug regarding the way non-root macros are exported when compiling documentation. Previously, a change in Rust's experimental `macro` syntax could have potentially broken usage of the library for all users. Now, a change in the syntax will only break building of the documentation (using `--cfg doc_cfg`), which is acceptable.
 
 ## 0.3.0 - 2022-10-28
 ### Added

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -4,6 +4,18 @@
 //! affect how this crate works logically; things included here should only affect how the crate is
 //! documented.
 
+/// Wrapper around a token tree to ensure it is not parsed at compile time if it is excluded by
+/// `cfg` rules.
+///
+/// This is necessary for using the `macro` keyword for controlling where macro documentation is
+/// exported, as the `macro` syntax is experimental and subject to change at any time. This
+/// protects the crate from being unusable if that syntax changes, as the changes would cause all
+/// compilation, even compilation not enabling `doc_cfg`, to break otherwise.
+#[cfg(doc_cfg)]
+macro_rules! unparsed {
+    ( $($tokens:tt)* ) => { $($tokens)* }
+}
+
 /// Defines a macro that is not documented at the crate's root.
 ///
 /// This changes the way the macro is defined only when the `doc_cfg` cfg flag is passed. It
@@ -29,14 +41,18 @@ macro_rules! non_root_macro {
         #[cfg(not(doc_cfg))]
         pub use $name;
 
-        $(#[$m])*
         #[cfg(doc_cfg)]
-        pub macro $name {
-            $(
-                ($($token)*) => ($($expansion)*)
-            ),*
+        crate::doc::unparsed! {
+            $(#[$m])*
+            pub macro $name {
+                $(
+                    ($($token)*) => ($($expansion)*)
+                ),*
+            }
         }
     )
 }
 
 pub(crate) use non_root_macro;
+#[cfg(doc_cfg)]
+pub(crate) use unparsed;


### PR DESCRIPTION
Fixes #143.

Note that this still will cause documentation to break if `macro` syntax ever changes. However, this is an acceptable risk, as it would just require a hot fix to allow the documentation to build again, and users would be able to use the library still. The benefit of having nicer, more understandable, and more organized documentation is worth it.