### PR TITLE
Macro for defining the type of a schedule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,23 @@
 ## Unreleased
 ### Added
 - `Debug`, `Eq`, `PartialEq`, `Serialize`, and `Deserialize` traits are added to the `registry` module.
+- `schedule!` macro for defining a schedule.
+- `Schedule!` macro for defining the type of a schedule.
+- `schedule::task` module for defining tasks that make up schedules.
 ### Changed
 - `Send` and `Sync` implementations of `World` now only require the registry to implement `Registry + Send` and `Registry + Sync` respectively.
 - Lifetime in `System` and `ParSystem` traits has been moved to the `Views` associated type.
 - The generic lifetimes on the `system::schedule::RawTask` and `system::Stages` traits have been removed.
 - `Registry` is now explicitly bound to the `static` lifetime. This was previously only implicit, with `Registry`s being made of `Component`s which were bound to `'static`.
 - Both `System` and `ParSystem` no longer require a lifetime bound on the `Registry` `R` in their `run()` methods.
-- `schedule` module has been overhauled. A builder API is no longer required to create a `Schedule`. Instead, a `Schedule` is defined as a heterogeneous list of tasks using the `schedule!` macro. Stages are defined at compile time using type-level recursion.
+- `Schedule` has been changed from a `struct` to a `trait`.
+- Schedules now have their stages defined at compile-time.
 ### Removed
 - `system::Null` is removed, since it is no longer needed for defining a `Schedule`.
+- `schedule::Builder` is removed, since it is no longer needed for defining a `Schedule`.
+- The `schedule::raw_task` module has been removed. There is now no distinction between a raw task and a regular task.
+- The `schedule::stage` module has been removed. It still exists as part of the private API, but is no longer exposed publicly.
+- The `schedule::stage!` macro is removed. Schedules are no longer defined in terms of their stages directly, but are defined in terms of their tasks using the `schedule!` and `Schedule!` macros.
 ### Fixed
 - Mitigated potential bug regarding the way non-root macros are exported when compiling documentation. Previously, a change in Rust's experimental `macro` syntax could have potentially broken usage of the library for all users. Now, a change in the syntax will only break building of the documentation (using `--cfg doc_cfg`), which is acceptable.
 

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -37,7 +37,6 @@ macro_rules! non_root_macro {
             );*
         }
 
-        $(#[$m])*
         #[cfg(not(doc_cfg))]
         pub use $name;
 

--- a/src/registry/debug/sealed.rs
+++ b/src/registry/debug/sealed.rs
@@ -76,9 +76,9 @@ pub trait Sealed: Registry {
     /// there are components remaining.
     ///
     /// [`DebugMap`]: core::fmt::DebugMap
-    unsafe fn debug_components<'a, 'b, R>(
+    unsafe fn debug_components<R>(
         pointers: &[*const u8],
-        debug_map: &mut DebugMap<'a, 'b>,
+        debug_map: &mut DebugMap,
         identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry;
@@ -95,9 +95,9 @@ impl Sealed for Null {
     {
     }
 
-    unsafe fn debug_components<'a, 'b, R>(
+    unsafe fn debug_components<R>(
         _pointers: &[*const u8],
-        _debug_map: &mut DebugMap<'a, 'b>,
+        _debug_map: &mut DebugMap,
         _identifier_iter: archetype::identifier::Iter<R>,
     ) where
         R: Registry,
@@ -160,9 +160,9 @@ where
         unsafe { R::extract_component_pointers(index, components, pointers, identifier_iter) };
     }
 
-    unsafe fn debug_components<'a, 'b, R_>(
+    unsafe fn debug_components<R_>(
         mut pointers: &[*const u8],
-        debug_map: &mut DebugMap<'a, 'b>,
+        debug_map: &mut DebugMap,
         mut identifier_iter: archetype::identifier::Iter<R_>,
     ) where
         R_: Registry,

--- a/src/registry/sealed/storage.rs
+++ b/src/registry/sealed/storage.rs
@@ -913,11 +913,8 @@ where
         // SAFETY: `identifier_iter` is guaranteed by the safety contract of this method to
         // return a value for every component within the registry.
         unsafe { identifier_iter.next().unwrap_unchecked() } {
-            let component_column = match components.get(0) {
-                Some(component_column) => component_column,
-                None => {
-                    return;
-                }
+            let Some(component_column) = components.get(0) else {
+                return;
             };
             drop(
                 // SAFETY: The pointer, capacity, and length are guaranteed by the safety

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -45,7 +45,7 @@
 //! Defining `System`s allows for reuse of querying logic in multiple places, as well as combining
 //! `System`s together within a `Schedule` to allow them to be run in parallel.
 //!
-//! [`Schedule`]: crate::system::schedule::Schedule
+//! [`Schedule`]: trait@crate::system::schedule::Schedule
 //! [`System`]: crate::system::System
 //! [`World`]: crate::world::World
 

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -204,11 +204,11 @@ doc::non_root_macro! {
 mod inner {
     use crate::doc;
 
-    doc::non_root_macro!{
+    doc::non_root_macro! {
         /// Macro for defining the type of a schedule.
-        /// 
+        ///
         /// This macro is used to define the type of a schedule made up of a list of tasks.
-        /// 
+        ///
         /// # Example
         /// ``` rust
         /// use brood::{

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -69,7 +69,7 @@
 //! ```
 //!
 //! [`ParSystem`]: crate::system::ParSystem
-//! [`Schedule`]: crate::system::Schedule
+//! [`Schedule`]: trait@crate::system::Schedule
 //! [`System`]: crate::system::System
 //! [`Views`]: crate::query::view::Views
 

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -200,6 +200,88 @@ doc::non_root_macro! {
     }
 }
 
+/// Nesting this macro definition in a module is necessary to unambiguate the import of the macro.
+mod inner {
+    use crate::doc;
+
+    doc::non_root_macro!{
+        /// Macro for defining the type of a schedule.
+        /// 
+        /// This macro is used to define the type of a schedule made up of a list of tasks.
+        /// 
+        /// # Example
+        /// ``` rust
+        /// use brood::{
+        ///     query::{
+        ///         filter,
+        ///         filter::Filter,
+        ///         result,
+        ///         views,
+        ///     },
+        ///     registry::{
+        ///         ContainsParQuery,
+        ///         ContainsQuery,
+        ///     },
+        ///     system::{
+        ///         schedule::task,
+        ///         ParSystem,
+        ///         Schedule,
+        ///         System,
+        ///     },
+        /// };
+        ///
+        /// // Define components.
+        /// struct Foo(usize);
+        /// struct Bar(bool);
+        /// struct Baz(f64);
+        ///
+        /// struct SystemA;
+        ///
+        /// impl System for SystemA {
+        ///     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+        ///     type Filter = filter::None;
+        ///
+        ///     fn run<'a, R, FI, VI, P, I, Q>(
+        ///         &mut self,
+        ///         query_results: result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
+        ///     ) where
+        ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
+        ///     {
+        ///         // Do something..
+        ///     }
+        /// }
+        ///
+        /// struct SystemB;
+        ///
+        /// impl ParSystem for SystemB {
+        ///     type Views<'a> = views!(&'a mut Baz, &'a Bar);
+        ///     type Filter = filter::None;
+        ///
+        ///     fn run<'a, R, FI, VI, P, I, Q>(
+        ///         &mut self,
+        ///         query_results: result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
+        ///     ) where
+        ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
+        ///     {
+        ///         // Do something..
+        ///     }
+        /// }
+        ///
+        /// type MySchedule = Schedule!(task::System<SystemA>, task::System<SystemB>);
+        /// ```
+        macro_rules! Schedule {
+            ($task:ty $(,$tasks:ty)* $(,)?) => (
+                ($task, $crate::system::schedule::Schedule!($($tasks,)*))
+            );
+            () => (
+                $crate::system::schedule::task::Null
+            );
+        }
+    }
+}
+
+pub use inner::Schedule;
+
 #[cfg(test)]
 mod tests {
     use super::Sealed as Schedule;
@@ -215,7 +297,6 @@ mod tests {
             ContainsParQuery,
             ContainsQuery,
         },
-        system,
         system::{
             schedule::{
                 stage,

--- a/src/system/schedule/task/mod.rs
+++ b/src/system/schedule/task/mod.rs
@@ -1,6 +1,6 @@
 //! Tasks that are used to define a [`Schedule`].
 //!
-//! [`Schedule`]: crate::system::Schedule
+//! [`Schedule`]: trait@crate::system::Schedule
 
 mod sealed;
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -545,7 +545,7 @@ where
     /// world.run_schedule(&mut schedule);
     /// ```
     ///
-    /// [`Schedule`]: crate::system::Schedule
+    /// [`Schedule`]: trait@crate::system::Schedule
     #[cfg(feature = "rayon")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     pub fn run_schedule<'a, S, I, P, RI, SFI, SVI, SP, SI, SQ>(&mut self, schedule: &'a mut S)

--- a/tests/trybuild/schedule/type_comma_alone.rs
+++ b/tests/trybuild/schedule/type_comma_alone.rs
@@ -1,0 +1,5 @@
+use brood::system::Schedule;
+
+type MySchedule = Schedule!(,);
+
+fn main() {}

--- a/tests/trybuild/schedule/type_comma_alone.stderr
+++ b/tests/trybuild/schedule/type_comma_alone.stderr
@@ -1,0 +1,11 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/schedule/type_comma_alone.rs:3:29
+  |
+3 | type MySchedule = Schedule!(,);
+  |                             ^ no rules expected this token in macro call
+  |
+note: while trying to match meta-variable `$task:ty`
+ --> src/system/schedule/mod.rs
+  |
+  |             ($task:ty $(,$tasks:ty)* $(,)?) => (
+  |              ^^^^^^^^

--- a/tests/trybuild/schedule/type_unexpected_token.rs
+++ b/tests/trybuild/schedule/type_unexpected_token.rs
@@ -1,0 +1,37 @@
+use brood::{query::{views, filter, result}, registry::ContainsQuery, system::{System, Schedule}};
+// This import is technically unused, since the macro fails to compile before it would be consumed.
+// I'm leaving it here, though, for completeness; user code would use this module, and these tests
+// should do their best to simulate user code.
+#[allow(unused_imports)]
+use brood::system::schedule::task;
+
+// Define systems.
+struct A;
+
+impl System for A {
+    type Views<'a> = views!();
+    type Filter = filter::None;
+
+    fn run<'a, R, FI, VI, P, I, Q>(
+        &mut self,
+        _query_results: result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
+    ) where
+        R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
+}
+
+struct B;
+
+impl System for B {
+    type Views<'a> = views!();
+    type Filter = filter::None;
+
+    fn run<'a, R, FI, VI, P, I, Q>(
+        &mut self,
+        _query_results: result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
+    ) where
+        R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
+}
+
+type MySchedule = Schedule!(task::System<A>, + task::System<B>,);
+
+fn main() {}

--- a/tests/trybuild/schedule/type_unexpected_token.stderr
+++ b/tests/trybuild/schedule/type_unexpected_token.stderr
@@ -1,0 +1,11 @@
+error: no rules expected the token `+`
+  --> tests/trybuild/schedule/type_unexpected_token.rs:35:46
+   |
+35 | type MySchedule = Schedule!(task::System<A>, + task::System<B>,);
+   |                                              ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$tasks:ty`
+  --> src/system/schedule/mod.rs
+   |
+   |             ($task:ty $(,$tasks:ty)* $(,)?) => (
+   |                          ^^^^^^^^^


### PR DESCRIPTION
Fixes #145.

This adds a `Schedule!` macro, used to define the type of a schedule. The capitalization of this macro follows the pattern being established by #141.

Also fixes an internal issue with some macros doc tests being run multiple times. Not a big issue, but this ensures that when one of these macro tests fails, it will only be indicated in the test results a single time.