### PR TITLE
Rename type macros in `UpperCamelCase`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@
 - Both `System` and `ParSystem` no longer require a lifetime bound on the `Registry` `R` in their `run()` methods.
 - `Schedule` has been changed from a `struct` to a `trait`.
 - Schedules now have their stages defined at compile-time.
+- `registry!` macro has been renamed to `Registry!` to indicate that it is intended to be a type-level macro.
 ### Removed
 - `system::Null` is removed, since it is no longer needed for defining a `Schedule`.
 - `schedule::Builder` is removed, since it is no longer needed for defining a `Schedule`.
 - The `schedule::raw_task` module has been removed. There is now no distinction between a raw task and a regular task.
 - The `schedule::stage` module has been removed. It still exists as part of the private API, but is no longer exposed publicly.
-- The `schedule::stage!` macro is removed. Schedules are no longer defined in terms of their stages directly, but are defined in terms of their tasks using the `schedule!` and `Schedule!` macros.
+- The `schedule::stages!` macro is removed. Schedules are no longer defined in terms of their stages directly, but are defined in terms of their tasks using the `schedule!` and `Schedule!` macros.
 ### Fixed
 - Mitigated potential bug regarding the way non-root macros are exported when compiling documentation. Previously, a change in Rust's experimental `macro` syntax could have potentially broken usage of the library for all users. Now, a change in the syntax will only break building of the documentation (using `--cfg doc_cfg`), which is acceptable.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `Schedule` has been changed from a `struct` to a `trait`.
 - Schedules now have their stages defined at compile-time.
 - `registry!` macro has been renamed to `Registry!` to indicate that it is intended to be a type-level macro.
+- `views!` macro has been renamed to `Views!` to indicate that it is intended to be a type-level macro.
 ### Removed
 - `system::Null` is removed, since it is no longer needed for defining a `Schedule`.
 - `schedule::Builder` is removed, since it is no longer needed for defining a `Schedule`.

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ struct Velocity {
 }
 ```
 
-In order to use these components within a `World` container, they will need to be contained in a `Registry`, provided to a `World` on creation. A `Registry` can be created using the `registry!()` macro.
+In order to use these components within a `World` container, they will need to be contained in a `Registry`, provided to a `World` on creation. A `Registry` can be created using the `Registry!()` macro.
 
 ``` rust
-use brood::registry;
+use brood::Registry;
 
-type Registry = registry!(Position, Velocity);
+type Registry = Registry!(Position, Velocity);
 ```
 
 A `World` can then be created using this `Registry`, and entities can be stored inside it.
@@ -109,7 +109,7 @@ There are lots of options for more complicated `System`s, including optional com
 For example, a `World` can be serialized to [`bincode`](https://crates.io/crates/bincode) (and deserialized from the same) as follows:
 
 ``` rust
-use brood::{entity, registry, World};
+use brood::{entity, Registry, World};
 
 #[derive(Deserialize, Serialize)]
 struct Position {
@@ -123,7 +123,7 @@ struct Velocity {
     y: f32,
 }
 
-type Registry = registry!(Position, Velocity);
+type Registry = Registry!(Position, Velocity);
 
 let mut world = World::<Registry>::new();
 
@@ -158,7 +158,7 @@ Note that there are two modes for serialization, depending on whether the serial
 To parallelize system operations on entities (commonly referred to as inner-parallelism), a `ParSystem` can be used instead of a standard `System`. This will allow the `ParSystem`'s operations to be spread across multiple CPUs. For example, a `ParSystem` can be defined as follows:
 
 ``` rust
-use brood::{entity, query::{filter, result, views}, registry, registry::ContainsParQuery, World, system::ParSystem};
+use brood::{entity, query::{filter, result, views}, Registry, registry::ContainsParQuery, World, system::ParSystem};
 
 struct Position {
     x: f32,
@@ -170,7 +170,7 @@ struct Velocity {
     y: f32,
 }
 
-type Registry = registry!(Position, Velocity);
+type Registry = Registry!(Position, Velocity);
 
 let mut world = World::<Registry>::new();
 
@@ -215,7 +215,7 @@ Multiple `System`s and `ParSystem`s can be run in parallel as well by defining a
 Define and run a `Schedule` that contains multiple `System`s as follows:
 
 ``` rust
-use brood::{entity, query::{filter, result, views}, registry, registry::ContainsQuery, World, system::{schedule, schedule::task, System}};
+use brood::{entity, query::{filter, result, views}, Registry, registry::ContainsQuery, World, system::{schedule, schedule::task, System}};
 
 struct Position {
     x: f32,
@@ -229,7 +229,7 @@ struct Velocity {
 
 struct IsMoving(bool);
 
-type Registry = registry!(Position, Velocity, IsMoving);
+type Registry = Registry!(Position, Velocity, IsMoving);
 
 let mut world = World::<Registry>::new();
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ Note that entities stored in `world` above can be made up of any subset of the `
 To operate on the entities stored in a `World`, a `System` must be used. `System`s are defined to operate on any entities containing a specified set of components, reading and modifying those components. An example system could be defined and run as follows:
 
 ``` rust
-use brood::{query::{filter, result, views}, registry::ContainsQuery, system::System};
+use brood::{query::{filter, result, Views}, registry::ContainsQuery, system::System};
 
 struct UpdatePosition;
 
 impl System for UpdatePosition {
     type Filter: filter::None;
-    type Views<'a>: views!(&'a mut Position, &'a Velocity);
+    type Views<'a>: Views!(&'a mut Position, &'a Velocity);
 
     fn run<'a, R, FI, VI, P, I, Q>(
         &mut self,
@@ -158,7 +158,7 @@ Note that there are two modes for serialization, depending on whether the serial
 To parallelize system operations on entities (commonly referred to as inner-parallelism), a `ParSystem` can be used instead of a standard `System`. This will allow the `ParSystem`'s operations to be spread across multiple CPUs. For example, a `ParSystem` can be defined as follows:
 
 ``` rust
-use brood::{entity, query::{filter, result, views}, Registry, registry::ContainsParQuery, World, system::ParSystem};
+use brood::{entity, query::{filter, result, Views}, Registry, registry::ContainsParQuery, World, system::ParSystem};
 
 struct Position {
     x: f32,
@@ -189,7 +189,7 @@ struct UpdatePosition;
 
 impl ParSystem for UpdatePosition {
     type Filter: filter::None;
-    type Views<'a>: views!(&'a mut Position, &'a Velocity);
+    type Views<'a>: Views!(&'a mut Position, &'a Velocity);
 
     fn run<'a, R, FI, VI, P, I, Q>(
         &mut self,
@@ -215,7 +215,7 @@ Multiple `System`s and `ParSystem`s can be run in parallel as well by defining a
 Define and run a `Schedule` that contains multiple `System`s as follows:
 
 ``` rust
-use brood::{entity, query::{filter, result, views}, Registry, registry::ContainsQuery, World, system::{schedule, schedule::task, System}};
+use brood::{entity, query::{filter, result, Views}, Registry, registry::ContainsQuery, World, system::{schedule, schedule::task, System}};
 
 struct Position {
     x: f32,
@@ -248,7 +248,7 @@ struct UpdatePosition;
 
 impl System for UpdatePosition {
     type Filter: filter::None;
-    type Views<'a>: views!(&'a mut Position, &'a Velocity);
+    type Views<'a>: Views!(&'a mut Position, &'a Velocity);
 
     fn run<'a, R, FI, VI, P, I, Q>(
         &mut self,
@@ -267,7 +267,7 @@ struct UpdateIsMoving;
 
 impl System for UpdateIsMoving {
     type Filter: filter::None;
-    type Views<'a>: views!(&'a Velocity, &'a mut IsMoving);
+    type Views<'a>: Views!(&'a Velocity, &'a mut IsMoving);
 
     fn run<'a, R, FI, VI, P, I, Q>(
         &mut self,

--- a/src/archetype/identifier/impl_serde.rs
+++ b/src/archetype/identifier/impl_serde.rs
@@ -119,7 +119,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::registry;
+    use crate::Registry;
     use alloc::vec;
     use serde_test::{
         assert_de_tokens_error,
@@ -140,7 +140,7 @@ mod tests {
     );
 
     type Registry =
-        registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+        Registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
     #[test]
     fn serialize_deserialize() {
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn serialize_deserialize_empty() {
-        let identifier = unsafe { Identifier::<registry!()>::new(vec![]) };
+        let identifier = unsafe { Identifier::<Registry!()>::new(vec![]) };
 
         assert_tokens(&identifier, &[Token::Tuple { len: 0 }, Token::TupleEnd]);
     }

--- a/src/archetype/identifier/iter.rs
+++ b/src/archetype/identifier/iter.rs
@@ -105,7 +105,7 @@ where
 mod tests {
     use crate::{
         archetype::Identifier,
-        registry,
+        Registry,
     };
     use alloc::{
         vec,
@@ -125,7 +125,7 @@ mod tests {
     );
 
     type Registry =
-        registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+        Registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
     #[test]
     fn none_set() {
@@ -177,14 +177,14 @@ mod tests {
 
     #[test]
     fn no_components() {
-        let buffer = unsafe { Identifier::<registry!()>::new(Vec::new()) };
+        let buffer = unsafe { Identifier::<Registry!()>::new(Vec::new()) };
 
         assert_eq!(unsafe { buffer.iter() }.collect::<Vec<bool>>(), Vec::new());
     }
 
     #[test]
     fn seven_components() {
-        let buffer = unsafe { Identifier::<registry!(A, B, C, D, E, F, G)>::new(vec![0]) };
+        let buffer = unsafe { Identifier::<Registry!(A, B, C, D, E, F, G)>::new(vec![0]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn eight_components() {
-        let buffer = unsafe { Identifier::<registry!(A, B, C, D, E, F, G, H)>::new(vec![0]) };
+        let buffer = unsafe { Identifier::<Registry!(A, B, C, D, E, F, G, H)>::new(vec![0]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn nine_components() {
-        let buffer = unsafe { Identifier::<registry!(A, B, C, D, E, F, G, H, I)>::new(vec![0, 0]) };
+        let buffer = unsafe { Identifier::<Registry!(A, B, C, D, E, F, G, H, I)>::new(vec![0, 0]) };
 
         assert_eq!(
             unsafe { buffer.iter() }.collect::<Vec<bool>>(),

--- a/src/archetype/identifier/mod.rs
+++ b/src/archetype/identifier/mod.rs
@@ -351,7 +351,7 @@ where
 mod tests {
     use crate::{
         archetype::Identifier,
-        registry,
+        Registry,
     };
     use alloc::{
         vec,
@@ -374,7 +374,7 @@ mod tests {
     );
 
     type Registry =
-        registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+        Registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
     #[test]
     fn buffer_as_slice() {
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn empty_buffer_as_slice() {
-        let buffer = unsafe { Identifier::<registry!()>::new(Vec::new()) };
+        let buffer = unsafe { Identifier::<Registry!()>::new(Vec::new()) };
 
         assert_eq!(unsafe { buffer.as_slice() }, &[]);
     }
@@ -422,7 +422,7 @@ mod tests {
 
     #[test]
     fn buffer_size_of_components() {
-        let buffer = unsafe { Identifier::<registry!(bool, u64, f32)>::new(vec![7]) };
+        let buffer = unsafe { Identifier::<Registry!(bool, u64, f32)>::new(vec![7]) };
 
         assert_eq!(buffer.size_of_components(), 13);
     }

--- a/src/archetype/impl_serde.rs
+++ b/src/archetype/impl_serde.rs
@@ -836,7 +836,7 @@ mod tests {
     use crate::{
         archetype::Identifier,
         entity,
-        registry,
+        Registry,
     };
     use alloc::{
         format,
@@ -862,7 +862,7 @@ mod tests {
     #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
     struct B(char);
 
-    type Registry = registry!(A, B);
+    type Registry = Registry!(A, B);
 
     #[test]
     fn serialize_deserialize_by_column() {

--- a/src/archetypes/impl_serde.rs
+++ b/src/archetypes/impl_serde.rs
@@ -110,7 +110,7 @@ mod tests {
     use crate::{
         archetype::Identifier,
         entity,
-        registry,
+        Registry,
     };
     use alloc::{
         format,
@@ -203,7 +203,7 @@ mod tests {
     #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
     struct B(char);
 
-    type Registry = registry!(A, B);
+    type Registry = Registry!(A, B);
 
     #[test]
     fn serialize_deserialize_empty() {

--- a/src/archetypes/mod.rs
+++ b/src/archetypes/mod.rs
@@ -310,7 +310,7 @@ mod tests {
     use crate::{
         archetype,
         archetypes::Archetypes,
-        registry,
+        Registry,
     };
     use alloc::vec;
 
@@ -327,7 +327,7 @@ mod tests {
     );
 
     type Registry =
-        registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+        Registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
     #[test]
     fn get_mut_or_insert_new_insertion() {

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -17,7 +17,7 @@
 //! ``` rust
 //! use brood::{
 //!     entities,
-//!     registry,
+//!     Registry,
 //!     World,
 //! };
 //!
@@ -25,7 +25,7 @@
 //! struct Foo(usize);
 //! struct Bar(bool);
 //!
-//! type Registry = registry!(Foo, Bar);
+//! type Registry = Registry!(Foo, Bar);
 //!
 //! let mut world = World::<Registry>::new();
 //!

--- a/src/entity/allocator/impl_serde.rs
+++ b/src/entity/allocator/impl_serde.rs
@@ -307,6 +307,7 @@ mod tests {
         archetype::Archetype,
         entity,
         registry,
+        Registry,
     };
     use claims::assert_ok;
     use core::{
@@ -330,7 +331,7 @@ mod tests {
     #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
     struct B;
 
-    type Registry = registry!(A, B);
+    type Registry = Registry!(A, B);
 
     trait Seed<R>
     where

--- a/src/entity/allocator/location.rs
+++ b/src/entity/allocator/location.rs
@@ -70,7 +70,7 @@ mod tests {
     use super::Location;
     use crate::{
         archetype::Identifier,
-        registry,
+        Registry,
     };
     use alloc::vec;
 
@@ -87,7 +87,7 @@ mod tests {
     );
 
     type Registry =
-        registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+        Registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
     #[test]
     fn new() {

--- a/src/entity/allocator/slot.rs
+++ b/src/entity/allocator/slot.rs
@@ -101,7 +101,7 @@ mod tests {
     use super::*;
     use crate::{
         archetype::Identifier,
-        registry,
+        Registry,
     };
     use alloc::vec;
     use claims::{
@@ -122,7 +122,7 @@ mod tests {
     );
 
     type Registry =
-        registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
+        Registry!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z);
 
     #[test]
     fn new() {

--- a/src/entity/identifier/mod.rs
+++ b/src/entity/identifier/mod.rs
@@ -12,7 +12,7 @@ mod impl_serde;
 /// ``` rust
 /// use brood::{
 ///     entity,
-///     registry,
+///     Registry,
 ///     World,
 /// };
 ///
@@ -20,7 +20,7 @@ mod impl_serde;
 /// struct Foo(usize);
 /// struct Bar(bool);
 ///
-/// type Registry = registry!(Foo, Bar);
+/// type Registry = Registry!(Foo, Bar);
 ///
 /// let mut world = World::<Registry>::new();
 ///

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -13,7 +13,7 @@
 //! ``` rust
 //! use brood::{
 //!     entity,
-//!     registry,
+//!     Registry,
 //!     World,
 //! };
 //!
@@ -21,7 +21,7 @@
 //! struct Foo(usize);
 //! struct Bar(bool);
 //!
-//! type Registry = registry!(Foo, Bar);
+//! type Registry = Registry!(Foo, Bar);
 //!
 //! let mut world = World::<Registry>::new();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! `World`.
 //!
 //! ``` rust
-//! use brood::registry;
+//! use brood::Registry;
 //!
 //! struct Position {
 //!     x: f32,
@@ -34,7 +34,7 @@
 //!     y: f32,
 //! }
 //!
-//! type Registry = registry!(Position, Velocity);
+//! type Registry = Registry!(Position, Velocity);
 //! ```
 //!
 //! You must define a separate component (meaning a new `struct` or `enum`) for each component you
@@ -46,7 +46,7 @@
 //! components within the `Registry` can then be inserted into the `World`.
 //!
 //! ``` rust
-//! # use brood::registry;
+//! # use brood::Registry;
 //! #
 //! # struct Position {
 //! #     x: f32,
@@ -58,7 +58,7 @@
 //! #     y: f32,
 //! # }
 //! #
-//! # type Registry = registry!(Position, Velocity);
+//! # type Registry = Registry!(Position, Velocity);
 //! #
 //! use brood::{
 //!     entity,

--- a/src/query/filter/mod.rs
+++ b/src/query/filter/mod.rs
@@ -11,7 +11,7 @@
 //! [`And`]: crate::query::filter::And
 //! [`Component`]: crate::component::Component
 //! [`Has<C>`]: crate::query::filter::Has
-//! [`Views`]: crate::query::view::Views
+//! [`Views`]: trait@crate::query::view::Views
 //! [`World`]: crate::world::World
 
 mod sealed;
@@ -38,7 +38,7 @@ use core::marker::PhantomData;
 /// [`And`]: crate::query::filter::And
 /// [`Component`]: crate::component::Component
 /// [`Has<C>`]: crate::query::filter::Has
-/// [`Views`]: crate::query::view::Views
+/// [`Views`]: trait@crate::query::view::Views
 /// [`World`]: crate::world::World
 pub trait Filter: Sealed {}
 
@@ -55,7 +55,7 @@ pub trait Filter: Sealed {}
 /// type NoFilter = filter::None;
 /// ```
 ///
-/// [`Views`]: crate::query::view::Views
+/// [`Views`]: trait@crate::query::view::Views
 pub enum None {}
 
 impl Filter for None {}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -43,7 +43,7 @@
 //! [`Component`]: crate::component::Component
 //! [`Filter`]: crate::query::filter::Filter
 //! [`result!`]: crate::query::result!
-//! [`Views`]: crate::query::view::Views
+//! [`Views`]: trait@crate::query::view::Views
 //! [`World`]: crate::world::World
 
 pub mod filter;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -55,7 +55,7 @@ pub(crate) mod claim;
 #[doc(inline)]
 pub use result::result;
 #[doc(inline)]
-pub use view::Views;
+pub use view::inner::Views;
 
 use core::marker::PhantomData;
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -20,8 +20,8 @@
 //!         result,
 //!         views,
 //!     },
-//!     registry,
 //!     Query,
+//!     Registry,
 //!     World,
 //! };
 //!
@@ -30,7 +30,7 @@
 //! struct Bar(bool);
 //! struct Baz(f64);
 //!
-//! type Registry = registry!(Foo, Bar, Baz);
+//! type Registry = Registry!(Foo, Bar, Baz);
 //!
 //! let mut world = World::<Registry>::new();
 //! world.insert(entity!(Foo(42), Bar(true), Baz(1.5)));
@@ -74,8 +74,8 @@ use core::marker::PhantomData;
 ///         result,
 ///         views,
 ///     },
-///     registry,
 ///     Query,
+///     Registry,
 ///     World,
 /// };
 ///
@@ -84,7 +84,7 @@ use core::marker::PhantomData;
 /// struct Bar(bool);
 /// struct Baz(f64);
 ///
-/// type Registry = registry!(Foo, Bar, Baz);
+/// type Registry = Registry!(Foo, Bar, Baz);
 ///
 /// let mut world = World::<Registry>::new();
 /// world.insert(entity!(Foo(42), Bar(true), Baz(1.5)));

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -18,7 +18,7 @@
 //!     query::{
 //!         filter,
 //!         result,
-//!         views,
+//!         Views,
 //!     },
 //!     Query,
 //!     Registry,
@@ -35,7 +35,7 @@
 //! let mut world = World::<Registry>::new();
 //! world.insert(entity!(Foo(42), Bar(true), Baz(1.5)));
 //!
-//! for result!(foo, bar) in world.query(Query::<views!(&mut Foo, &Bar), filter::Has<Baz>>::new()) {
+//! for result!(foo, bar) in world.query(Query::<Views!(&mut Foo, &Bar), filter::Has<Baz>>::new()) {
 //!     // Do something.
 //! }
 //! ```
@@ -55,7 +55,7 @@ pub(crate) mod claim;
 #[doc(inline)]
 pub use result::result;
 #[doc(inline)]
-pub use view::views;
+pub use view::Views;
 
 use core::marker::PhantomData;
 
@@ -72,7 +72,7 @@ use core::marker::PhantomData;
 ///     query::{
 ///         filter,
 ///         result,
-///         views,
+///         Views,
 ///     },
 ///     Query,
 ///     Registry,
@@ -89,7 +89,7 @@ use core::marker::PhantomData;
 /// let mut world = World::<Registry>::new();
 /// world.insert(entity!(Foo(42), Bar(true), Baz(1.5)));
 ///
-/// for result!(foo, bar) in world.query(Query::<views!(&mut Foo, &Bar), filter::Has<Baz>>::new()) {
+/// for result!(foo, bar) in world.query(Query::<Views!(&mut Foo, &Bar), filter::Has<Baz>>::new()) {
 ///     // Do something.
 /// }
 /// ```

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -40,15 +40,15 @@ use core::{
 ///         result,
 ///         views,
 ///     },
-///     registry,
 ///     Query,
+///     Registry,
 ///     World,
 /// };
 ///
 /// struct Foo(u32);
 /// struct Bar(bool);
 ///
-/// type Registry = registry!(Foo, Bar);
+/// type Registry = Registry!(Foo, Bar);
 ///
 /// let mut world = World::<Registry>::new();
 /// world.insert(entity!(Foo(42), Bar(true)));

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -64,7 +64,7 @@ use core::{
 /// [`Filter`]: crate::query::filter::Filter
 /// [`query`]: crate::world::World::query()
 /// [`result!`]: crate::query::result!
-/// [`Views`]: crate::query::view::Views
+/// [`Views`]: trait@crate::query::view::Views
 /// [`World`]: crate::world::World
 pub struct Iter<'a, R, F, FI, V, VI, P, I, Q>
 where

--- a/src/query/result/iter.rs
+++ b/src/query/result/iter.rs
@@ -38,7 +38,7 @@ use core::{
 ///     query::{
 ///         filter,
 ///         result,
-///         views,
+///         Views,
 ///     },
 ///     Query,
 ///     Registry,
@@ -53,7 +53,7 @@ use core::{
 /// let mut world = World::<Registry>::new();
 /// world.insert(entity!(Foo(42), Bar(true)));
 ///
-/// for result!(foo, bar) in world.query(Query::<views!(&mut Foo, &Bar)>::new()) {
+/// for result!(foo, bar) in world.query(Query::<Views!(&mut Foo, &Bar)>::new()) {
 ///     if bar.0 {
 ///         foo.0 += 1;
 ///     }

--- a/src/query/result/mod.rs
+++ b/src/query/result/mod.rs
@@ -21,7 +21,7 @@
 //!     query::{
 //!         filter,
 //!         result,
-//!         views,
+//!         Views,
 //!     },
 //!     Query,
 //!     Registry,
@@ -36,7 +36,7 @@
 //! let mut world = World::<Registry>::new();
 //! world.insert(entity!(Foo(42), Bar(true)));
 //!
-//! for result!(foo, bar) in world.query(Query::<views!(&mut Foo, &Bar)>::new()) {
+//! for result!(foo, bar) in world.query(Query::<Views!(&mut Foo, &Bar)>::new()) {
 //!     if bar.0 {
 //!         foo.0 += 1;
 //!     }
@@ -77,7 +77,7 @@ doc::non_root_macro! {
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entity, query::{filter, result, views}, Registry, Query, World};
+    /// use brood::{entity, query::{filter, result, Views}, Registry, Query, World};
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
@@ -87,7 +87,7 @@ doc::non_root_macro! {
     /// let mut world = World::<Registry>::new();
     /// world.insert(entity!(Foo(42), Bar(true)));
     ///
-    /// for result!(foo, bar) in world.query(Query::<views!(&mut Foo, &Bar)>::new()) {
+    /// for result!(foo, bar) in world.query(Query::<Views!(&mut Foo, &Bar)>::new()) {
     ///     // ...
     /// }
     /// ```

--- a/src/query/result/mod.rs
+++ b/src/query/result/mod.rs
@@ -23,15 +23,15 @@
 //!         result,
 //!         views,
 //!     },
-//!     registry,
 //!     Query,
+//!     Registry,
 //!     World,
 //! };
 //!
 //! struct Foo(u32);
 //! struct Bar(bool);
 //!
-//! type Registry = registry!(Foo, Bar);
+//! type Registry = Registry!(Foo, Bar);
 //!
 //! let mut world = World::<Registry>::new();
 //! world.insert(entity!(Foo(42), Bar(true)));
@@ -77,12 +77,12 @@ doc::non_root_macro! {
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entity, query::{filter, result, views}, registry, Query, World};
+    /// use brood::{entity, query::{filter, result, views}, Registry, Query, World};
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     /// world.insert(entity!(Foo(42), Bar(true)));

--- a/src/query/result/mod.rs
+++ b/src/query/result/mod.rs
@@ -46,7 +46,7 @@
 //! [`Component`]: crate::component::Component
 //! [`Filter`]: crate::query::filter::Filter
 //! [`result!`]: crate::query::result!
-//! [`Views`]: crate::query::view::Views
+//! [`Views`]: trait@crate::query::view::Views
 //! [`World`]: crate::world::World
 
 pub(crate) mod get;

--- a/src/query/result/par_iter.rs
+++ b/src/query/result/par_iter.rs
@@ -46,8 +46,8 @@ use rayon::iter::{
 ///         result,
 ///         views,
 ///     },
-///     registry,
 ///     Query,
+///     Registry,
 ///     World,
 /// };
 /// use rayon::iter::ParallelIterator;
@@ -55,7 +55,7 @@ use rayon::iter::{
 /// struct Foo(u32);
 /// struct Bar(bool);
 ///
-/// type Registry = registry!(Foo, Bar);
+/// type Registry = Registry!(Foo, Bar);
 ///
 /// let mut world = World::<Registry>::new();
 /// world.insert(entity!(Foo(42), Bar(true)));

--- a/src/query/result/par_iter.rs
+++ b/src/query/result/par_iter.rs
@@ -44,7 +44,7 @@ use rayon::iter::{
 ///     query::{
 ///         filter,
 ///         result,
-///         views,
+///         Views,
 ///     },
 ///     Query,
 ///     Registry,
@@ -61,7 +61,7 @@ use rayon::iter::{
 /// world.insert(entity!(Foo(42), Bar(true)));
 ///
 /// world
-///     .par_query(Query::<views!(&mut Foo, &Bar)>::new())
+///     .par_query(Query::<Views!(&mut Foo, &Bar)>::new())
 ///     .for_each(|result!(foo, bar)| {
 ///         if bar.0 {
 ///             foo.0 += 1;

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -43,7 +43,7 @@
 //! [`query`]: crate::world::World::query()
 //! [`System`]: crate::system::System
 //! [`View`]: crate::query::view::View
-//! [`Views`]: crate::query::view::Views
+//! [`Views`]: trait@crate::query::view::Views
 //! [`Views!`]: crate::query::Views!
 //! [`World`]: crate::world::World.
 
@@ -116,7 +116,7 @@ use sealed::ViewSealed;
 ///
 /// [`Component`]: crate::component::Component
 /// [`Identifier`]: crate::entity::Identifier
-/// [`Views`]: crate::query::view::Views
+/// [`Views`]: trait@crate::query::view::Views
 /// [`Views!`]: crate::query::Views!
 /// [`World`]: crate::world::World
 pub trait View<'a>: ViewSealed<'a> {}

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -173,7 +173,7 @@ where
 {
 }
 
-mod inner {
+pub(crate) mod inner {
     use crate::doc;
     doc::non_root_macro! {
         /// Creates a set of [`View`]s over components.

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -31,7 +31,7 @@
 //! struct Bar(bool);
 //! struct Baz(f64);
 //!
-//! type MyViews<'a> = Views!(&'a mut Foo, &'a Bar, Option<&'a Baz>, entity::Identifier);
+//! type Views<'a> = Views!(&'a mut Foo, &'a Bar, Option<&'a Baz>, entity::Identifier);
 //! ```
 //!
 //! Note that the lifetime `'a` can often be omitted when [`query`]ing a [`World`], but is required
@@ -111,7 +111,7 @@ use sealed::ViewSealed;
 /// struct Foo(u32);
 /// struct Bar(bool);
 ///
-/// type MyViews<'a> = Views!(&'a mut Foo, &'a Bar);
+/// type Views<'a> = Views!(&'a mut Foo, &'a Bar);
 /// ```
 ///
 /// [`Component`]: crate::component::Component
@@ -154,7 +154,7 @@ define_null!();
 /// struct Foo(u32);
 /// struct Bar(bool);
 ///
-/// type MyViews<'a> = Views!(&'a mut Foo, &'a Bar);
+/// type Views<'a> = Views!(&'a mut Foo, &'a Bar);
 /// ```
 ///
 /// [`Component`]: crate::component::Component
@@ -191,7 +191,7 @@ pub(crate) mod inner {
         /// struct Foo(u32);
         /// struct Bar(bool);
         ///
-        /// type MyViews<'a> = Views!(&'a mut Foo, &'a Bar);
+        /// type Views<'a> = Views!(&'a mut Foo, &'a Bar);
         /// ```
         ///
         /// Note that the lifetime `'a` can often be omitted when [`query`]ing a [`World`], but is required

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -17,13 +17,13 @@
 //! results.
 //!
 //! `Views` is a heterogeneous list of individual `View`s. Therefore, it is easiest to define them
-//! using the [`views!`] macro.
+//! using the [`Views!`] macro.
 //!
 //! # Example
 //! ``` rust
 //! use brood::{
 //!     entity,
-//!     query::views,
+//!     query::Views,
 //! };
 //!
 //! // Define components.
@@ -31,7 +31,7 @@
 //! struct Bar(bool);
 //! struct Baz(f64);
 //!
-//! type Views<'a> = views!(&'a mut Foo, &'a Bar, Option<&'a Baz>, entity::Identifier);
+//! type MyViews<'a> = Views!(&'a mut Foo, &'a Bar, Option<&'a Baz>, entity::Identifier);
 //! ```
 //!
 //! Note that the lifetime `'a` can often be omitted when [`query`]ing a [`World`], but is required
@@ -44,7 +44,7 @@
 //! [`System`]: crate::system::System
 //! [`View`]: crate::query::view::View
 //! [`Views`]: crate::query::view::Views
-//! [`views!`]: crate::query::views!
+//! [`Views!`]: crate::query::Views!
 //! [`World`]: crate::world::World.
 
 mod get;
@@ -70,7 +70,6 @@ pub(crate) use sealed::ViewsSealed;
 
 use crate::{
     component::Component,
-    doc,
     entity,
     hlist::define_null,
 };
@@ -102,23 +101,23 @@ use sealed::ViewSealed;
 /// ```
 ///
 /// Note that a single `View` by itself isn't very useful. To be usable in querying a [`World`],
-/// a [`Views`] heterogeneous list must be used. It is recommended to use the [`views!`] macro to
+/// a [`Views`] heterogeneous list must be used. It is recommended to use the [`Views!`] macro to
 /// construct this heterogeneous list.
 ///
 /// ``` rust
-/// use brood::query::views;
+/// use brood::query::Views;
 ///
 /// // Define components.
 /// struct Foo(u32);
 /// struct Bar(bool);
 ///
-/// type Views<'a> = views!(&'a mut Foo, &'a Bar);
+/// type MyViews<'a> = Views!(&'a mut Foo, &'a Bar);
 /// ```
 ///
 /// [`Component`]: crate::component::Component
 /// [`Identifier`]: crate::entity::Identifier
 /// [`Views`]: crate::query::view::Views
-/// [`views!`]: crate::query::views!
+/// [`Views!`]: crate::query::Views!
 /// [`World`]: crate::world::World
 pub trait View<'a>: ViewSealed<'a> {}
 
@@ -145,23 +144,23 @@ define_null!();
 /// In other words, borrows in `Views` must follow Rust's
 /// [borrowing rules](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html).
 ///
-/// As `Views` is a heterogeneous list, it is most easily constructed using the [`views!`] macro.
+/// As `Views` is a heterogeneous list, it is most easily constructed using the [`Views!`] macro.
 ///
 /// # Example
 /// ``` rust
-/// use brood::query::views;
+/// use brood::query::Views;
 ///
 /// // Define components.
 /// struct Foo(u32);
 /// struct Bar(bool);
 ///
-/// type Views<'a> = views!(&'a mut Foo, &'a Bar);
+/// type MyViews<'a> = Views!(&'a mut Foo, &'a Bar);
 /// ```
 ///
 /// [`Component`]: crate::component::Component
 /// [`Filter`]: crate::query::filter::Filter
 /// [`View`]: crate::query::view::View
-/// [`views!`]: crate::query::views!
+/// [`Views!`]: crate::query::Views!
 /// [`World`]: crate::world::World
 pub trait Views<'a>: ViewsSealed<'a> {}
 
@@ -174,38 +173,43 @@ where
 {
 }
 
-doc::non_root_macro! {
-    /// Creates a set of [`View`]s over components.
-    ///
-    /// These views can be used to [`query`] the components stored within a [`World`]. They can also be
-    /// used when defining [`System`]s to be run over components stored in a [`World`].
-    ///
-    /// See the documentation for [`View`] to learn more about what kinds of `View`s can be created.
-    ///
-    /// # Example
-    /// ``` rust
-    /// use brood::query::views;
-    ///
-    /// // Define components.
-    /// struct Foo(u32);
-    /// struct Bar(bool);
-    ///
-    /// type Views<'a> = views!(&'a mut Foo, &'a Bar);
-    /// ```
-    ///
-    /// Note that the lifetime `'a` can often be omitted when [`query`]ing a [`World`], but is required
-    /// when defining a [`System`].
-    ///
-    /// [`query`]: crate::world::World::query()
-    /// [`System`]: crate::system::System
-    /// [`View`]: crate::query::view::View
-    /// [`World`]: crate::world::World
-    macro_rules! views {
-        ($view:ty $(,$views:ty)* $(,)?) => (
-            ($view, $crate::query::view::views!($($views,)*))
-        );
-        () => (
-            $crate::query::view::Null
-        );
+mod inner {
+    use crate::doc;
+    doc::non_root_macro! {
+        /// Creates a set of [`View`]s over components.
+        ///
+        /// These views can be used to [`query`] the components stored within a [`World`]. They can also be
+        /// used when defining [`System`]s to be run over components stored in a [`World`].
+        ///
+        /// See the documentation for [`View`] to learn more about what kinds of `View`s can be created.
+        ///
+        /// # Example
+        /// ``` rust
+        /// use brood::query::Views;
+        ///
+        /// // Define components.
+        /// struct Foo(u32);
+        /// struct Bar(bool);
+        ///
+        /// type MyViews<'a> = Views!(&'a mut Foo, &'a Bar);
+        /// ```
+        ///
+        /// Note that the lifetime `'a` can often be omitted when [`query`]ing a [`World`], but is required
+        /// when defining a [`System`].
+        ///
+        /// [`query`]: crate::world::World::query()
+        /// [`System`]: crate::system::System
+        /// [`View`]: crate::query::view::View
+        /// [`World`]: crate::world::World
+        macro_rules! Views {
+            ($view:ty $(,$views:ty)* $(,)?) => (
+                ($view, $crate::query::view::Views!($($views,)*))
+            );
+            () => (
+                $crate::query::view::Null
+            );
+        }
     }
 }
+
+pub use inner::Views;

--- a/src/query/view/par/mod.rs
+++ b/src/query/view/par/mod.rs
@@ -68,7 +68,7 @@ impl<'a> ParView<'a> for entity::Identifier {}
 /// struct Bar(bool);
 ///
 /// // Define views over those components.
-/// type MyViews<'a> = Views!(&'a Foo, &'a mut Bar);
+/// type Views<'a> = Views!(&'a Foo, &'a mut Bar);
 /// ```
 ///
 /// Because the `Component`s viewed above implement both [`Send`] and [`Sync`], the views created

--- a/src/query/view/par/mod.rs
+++ b/src/query/view/par/mod.rs
@@ -78,7 +78,7 @@ impl<'a> ParView<'a> for entity::Identifier {}
 /// [`ParSystem`]: crate::system::ParSystem
 /// [`ParView`]: crate::query::view::ParView
 /// [`par_query`]: crate::world::World::par_query()
-/// [`Views`]: crate::query::view::Views
+/// [`Views`]: trait@crate::query::view::Views
 #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 pub trait ParViews<'a>: ParViewsSeal<'a> + Send {}
 

--- a/src/query/view/par/mod.rs
+++ b/src/query/view/par/mod.rs
@@ -61,14 +61,14 @@ impl<'a> ParView<'a> for entity::Identifier {}
 ///
 /// # Example
 /// ``` rust
-/// use brood::query::views;
+/// use brood::query::Views;
 ///
 /// // Define components.
 /// struct Foo(usize);
 /// struct Bar(bool);
 ///
 /// // Define views over those components.
-/// type Views<'a> = views!(&'a Foo, &'a mut Bar);
+/// type MyViews<'a> = Views!(&'a Foo, &'a mut Bar);
 /// ```
 ///
 /// Because the `Component`s viewed above implement both [`Send`] and [`Sync`], the views created

--- a/src/registry/contains/component/sealed.rs
+++ b/src/registry/contains/component/sealed.rs
@@ -93,7 +93,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::Sealed;
-    use crate::registry;
+    use crate::Registry;
 
     struct A;
     struct B;
@@ -101,7 +101,7 @@ mod tests {
     struct D;
     struct E;
 
-    type Registry = registry!(A, B, C, D, E);
+    type Registry = Registry!(A, B, C, D, E);
 
     #[test]
     fn contains_start() {

--- a/src/registry/contains/entities/sealed.rs
+++ b/src/registry/contains/entities/sealed.rs
@@ -91,7 +91,7 @@ mod tests {
     use super::*;
     use crate::{
         entities,
-        registry,
+        Registry,
     };
 
     #[derive(Clone, Debug, Eq, PartialEq)]
@@ -105,7 +105,7 @@ mod tests {
     #[derive(Clone, Debug, Eq, PartialEq)]
     struct E;
 
-    type Registry = registry!(A, B, C, D, E);
+    type Registry = Registry!(A, B, C, D, E);
 
     #[test]
     fn entities_empty() {

--- a/src/registry/contains/entity/sealed.rs
+++ b/src/registry/contains/entity/sealed.rs
@@ -76,7 +76,7 @@ mod entity_tests {
     use super::*;
     use crate::{
         entity,
-        registry,
+        Registry,
     };
 
     #[derive(Debug, Eq, PartialEq)]
@@ -90,7 +90,7 @@ mod entity_tests {
     #[derive(Debug, Eq, PartialEq)]
     struct E;
 
-    type Registry = registry!(A, B, C, D, E);
+    type Registry = Registry!(A, B, C, D, E);
 
     #[test]
     fn entity_empty() {

--- a/src/registry/contains/filter/sealed.rs
+++ b/src/registry/contains/filter/sealed.rs
@@ -245,7 +245,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        query::views,
+        query::Views,
         Registry,
     };
     use alloc::vec;
@@ -402,7 +402,7 @@ mod tests {
     #[test]
     fn views_true() {
         assert!(unsafe {
-            <Registry as Sealed<views!(&mut A), _>>::filter(
+            <Registry as Sealed<Views!(&mut A), _>>::filter(
                 archetype::Identifier::<Registry>::new(vec![1]).as_ref(),
             )
         });
@@ -411,7 +411,7 @@ mod tests {
     #[test]
     fn views_false() {
         assert!(!unsafe {
-            <Registry as Sealed<views!(&mut A, &B), _>>::filter(
+            <Registry as Sealed<Views!(&mut A, &B), _>>::filter(
                 archetype::Identifier::<Registry>::new(vec![1]).as_ref(),
             )
         });

--- a/src/registry/contains/filter/sealed.rs
+++ b/src/registry/contains/filter/sealed.rs
@@ -246,14 +246,14 @@ mod tests {
     use super::*;
     use crate::{
         query::views,
-        registry,
+        Registry,
     };
     use alloc::vec;
 
     struct A;
     struct B;
 
-    type Registry = registry!(A, B);
+    type Registry = Registry!(A, B);
 
     #[test]
     fn filter_none() {

--- a/src/registry/eq/sealed.rs
+++ b/src/registry/eq/sealed.rs
@@ -163,7 +163,7 @@ mod tests {
     use super::Sealed;
     use crate::{
         archetype::Identifier,
-        registry,
+        Registry,
     };
     use alloc::vec;
 
@@ -175,7 +175,7 @@ mod tests {
         struct B(bool);
         #[derive(PartialEq)]
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
         let mut a_column_a = vec![A(0), A(1), A(2)];
         let mut b_column_a = vec![B(false), B(true), B(true)];
@@ -207,7 +207,7 @@ mod tests {
         struct B(bool);
         #[derive(PartialEq)]
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
         let mut a_column_a = vec![A(0), A(1), A(2)];
         let mut b_column_a = vec![B(false), B(true), B(true)];

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,6 +1,6 @@
 //! A heterogeneous list of registered [`Component`]s.
 //!
-//! [`Registry`]s are most often defined using the [`registry!`] macro. The items contained within
+//! [`Registry`]s are most often defined using the [`Registry!`] macro. The items contained within
 //! this module should rarely be needed in user code.
 //!
 //! Recommended practice is to define a `Registry` as a custom type, and use that type when
@@ -9,7 +9,7 @@
 //! # Example
 //! ``` rust
 //! use brood::{
-//!     registry,
+//!     Registry,
 //!     World,
 //! };
 //!
@@ -17,14 +17,14 @@
 //! struct Foo(usize);
 //! struct Bar(bool);
 //!
-//! type Registry = registry!(Foo, Bar);
+//! type Registry = Registry!(Foo, Bar);
 //!
 //! let world = World::<Registry>::new();
 //! ```
 //!
 //! [`Component`]: crate::component::Component
 //! [`Registry`]: crate::registry::Registry
-//! [`registry!`]: crate::registry!
+//! [`Registry!`]: crate::Registry!
 //! [`World`]: crate::world::World
 
 pub(crate) mod contains;
@@ -86,13 +86,13 @@ define_null_uninstantiable!();
 ///
 /// # Example
 /// ``` rust
-/// use brood::registry;
+/// use brood::Registry;
 ///
 /// // Define components.
 /// struct Foo(usize);
 /// struct Bar(bool);
 ///
-/// type Registry = registry!(Foo, Bar);
+/// type Registry = Registry!(Foo, Bar);
 /// ```
 ///
 /// [`Component`]: crate::component::Component
@@ -120,7 +120,7 @@ where
 /// # Example
 /// ``` rust
 /// use brood::{
-///     registry,
+///     Registry,
 ///     World,
 /// };
 ///
@@ -129,7 +129,7 @@ where
 /// struct Bar(f32);
 ///
 /// // Define a registry containing those components.
-/// type Registry = registry!(Foo, Bar);
+/// type Registry = Registry!(Foo, Bar);
 ///
 /// // Define a world using the registry.
 /// let world = World::<Registry>::new();
@@ -137,9 +137,9 @@ where
 ///
 /// [`World`]: crate::World
 #[macro_export]
-macro_rules! registry {
+macro_rules! Registry {
     ($component:ty $(,$components:ty)* $(,)?) => {
-        ($component, $crate::registry!($($components,)*))
+        ($component, $crate::Registry!($($components,)*))
     };
     () => {
         $crate::registry::Null

--- a/src/registry/sealed/assertions.rs
+++ b/src/registry/sealed/assertions.rs
@@ -45,7 +45,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::Assertions;
-    use crate::registry;
+    use crate::Registry;
     use fnv::FnvBuildHasher;
     use hashbrown::HashSet;
 
@@ -55,14 +55,14 @@ mod tests {
 
     #[test]
     fn no_duplicates() {
-        type NoDuplicates = registry!(A, B, C);
+        type NoDuplicates = Registry!(A, B, C);
 
         NoDuplicates::assert_no_duplicates(&mut HashSet::with_hasher(FnvBuildHasher::default()));
     }
 
     #[test]
     fn empty_no_duplicates() {
-        type Empty = registry!();
+        type Empty = Registry!();
 
         Empty::assert_no_duplicates(&mut HashSet::with_hasher(FnvBuildHasher::default()));
     }
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn has_duplicates() {
-        type HasDuplicates = registry!(A, B, A, C);
+        type HasDuplicates = Registry!(A, B, A, C);
 
         HasDuplicates::assert_no_duplicates(&mut HashSet::with_hasher(FnvBuildHasher::default()));
     }

--- a/src/registry/sealed/canonical.rs
+++ b/src/registry/sealed/canonical.rs
@@ -133,7 +133,7 @@ mod tests {
     use crate::{
         archetype,
         entity,
-        registry,
+        Registry,
     };
     use alloc::vec::Vec;
 
@@ -148,11 +148,11 @@ mod tests {
     struct I;
 
     // Using enough components to create archetype identifiers with more than one byte.
-    type Registry = registry!(A, B, C, D, E, F, G, H, I);
+    type Registry = Registry!(A, B, C, D, E, F, G, H, I);
 
     #[test]
     fn create_archetype_identifier_empty_registry() {
-        type Registry = registry!();
+        type Registry = Registry!();
 
         assert_eq!(Registry::create_archetype_identifier(), unsafe {
             archetype::Identifier::<Registry>::new(Vec::new())

--- a/src/registry/sealed/length.rs
+++ b/src/registry/sealed/length.rs
@@ -30,11 +30,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::Length;
-    use crate::registry;
+    use crate::Registry;
 
     #[test]
     fn empty() {
-        type Registry = registry!();
+        type Registry = Registry!();
 
         assert_eq!(Registry::LEN, 0);
     }
@@ -45,7 +45,7 @@ mod tests {
         struct B;
         struct C;
 
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
 
         assert_eq!(Registry::LEN, 3);
     }

--- a/src/registry/sealed/storage.rs
+++ b/src/registry/sealed/storage.rs
@@ -1090,7 +1090,7 @@ mod tests {
     use super::Storage;
     use crate::{
         archetype::Identifier,
-        registry,
+        Registry,
     };
     use alloc::{
         vec,
@@ -1107,7 +1107,7 @@ mod tests {
 
     #[test]
     fn new_components_with_capacity_empty_registry() {
-        type Registry = registry!();
+        type Registry = Registry!();
         let identifier = unsafe { Identifier::<Registry>::new(Vec::new()) };
 
         let mut components = Vec::new();
@@ -1121,7 +1121,7 @@ mod tests {
         struct A(usize);
         struct B(usize);
         struct C(usize);
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
         const CAPACITY: usize = 100;
 
@@ -1143,7 +1143,7 @@ mod tests {
         struct A(usize);
         struct B(usize);
         struct C(usize);
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![5]) };
         const CAPACITY: usize = 100;
 
@@ -1164,7 +1164,7 @@ mod tests {
         struct A(usize);
         struct B(usize);
         struct C(usize);
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![0]) };
         const CAPACITY: usize = 100;
 
@@ -1178,7 +1178,7 @@ mod tests {
 
     #[test]
     fn size_of_components_for_identifier_empty_registry() {
-        type Registry = registry!();
+        type Registry = Registry!();
         let identifier = unsafe { Identifier::<Registry>::new(Vec::new()) };
 
         let size = unsafe { Registry::size_of_components_for_identifier(identifier.iter()) };
@@ -1191,7 +1191,7 @@ mod tests {
         struct A;
         struct B(f32);
         struct C(u8);
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
 
         let size = unsafe { Registry::size_of_components_for_identifier(identifier.iter()) };
@@ -1204,7 +1204,7 @@ mod tests {
         struct A;
         struct B(f32);
         struct C(u8);
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![5]) };
 
         let size = unsafe { Registry::size_of_components_for_identifier(identifier.iter()) };
@@ -1217,7 +1217,7 @@ mod tests {
         struct A;
         struct B(f32);
         struct C(u8);
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![0]) };
 
         let size = unsafe { Registry::size_of_components_for_identifier(identifier.iter()) };
@@ -1227,7 +1227,7 @@ mod tests {
 
     #[test]
     fn remove_component_row_empty_registry() {
-        type Registry = registry!();
+        type Registry = Registry!();
         let identifier = unsafe { Identifier::<Registry>::new(Vec::new()) };
         // `components` must be empty because there are no components in the registry.
         let mut components = Vec::new();
@@ -1245,7 +1245,7 @@ mod tests {
         struct B(bool);
         #[derive(Debug, Eq, PartialEq)]
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
         let mut a_column = ManuallyDrop::new(vec![A(0), A(1), A(2)]);
         let mut b_column = ManuallyDrop::new(vec![B(false), B(true), B(true)]);
@@ -1292,7 +1292,7 @@ mod tests {
         struct B(bool);
         #[derive(Debug, Eq, PartialEq)]
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![5]) };
         let mut a_column = ManuallyDrop::new(vec![A(0), A(1), A(2)]);
         let mut c_column = ManuallyDrop::new(vec![C, C, C]);
@@ -1326,7 +1326,7 @@ mod tests {
         struct A(usize);
         struct B(bool);
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![0]) };
         // `components` must be empty because there are no components in the identifier.
         let mut components = Vec::new();
@@ -1342,7 +1342,7 @@ mod tests {
         struct A(usize);
         struct B(bool);
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
         let mut a_column = vec![A(0), A(1), A(2)];
         let mut b_column = vec![B(false), B(true), B(true)];
@@ -1358,7 +1358,7 @@ mod tests {
 
     #[test]
     fn pop_component_row_empty_registry() {
-        type Registry = registry!();
+        type Registry = Registry!();
         let identifier = unsafe { Identifier::<Registry>::new(Vec::new()) };
         // `components` must be empty because there are no components in the registry.
         let mut components = Vec::new();
@@ -1388,7 +1388,7 @@ mod tests {
         struct B(bool);
         #[derive(Debug, Eq, PartialEq)]
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
         let mut a_column = ManuallyDrop::new(vec![A(0), A(1), A(2)]);
         let mut b_column = ManuallyDrop::new(vec![B(false), B(true), B(true)]);
@@ -1455,7 +1455,7 @@ mod tests {
         struct B(bool);
         #[derive(Debug, Eq, PartialEq)]
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![5]) };
         let mut a_column = ManuallyDrop::new(vec![A(0), A(1), A(2)]);
         let mut c_column = ManuallyDrop::new(vec![C, C, C]);
@@ -1506,7 +1506,7 @@ mod tests {
         struct A(usize);
         struct B(bool);
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![0]) };
         // `components` must be empty because there are no components in the identifier.
         let mut components = Vec::new();
@@ -1534,7 +1534,7 @@ mod tests {
         struct A(usize);
         struct B(bool);
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
         let mut a_column = vec![A(0), A(1), A(2)];
         let mut b_column = vec![B(false), B(true), B(true)];
@@ -1567,7 +1567,7 @@ mod tests {
         struct B(bool);
         #[derive(Debug, PartialEq)]
         struct C(f32);
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
         let mut a_column = ManuallyDrop::new(vec![A(0), A(1), A(2)]);
         let mut b_column = ManuallyDrop::new(vec![B(false), B(true), B(true)]);
@@ -1637,7 +1637,7 @@ mod tests {
         struct B(bool);
         #[derive(Debug, PartialEq)]
         struct C(f32);
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![5]) };
         let mut a_column = ManuallyDrop::new(vec![A(0), A(1), A(2)]);
         let mut c_column = ManuallyDrop::new(vec![C(1.0), C(1.1), C(1.2)]);
@@ -1698,7 +1698,7 @@ mod tests {
 
     #[test]
     fn free_components_empty_registry() {
-        type Registry = registry!();
+        type Registry = Registry!();
         let identifier = unsafe { Identifier::<Registry>::new(Vec::new()) };
         let mut components = Vec::new();
 
@@ -1714,7 +1714,7 @@ mod tests {
                 unsafe { DROP_COUNT += 1 };
             }
         }
-        type Registry = registry!(A);
+        type Registry = Registry!(A);
         let identifier = unsafe { Identifier::<Registry>::new(vec![1]) };
         let mut a_column = ManuallyDrop::new(vec![A]);
         let mut components = vec![(a_column.as_mut_ptr().cast::<u8>(), a_column.capacity())];
@@ -1726,7 +1726,7 @@ mod tests {
 
     #[test]
     fn try_free_components_empty_registry() {
-        type Registry = registry!();
+        type Registry = Registry!();
         let identifier = unsafe { Identifier::<Registry>::new(Vec::new()) };
         let mut components = Vec::new();
 
@@ -1742,7 +1742,7 @@ mod tests {
                 unsafe { DROP_COUNT += 1 };
             }
         }
-        type Registry = registry!(A);
+        type Registry = Registry!(A);
         let identifier = unsafe { Identifier::<Registry>::new(vec![1]) };
         let mut a_column = ManuallyDrop::new(vec![A]);
         let mut components = vec![(a_column.as_mut_ptr().cast::<u8>(), a_column.capacity())];
@@ -1762,7 +1762,7 @@ mod tests {
             }
         }
         struct B;
-        type Registry = registry!(A, B);
+        type Registry = Registry!(A, B);
         let identifier = unsafe { Identifier::<Registry>::new(vec![3]) };
         let mut a_column = ManuallyDrop::new(vec![A]);
         let mut components = vec![(a_column.as_mut_ptr().cast::<u8>(), a_column.capacity())];
@@ -1774,7 +1774,7 @@ mod tests {
 
     #[test]
     fn clear_components_empty_registry() {
-        type Registry = registry!();
+        type Registry = Registry!();
         let identifier = unsafe { Identifier::<Registry>::new(Vec::new()) };
         let mut components = Vec::new();
 
@@ -1788,7 +1788,7 @@ mod tests {
         struct A(usize);
         struct B(bool);
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
         let mut a_column = ManuallyDrop::new(vec![A(0), A(1), A(2)]);
         let mut b_column = ManuallyDrop::new(vec![B(false), B(true), B(true)]);
@@ -1832,7 +1832,7 @@ mod tests {
         struct A(usize);
         struct B(bool);
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![5]) };
         let mut a_column = ManuallyDrop::new(vec![A(0), A(1), A(2)]);
         let mut c_column = ManuallyDrop::new(vec![C, C, C]);
@@ -1863,7 +1863,7 @@ mod tests {
 
     #[test]
     fn shrink_components_to_fit_empty_registry() {
-        type Registry = registry!();
+        type Registry = Registry!();
         let identifier = unsafe { Identifier::<Registry>::new(Vec::new()) };
         let mut components = Vec::new();
 
@@ -1877,7 +1877,7 @@ mod tests {
         struct A(usize);
         struct B(bool);
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![7]) };
         let mut a_column = ManuallyDrop::new(vec![
             A(0),
@@ -1942,7 +1942,7 @@ mod tests {
         struct A(usize);
         struct B(bool);
         struct C;
-        type Registry = registry!(A, B, C);
+        type Registry = Registry!(A, B, C);
         let identifier = unsafe { Identifier::<Registry>::new(vec![3]) };
         let mut a_column = ManuallyDrop::new(vec![
             A(0),

--- a/src/registry/serde/de/sealed.rs
+++ b/src/registry/serde/de/sealed.rs
@@ -285,7 +285,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::registry;
+    use crate::Registry;
     use alloc::vec;
     use serde_derive::Deserialize;
 
@@ -295,7 +295,7 @@ mod tests {
     struct B;
     #[derive(Deserialize)]
     struct C;
-    type Registry = registry!(A, B, C);
+    type Registry = Registry!(A, B, C);
 
     #[test]
     fn expected_row_component_names_empty() {

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -10,7 +10,7 @@
 //!         filter,
 //!         filter::Filter,
 //!         result,
-//!         views,
+//!         Views,
 //!     },
 //!     registry::ContainsQuery,
 //!     system::System,
@@ -24,7 +24,7 @@
 //! struct MySystem;
 //!
 //! impl System for MySystem {
-//!     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+//!     type Views<'a> = Views!(&'a mut Foo, &'a Bar);
 //!     type Filter = filter::None;
 //!
 //!     fn run<'a, R, FI, VI, P, I, Q>(
@@ -96,7 +96,7 @@ use crate::{
 ///         filter,
 ///         filter::Filter,
 ///         result,
-///         views,
+///         Views,
 ///     },
 ///     registry::ContainsQuery,
 ///     system::System,
@@ -110,7 +110,7 @@ use crate::{
 /// struct MySystem;
 ///
 /// impl System for MySystem {
-///     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+///     type Views<'a> = Views!(&'a mut Foo, &'a Bar);
 ///     type Filter = filter::None;
 ///
 ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -150,7 +150,7 @@ pub trait System {
     ///         filter,
     ///         filter::Filter,
     ///         result,
-    ///         views,
+    ///         Views,
     ///     },
     ///     registry::ContainsQuery,
     ///     system::System,
@@ -164,7 +164,7 @@ pub trait System {
     /// struct MySystem;
     ///
     /// impl System for MySystem {
-    ///     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+    ///     type Views<'a> = Views!(&'a mut Foo, &'a Bar);
     ///     type Filter = filter::None;
     ///
     ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -201,7 +201,7 @@ pub trait System {
     /// executes the removal during post processing.
     ///
     /// ``` rust
-    /// use brood::{entity, query::{filter, filter::Filter, result, views}, registry::{ContainsQuery, Registry}, system::System, World};
+    /// use brood::{entity, query::{filter, filter::Filter, result, Views}, registry::{ContainsQuery, Registry}, system::System, World};
     ///
     /// // Define components.
     /// struct Foo(usize);
@@ -214,7 +214,7 @@ pub trait System {
     /// }
     ///
     /// impl System for MySystem {
-    ///     type Views<'a> = views!(&'a mut Foo, &'a Bar, entity::Identifier);
+    ///     type Views<'a> = Views!(&'a mut Foo, &'a Bar, entity::Identifier);
     ///     type Filter = filter::None;
     ///
     ///     fn run<'a, R, FI, VI, P, I, Q>(&mut self, query_results: result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>)

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -62,7 +62,7 @@ pub use par::ParSystem;
 #[doc(inline)]
 pub use schedule::{
     schedule,
-    Schedule,
+    inner::Schedule,
 };
 
 use crate::{

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -61,8 +61,8 @@ pub use par::ParSystem;
 #[cfg(feature = "rayon")]
 #[doc(inline)]
 pub use schedule::{
-    schedule,
     inner::Schedule,
+    schedule,
 };
 
 use crate::{

--- a/src/system/par.rs
+++ b/src/system/par.rs
@@ -24,7 +24,7 @@ use crate::{
 ///         filter,
 ///         filter::Filter,
 ///         result,
-///         views,
+///         Views,
 ///     },
 ///     registry::ContainsParQuery,
 ///     system::ParSystem,
@@ -39,7 +39,7 @@ use crate::{
 /// struct MySystem;
 ///
 /// impl ParSystem for MySystem {
-///     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+///     type Views<'a> = Views!(&'a mut Foo, &'a Bar);
 ///     type Filter = filter::None;
 ///
 ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -83,7 +83,7 @@ pub trait ParSystem {
     ///         filter,
     ///         filter::Filter,
     ///         result,
-    ///         views,
+    ///         Views,
     ///     },
     ///     registry::ContainsParQuery,
     ///     system::ParSystem,
@@ -98,7 +98,7 @@ pub trait ParSystem {
     /// struct MySystem;
     ///
     /// impl ParSystem for MySystem {
-    ///     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+    ///     type Views<'a> = Views!(&'a mut Foo, &'a Bar);
     ///     type Filter = filter::None;
     ///
     ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -135,7 +135,7 @@ pub trait ParSystem {
     /// executes the removal during post processing.
     ///
     /// ``` rust
-    /// use brood::{entity, query::{filter, filter::Filter, result, views}, registry::{ContainsParQuery, Registry}, system::ParSystem, World};
+    /// use brood::{entity, query::{filter, filter::Filter, result, Views}, registry::{ContainsParQuery, Registry}, system::ParSystem, World};
     /// use rayon::iter::ParallelIterator;
     ///
     /// // Define components.
@@ -149,7 +149,7 @@ pub trait ParSystem {
     /// }
     ///
     /// impl ParSystem for MySystem {
-    ///     type Views<'a> = views!(&'a mut Foo, &'a Bar, entity::Identifier);
+    ///     type Views<'a> = Views!(&'a mut Foo, &'a Bar, entity::Identifier);
     ///     type Filter = filter::None;
     ///
     ///     fn run<'a, R, FI, VI, P, I, Q>(&mut self, query_results: result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>)

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -292,7 +292,6 @@ mod tests {
             result,
             views,
         },
-        registry,
         registry::{
             ContainsParQuery,
             ContainsQuery,
@@ -306,6 +305,7 @@ mod tests {
             ParSystem,
             System,
         },
+        Registry,
     };
     use core::any::TypeId;
 
@@ -315,7 +315,7 @@ mod tests {
     struct D;
     struct E;
 
-    type Registry = registry!(A, B, C, D, E);
+    type Registry = Registry!(A, B, C, D, E);
 
     #[test]
     fn null() {

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -14,7 +14,7 @@
 //!         filter,
 //!         filter::Filter,
 //!         result,
-//!         views,
+//!         Views,
 //!     },
 //!     registry::ContainsQuery,
 //!     system::{
@@ -32,7 +32,7 @@
 //! struct SystemA;
 //!
 //! impl System for SystemA {
-//!     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+//!     type Views<'a> = Views!(&'a mut Foo, &'a Bar);
 //!     type Filter = filter::None;
 //!
 //!     fn run<'a, R, FI, VI, P, I, Q>(
@@ -50,7 +50,7 @@
 //! struct SystemB;
 //!
 //! impl System for SystemB {
-//!     type Views<'a> = views!(&'a mut Baz, &'a Bar);
+//!     type Views<'a> = Views!(&'a mut Baz, &'a Bar);
 //!     type Filter = filter::None;
 //!
 //!     fn run<'a, R, FI, VI, P, I, Q>(
@@ -134,7 +134,7 @@ doc::non_root_macro! {
     ///         filter,
     ///         filter::Filter,
     ///         result,
-    ///         views,
+    ///         Views,
     ///     },
     ///     registry::{
     ///         ContainsParQuery,
@@ -156,7 +156,7 @@ doc::non_root_macro! {
     /// struct SystemA;
     ///
     /// impl System for SystemA {
-    ///     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+    ///     type Views<'a> = Views!(&'a mut Foo, &'a Bar);
     ///     type Filter = filter::None;
     ///
     ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -172,7 +172,7 @@ doc::non_root_macro! {
     /// struct SystemB;
     ///
     /// impl ParSystem for SystemB {
-    ///     type Views<'a> = views!(&'a mut Baz, &'a Bar);
+    ///     type Views<'a> = Views!(&'a mut Baz, &'a Bar);
     ///     type Filter = filter::None;
     ///
     ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -216,7 +216,7 @@ mod inner {
         ///         filter,
         ///         filter::Filter,
         ///         result,
-        ///         views,
+        ///         Views,
         ///     },
         ///     registry::{
         ///         ContainsParQuery,
@@ -238,7 +238,7 @@ mod inner {
         /// struct SystemA;
         ///
         /// impl System for SystemA {
-        ///     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+        ///     type Views<'a> = Views!(&'a mut Foo, &'a Bar);
         ///     type Filter = filter::None;
         ///
         ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -254,7 +254,7 @@ mod inner {
         /// struct SystemB;
         ///
         /// impl ParSystem for SystemB {
-        ///     type Views<'a> = views!(&'a mut Baz, &'a Bar);
+        ///     type Views<'a> = Views!(&'a mut Baz, &'a Bar);
         ///     type Filter = filter::None;
         ///
         ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -290,7 +290,7 @@ mod tests {
         query::{
             filter,
             result,
-            views,
+            Views,
         },
         registry::{
             ContainsParQuery,
@@ -330,7 +330,7 @@ mod tests {
         struct ImmutA;
 
         impl System for ImmutA {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -367,7 +367,7 @@ mod tests {
         struct MutA;
 
         impl System for MutA {
-            type Views<'a> = views!(&'a mut A);
+            type Views<'a> = Views!(&'a mut A);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -404,7 +404,7 @@ mod tests {
         struct OptionImmutA;
 
         impl System for OptionImmutA {
-            type Views<'a> = views!(Option<&'a A>);
+            type Views<'a> = Views!(Option<&'a A>);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -441,7 +441,7 @@ mod tests {
         struct OptionMutA;
 
         impl System for OptionMutA {
-            type Views<'a> = views!(Option<&'a mut A>);
+            type Views<'a> = Views!(Option<&'a mut A>);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -478,7 +478,7 @@ mod tests {
         struct EntityIdentifier;
 
         impl System for EntityIdentifier {
-            type Views<'a> = views!(entity::Identifier);
+            type Views<'a> = Views!(entity::Identifier);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -518,7 +518,7 @@ mod tests {
         struct ImmutA;
 
         impl ParSystem for ImmutA {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -565,7 +565,7 @@ mod tests {
         struct MutA;
 
         impl ParSystem for MutA {
-            type Views<'a> = views!(&'a mut A);
+            type Views<'a> = Views!(&'a mut A);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -612,7 +612,7 @@ mod tests {
         struct OptionImmutA;
 
         impl ParSystem for OptionImmutA {
-            type Views<'a> = views!(Option<&'a A>);
+            type Views<'a> = Views!(Option<&'a A>);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -662,7 +662,7 @@ mod tests {
         struct OptionMutA;
 
         impl ParSystem for OptionMutA {
-            type Views<'a> = views!(Option<&'a mut A>);
+            type Views<'a> = Views!(Option<&'a mut A>);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -712,7 +712,7 @@ mod tests {
         struct EntityIdentifier;
 
         impl ParSystem for EntityIdentifier {
-            type Views<'a> = views!(entity::Identifier);
+            type Views<'a> = Views!(entity::Identifier);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -762,7 +762,7 @@ mod tests {
         struct AB;
 
         impl System for AB {
-            type Views<'a> = views!(&'a mut A, &'a mut B);
+            type Views<'a> = Views!(&'a mut A, &'a mut B);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -778,7 +778,7 @@ mod tests {
         struct CD;
 
         impl System for CD {
-            type Views<'a> = views!(&'a mut C, &'a mut D);
+            type Views<'a> = Views!(&'a mut C, &'a mut D);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -794,7 +794,7 @@ mod tests {
         struct CE;
 
         impl System for CE {
-            type Views<'a> = views!(&'a mut C, &'a mut E);
+            type Views<'a> = Views!(&'a mut C, &'a mut E);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -69,7 +69,7 @@
 //! ```
 //!
 //! [`ParSystem`]: crate::system::ParSystem
-//! [`Schedule`]: trait@crate::system::Schedule
+//! [`Schedule`]: trait@crate::system::schedule::Schedule
 //! [`System`]: crate::system::System
 //! [`Views`]: trait@crate::query::view::Views
 
@@ -201,7 +201,7 @@ doc::non_root_macro! {
 }
 
 /// Nesting this macro definition in a module is necessary to unambiguate the import of the macro.
-mod inner {
+pub(crate) mod inner {
     use crate::doc;
 
     doc::non_root_macro! {

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -71,7 +71,7 @@
 //! [`ParSystem`]: crate::system::ParSystem
 //! [`Schedule`]: trait@crate::system::Schedule
 //! [`System`]: crate::system::System
-//! [`Views`]: crate::query::view::Views
+//! [`Views`]: trait@crate::query::view::Views
 
 pub mod task;
 
@@ -106,7 +106,7 @@ use task::Task;
 /// [`ParSystem`]: crate::system::ParSystem
 /// [`schedule!`]: crate::system::schedule!
 /// [`System`]: crate::system::System
-/// [`Views`]: crate::query::view::Views
+/// [`Views`]: trait@crate::query::view::Views
 pub trait Schedule<'a, R, I, P, RI, SFI, SVI, SP, SI, SQ>:
     Sealed<'a, R, I, P, RI, SFI, SVI, SP, SI, SQ>
 where

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -267,7 +267,7 @@ pub(crate) mod inner {
         ///     }
         /// }
         ///
-        /// type MySchedule = Schedule!(task::System<SystemA>, task::System<SystemB>);
+        /// type Schedule = Schedule!(task::System<SystemA>, task::System<SystemB>);
         /// ```
         macro_rules! Schedule {
             ($task:ty $(,$tasks:ty)* $(,)?) => (

--- a/src/system/schedule/task/mod.rs
+++ b/src/system/schedule/task/mod.rs
@@ -1,6 +1,6 @@
 //! Tasks that are used to define a [`Schedule`].
 //!
-//! [`Schedule`]: trait@crate::system::Schedule
+//! [`Schedule`]: trait@crate::system::schedule::Schedule
 
 mod sealed;
 

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -304,7 +304,7 @@ where
     /// assert_eq!(foo.0, 42);
     /// assert_eq!(bar.0, true);
     /// ```
-    /// 
+    ///
     /// [`Views`]: trait@crate::query::view::Views
     pub fn query<V, F, VI, FI, P, I, Q>(
         &'a mut self,

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -304,6 +304,8 @@ where
     /// assert_eq!(foo.0, 42);
     /// assert_eq!(bar.0, true);
     /// ```
+    /// 
+    /// [`Views`]: trait@crate::query::Views
     pub fn query<V, F, VI, FI, P, I, Q>(
         &'a mut self,
         #[allow(unused_variables)] query: Query<V, F>,

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -282,7 +282,7 @@ where
     ///     query::{
     ///         filter,
     ///         result,
-    ///         views,
+    ///         Views,
     ///     },
     ///     Query,
     ///     Registry,
@@ -298,7 +298,7 @@ where
     /// let entity_identifier = world.insert(entity!(Foo(42), Bar(true)));
     /// let mut entry = world.entry(entity_identifier).unwrap();
     ///
-    /// let result = entry.query(Query::<views!(&Foo, &Bar), filter::None>::new());
+    /// let result = entry.query(Query::<Views!(&Foo, &Bar), filter::None>::new());
     /// assert!(result.is_some());
     /// let result!(foo, bar) = result.unwrap();
     /// assert_eq!(foo.0, 42);

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -34,14 +34,14 @@ use core::fmt;
 /// ``` rust
 /// use brood::{
 ///     entity,
-///     registry,
+///     Registry,
 ///     World,
 /// };
 ///
 /// struct Foo(u32);
 /// struct Bar(bool);
 ///
-/// type Registry = registry!(Foo, Bar);
+/// type Registry = Registry!(Foo, Bar);
 ///
 /// let mut world = World::<Registry>::new();
 /// let entity_identifier = world.insert(entity!(Foo(42), Bar(true)));
@@ -76,7 +76,7 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     registry,
+    ///     Registry,
     ///     World,
     /// };
     ///
@@ -84,7 +84,7 @@ where
     /// struct Bar(bool);
     /// struct Baz(f64);
     ///
-    /// type Registry = registry!(Foo, Bar, Baz);
+    /// type Registry = Registry!(Foo, Bar, Baz);
     ///
     /// let mut world = World::<Registry>::new();
     /// let entity_identifier = world.insert(entity!(Foo(42), Bar(true)));
@@ -184,14 +184,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     registry,
+    ///     Registry,
     ///     World,
     /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     /// let entity_identifier = world.insert(entity!(Foo(42), Bar(true)));
@@ -284,15 +284,15 @@ where
     ///         result,
     ///         views,
     ///     },
-    ///     registry,
     ///     Query,
+    ///     Registry,
     ///     World,
     /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     /// let entity_identifier = world.insert(entity!(Foo(42), Bar(true)));

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -305,7 +305,7 @@ where
     /// assert_eq!(bar.0, true);
     /// ```
     /// 
-    /// [`Views`]: trait@crate::query::Views
+    /// [`Views`]: trait@crate::query::view::Views
     pub fn query<V, F, VI, FI, P, I, Q>(
         &'a mut self,
         #[allow(unused_variables)] query: Query<V, F>,

--- a/src/world/impl_default.rs
+++ b/src/world/impl_default.rs
@@ -15,9 +15,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::registry;
+    use crate::Registry;
 
-    type Registry = registry!();
+    type Registry = Registry!();
 
     #[test]
     fn default() {

--- a/src/world/impl_eq.rs
+++ b/src/world/impl_eq.rs
@@ -20,7 +20,7 @@ mod tests {
     use super::*;
     use crate::{
         entity,
-        registry,
+        Registry,
     };
 
     #[derive(Debug, Eq, PartialEq)]
@@ -29,11 +29,11 @@ mod tests {
     #[derive(Debug, Eq, PartialEq)]
     struct B(char);
 
-    type Registry = registry!(A, B);
+    type Registry = Registry!(A, B);
 
     #[test]
     fn empty_eq() {
-        assert_eq!(World::<registry!()>::new(), World::<registry!()>::new());
+        assert_eq!(World::<Registry!()>::new(), World::<Registry!()>::new());
     }
 
     #[test]

--- a/src/world/impl_serde.rs
+++ b/src/world/impl_serde.rs
@@ -88,7 +88,7 @@ mod tests {
     use super::*;
     use crate::{
         entity,
-        registry,
+        Registry,
     };
     use serde_derive::{
         Deserialize,
@@ -108,7 +108,7 @@ mod tests {
     #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
     struct B(char);
 
-    type Registry = registry!(A, B);
+    type Registry = Registry!(A, B);
 
     #[test]
     fn serialize_deserialize_empty() {

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -42,9 +42,9 @@ use crate::{
     query::view::ParViews,
     registry::ContainsParQuery,
     system::{
+        schedule::Schedule,
         schedule::Stages,
         ParSystem,
-        schedule::Schedule,
     },
 };
 use alloc::vec::Vec;

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -274,7 +274,7 @@ where
     /// [`Filter`]: crate::query::filter::Filter
     /// [`Iterator`]: core::iter::Iterator
     /// [`query`]: crate::query
-    /// [`Views`]: crate::query::view::Views
+    /// [`Views`]: trait@crate::query::view::Views
     pub fn query<'a, V, F, VI, FI, P, I, Q>(
         &'a mut self,
         #[allow(unused_variables)] query: Query<V, F>,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -44,7 +44,7 @@ use crate::{
     system::{
         schedule::Stages,
         ParSystem,
-        Schedule,
+        schedule::Schedule,
     },
 };
 use alloc::vec::Vec;
@@ -545,7 +545,7 @@ where
     /// world.run_schedule(&mut schedule);
     /// ```
     ///
-    /// [`Schedule`]: trait@crate::system::Schedule
+    /// [`Schedule`]: trait@crate::system::schedule::Schedule
     #[cfg(feature = "rayon")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     pub fn run_schedule<'a, S, I, P, RI, SFI, SVI, SP, SI, SQ>(&mut self, schedule: &'a mut S)

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -61,7 +61,7 @@ use hashbrown::HashSet;
 /// ``` rust
 /// use brood::{
 ///     entity,
-///     registry,
+///     Registry,
 ///     World,
 /// };
 ///
@@ -70,7 +70,7 @@ use hashbrown::HashSet;
 /// struct Bar(bool);
 ///
 /// // Create a world.
-/// let mut world = World::<registry!(Foo, Bar)>::new();
+/// let mut world = World::<Registry!(Foo, Bar)>::new();
 ///
 /// // Insert a new entity. The returned identifier uniquely identifies the entity.
 /// let entity_identifier = world.insert(entity!(Foo(42), Bar(true)));
@@ -124,14 +124,14 @@ where
     /// # Example
     /// ``` rust
     /// use brood::{
-    ///     registry,
+    ///     Registry,
     ///     World,
     /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let world = World::<Registry>::new();
     /// ```
@@ -148,14 +148,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     registry,
+    ///     Registry,
     ///     World,
     /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     ///
@@ -189,14 +189,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entities,
-    ///     registry,
+    ///     Registry,
     ///     World,
     /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     ///
@@ -242,8 +242,8 @@ where
     ///         result,
     ///         views,
     ///     },
-    ///     registry,
     ///     Query,
+    ///     Registry,
     ///     World,
     /// };
     ///
@@ -251,7 +251,7 @@ where
     /// struct Bar(bool);
     /// struct Baz(u32);
     ///
-    /// type Registry = registry!(Foo, Bar, Baz);
+    /// type Registry = Registry!(Foo, Bar, Baz);
     ///
     /// let mut world = World::<Registry>::new();
     /// let inserted_entity_identifier = world.insert(entity!(Foo(42), Bar(true), Baz(100)));
@@ -303,8 +303,8 @@ where
     ///         result,
     ///         views,
     ///     },
-    ///     registry,
     ///     Query,
+    ///     Registry,
     ///     World,
     /// };
     /// use rayon::iter::ParallelIterator;
@@ -313,7 +313,7 @@ where
     /// struct Bar(bool);
     /// struct Baz(u32);
     ///
-    /// type Registry = registry!(Foo, Bar, Baz);
+    /// type Registry = Registry!(Foo, Bar, Baz);
     ///
     /// let mut world = World::<Registry>::new();
     /// let inserted_entity_identifier = world.insert(entity!(Foo(42), Bar(true), Baz(100)));
@@ -365,9 +365,9 @@ where
     ///         result,
     ///         views,
     ///     },
-    ///     registry,
     ///     registry::ContainsQuery,
     ///     system::System,
+    ///     Registry,
     ///     World,
     /// };
     ///
@@ -375,7 +375,7 @@ where
     /// struct Foo(usize);
     /// struct Bar(usize);
     ///
-    /// type MyRegistry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// // Define system.
     /// struct MySystem;
@@ -397,7 +397,7 @@ where
     ///     }
     /// }
     ///
-    /// let mut world = World::<MyRegistry>::new();
+    /// let mut world = World::<Registry>::new();
     /// world.insert(entity!(Foo(42), Bar(100)));
     ///
     /// world.run_system(&mut MySystem);
@@ -424,9 +424,9 @@ where
     ///         result,
     ///         views,
     ///     },
-    ///     registry,
     ///     registry::ContainsParQuery,
     ///     system::ParSystem,
+    ///     Registry,
     ///     World,
     /// };
     /// use rayon::iter::ParallelIterator;
@@ -435,7 +435,7 @@ where
     /// struct Foo(usize);
     /// struct Bar(usize);
     ///
-    /// type MyRegistry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// // Define system.
     /// struct MySystem;
@@ -454,7 +454,7 @@ where
     ///     }
     /// }
     ///
-    /// let mut world = World::<MyRegistry>::new();
+    /// let mut world = World::<Registry>::new();
     /// world.insert(entity!(Foo(42), Bar(100)));
     ///
     /// world.run_par_system(&mut MySystem);
@@ -483,7 +483,6 @@ where
     ///         result,
     ///         views,
     ///     },
-    ///     registry,
     ///     registry::ContainsQuery,
     ///     system::{
     ///         schedule,
@@ -491,6 +490,7 @@ where
     ///         Schedule,
     ///         System,
     ///     },
+    ///     Registry,
     ///     World,
     /// };
     ///
@@ -498,7 +498,7 @@ where
     /// struct Foo(usize);
     /// struct Bar(usize);
     ///
-    /// type MyRegistry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// // Define systems.
     /// struct SystemA;
@@ -539,7 +539,7 @@ where
     /// // Define schedule.
     /// let mut schedule = schedule!(task::System(SystemA), task::System(SystemB));
     ///
-    /// let mut world = World::<MyRegistry>::new();
+    /// let mut world = World::<Registry>::new();
     /// world.insert(entity!(Foo(42), Bar(100)));
     ///
     /// world.run_schedule(&mut schedule);
@@ -561,14 +561,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     registry,
+    ///     Registry,
     ///     World,
     /// };
     ///
     /// struct Foo(usize);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     /// let entity_identifier = world.insert(entity!(Foo(42), Bar(true)));
@@ -591,14 +591,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     registry,
+    ///     Registry,
     ///     World,
     /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     /// let entity_identifier = world.insert(entity!(Foo(42), Bar(true)));
@@ -625,14 +625,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     registry,
+    ///     Registry,
     ///     World,
     /// };
     ///
     /// struct Foo(u32);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     /// let entity_identifier = world.insert(entity!(Foo(42), Bar(true)));
@@ -670,14 +670,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     registry,
+    ///     Registry,
     ///     World,
     /// };
     ///
     /// struct Foo(usize);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     /// world.insert(entity!(Foo(42), Bar(true)));
@@ -697,14 +697,14 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entities, registry, World};
+    /// use brood::{entities, Registry, World};
     ///
     /// #[derive(Clone)]
     /// struct Foo(usize);
     /// #[derive(Clone)]
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     /// world.extend(entities!((Foo(42), Bar(false)); 100));
@@ -722,14 +722,14 @@ where
     /// ``` rust
     /// use brood::{
     ///     entity,
-    ///     registry,
+    ///     Registry,
     ///     World,
     /// };
     ///
     /// struct Foo(usize);
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     ///
@@ -748,14 +748,14 @@ where
     ///
     /// # Example
     /// ``` rust
-    /// use brood::{entities, registry, World};
+    /// use brood::{entities, Registry, World};
     ///
     /// #[derive(Clone)]
     /// struct Foo(usize);
     /// #[derive(Clone)]
     /// struct Bar(bool);
     ///
-    /// type Registry = registry!(Foo, Bar);
+    /// type Registry = Registry!(Foo, Bar);
     ///
     /// let mut world = World::<Registry>::new();
     ///
@@ -788,7 +788,7 @@ mod tests {
             result,
             views,
         },
-        registry,
+        Registry,
     };
     use alloc::vec;
     use claims::{
@@ -804,7 +804,7 @@ mod tests {
     #[derive(Clone, Debug)]
     struct B(char);
 
-    type Registry = registry!(A, B);
+    type Registry = Registry!(A, B);
 
     #[test]
     fn insert() {

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -240,7 +240,7 @@ where
     ///     query::{
     ///         filter,
     ///         result,
-    ///         views,
+    ///         Views,
     ///     },
     ///     Query,
     ///     Registry,
@@ -258,7 +258,7 @@ where
     ///
     /// // Note that the views provide implicit filters.
     /// for result!(foo, baz, entity_identifier) in world.query(Query::<
-    ///     views!(&mut Foo, &Baz, entity::Identifier),
+    ///     Views!(&mut Foo, &Baz, entity::Identifier),
     ///     filter::Has<Bar>,
     /// >::new())
     /// {
@@ -301,7 +301,7 @@ where
     ///     query::{
     ///         filter,
     ///         result,
-    ///         views,
+    ///         Views,
     ///     },
     ///     Query,
     ///     Registry,
@@ -321,7 +321,7 @@ where
     /// // Note that the views provide implicit filters.
     /// world
     ///     .par_query(Query::<
-    ///         views!(&mut Foo, &Baz, entity::Identifier),
+    ///         Views!(&mut Foo, &Baz, entity::Identifier),
     ///         filter::Has<Bar>,
     ///     >::new())
     ///     .for_each(|result!(foo, baz, entity_identifier)| {
@@ -363,7 +363,7 @@ where
     ///         filter,
     ///         filter::Filter,
     ///         result,
-    ///         views,
+    ///         Views,
     ///     },
     ///     registry::ContainsQuery,
     ///     system::System,
@@ -381,7 +381,7 @@ where
     /// struct MySystem;
     ///
     /// impl System for MySystem {
-    ///     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+    ///     type Views<'a> = Views!(&'a mut Foo, &'a Bar);
     ///     type Filter = filter::None;
     ///
     ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -422,7 +422,7 @@ where
     ///         filter,
     ///         filter::Filter,
     ///         result,
-    ///         views,
+    ///         Views,
     ///     },
     ///     registry::ContainsParQuery,
     ///     system::ParSystem,
@@ -441,7 +441,7 @@ where
     /// struct MySystem;
     ///
     /// impl ParSystem for MySystem {
-    ///     type Views<'a> = views!(&'a mut Foo, &'a Bar);
+    ///     type Views<'a> = Views!(&'a mut Foo, &'a Bar);
     ///     type Filter = filter::None;
     ///
     ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -481,7 +481,7 @@ where
     ///         filter,
     ///         filter::Filter,
     ///         result,
-    ///         views,
+    ///         Views,
     ///     },
     ///     registry::ContainsQuery,
     ///     system::{
@@ -505,7 +505,7 @@ where
     /// struct SystemB;
     ///
     /// impl System for SystemA {
-    ///     type Views<'a> = views!(&'a mut Foo);
+    ///     type Views<'a> = Views!(&'a mut Foo);
     ///     type Filter = filter::None;
     ///
     ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -521,7 +521,7 @@ where
     /// }
     ///
     /// impl System for SystemB {
-    ///     type Views<'a> = views!(&'a mut Bar);
+    ///     type Views<'a> = Views!(&'a mut Bar);
     ///     type Filter = filter::None;
     ///
     ///     fn run<'a, R, FI, VI, P, I, Q>(
@@ -786,7 +786,7 @@ mod tests {
         query::{
             filter,
             result,
-            views,
+            Views,
         },
         Registry,
     };
@@ -867,7 +867,7 @@ mod tests {
         world.insert(entity!());
 
         let mut result = world
-            .query(Query::<views!(&B, &A)>::new())
+            .query(Query::<Views!(&B, &A)>::new())
             .map(|result!(b, a)| (b.0, a.0))
             .collect::<Vec<_>>();
         result.sort();
@@ -884,7 +884,7 @@ mod tests {
         world.insert(entity!());
 
         let mut result = world
-            .query(Query::<views!(&A)>::new())
+            .query(Query::<Views!(&A)>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         result.sort();
@@ -901,7 +901,7 @@ mod tests {
         world.insert(entity!());
 
         let mut result = world
-            .query(Query::<views!(&mut B)>::new())
+            .query(Query::<Views!(&mut B)>::new())
             .map(|result!(b)| b.0)
             .collect::<Vec<_>>();
         result.sort();
@@ -918,7 +918,7 @@ mod tests {
         world.insert(entity!());
 
         let mut result = world
-            .query(Query::<views!(Option<&A>)>::new())
+            .query(Query::<Views!(Option<&A>)>::new())
             .map(|result!(a)| a.map(|a| a.0))
             .collect::<Vec<_>>();
         result.sort();
@@ -935,7 +935,7 @@ mod tests {
         world.insert(entity!());
 
         let mut result = world
-            .query(Query::<views!(Option<&mut B>)>::new())
+            .query(Query::<Views!(Option<&mut B>)>::new())
             .map(|result!(b)| b.map(|b| b.0))
             .collect::<Vec<_>>();
         result.sort();
@@ -953,7 +953,7 @@ mod tests {
 
         let result = world
             .query(Query::<
-                views!(entity::Identifier),
+                Views!(entity::Identifier),
                 filter::And<filter::Has<A>, filter::Has<B>>,
             >::new())
             .map(|result!(identifier)| identifier)
@@ -971,7 +971,7 @@ mod tests {
         world.insert(entity!());
 
         let result = world
-            .query(Query::<views!(&A), filter::Has<B>>::new())
+            .query(Query::<Views!(&A), filter::Has<B>>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         assert_eq!(result, vec![1]);
@@ -987,7 +987,7 @@ mod tests {
         world.insert(entity!());
 
         let result = world
-            .query(Query::<views!(&A), filter::Not<filter::Has<B>>>::new())
+            .query(Query::<Views!(&A), filter::Not<filter::Has<B>>>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         assert_eq!(result, vec![2]);
@@ -1004,7 +1004,7 @@ mod tests {
 
         let result = world
             .query(Query::<
-                views!(&A),
+                Views!(&A),
                 filter::And<filter::Has<A>, filter::Has<B>>,
             >::new())
             .map(|result!(a)| a.0)
@@ -1023,7 +1023,7 @@ mod tests {
 
         let mut result = world
             .query(Query::<
-                views!(&A),
+                Views!(&A),
                 filter::Or<filter::Has<A>, filter::Has<B>>,
             >::new())
             .map(|result!(a)| a.0)
@@ -1042,7 +1042,7 @@ mod tests {
         world.insert(entity!());
 
         let mut result = world
-            .query(Query::<views!(&B, &A)>::new())
+            .query(Query::<Views!(&B, &A)>::new())
             .map(|result!(b, a)| (a.0, b.0))
             .collect::<Vec<_>>();
         result.sort();
@@ -1060,7 +1060,7 @@ mod tests {
         world.insert(entity!());
 
         let mut result = world
-            .par_query(Query::<views!(&A)>::new())
+            .par_query(Query::<Views!(&A)>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         result.sort();
@@ -1078,7 +1078,7 @@ mod tests {
         world.insert(entity!());
 
         let mut result = world
-            .par_query(Query::<views!(&mut B)>::new())
+            .par_query(Query::<Views!(&mut B)>::new())
             .map(|result!(b)| b.0)
             .collect::<Vec<_>>();
         result.sort();
@@ -1096,7 +1096,7 @@ mod tests {
         world.insert(entity!());
 
         let mut result = world
-            .par_query(Query::<views!(Option<&A>)>::new())
+            .par_query(Query::<Views!(Option<&A>)>::new())
             .map(|result!(a)| a.map(|a| a.0))
             .collect::<Vec<_>>();
         result.sort();
@@ -1114,7 +1114,7 @@ mod tests {
         world.insert(entity!());
 
         let mut result = world
-            .par_query(Query::<views!(Option<&mut B>)>::new())
+            .par_query(Query::<Views!(Option<&mut B>)>::new())
             .map(|result!(b)| b.map(|b| b.0))
             .collect::<Vec<_>>();
         result.sort();
@@ -1133,7 +1133,7 @@ mod tests {
 
         let result = world
             .par_query(Query::<
-                views!(entity::Identifier),
+                Views!(entity::Identifier),
                 filter::And<filter::Has<A>, filter::Has<B>>,
             >::new())
             .map(|result!(identifier)| identifier)
@@ -1152,7 +1152,7 @@ mod tests {
         world.insert(entity!());
 
         let result = world
-            .par_query(Query::<views!(&A), filter::Has<B>>::new())
+            .par_query(Query::<Views!(&A), filter::Has<B>>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         assert_eq!(result, vec![1]);
@@ -1169,7 +1169,7 @@ mod tests {
         world.insert(entity!());
 
         let result = world
-            .par_query(Query::<views!(&A), filter::Not<filter::Has<B>>>::new())
+            .par_query(Query::<Views!(&A), filter::Not<filter::Has<B>>>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         assert_eq!(result, vec![2]);
@@ -1187,7 +1187,7 @@ mod tests {
 
         let result = world
             .par_query(Query::<
-                views!(&A),
+                Views!(&A),
                 filter::And<filter::Has<A>, filter::Has<B>>,
             >::new())
             .map(|result!(a)| a.0)
@@ -1207,7 +1207,7 @@ mod tests {
 
         let mut result = world
             .par_query(Query::<
-                views!(&A),
+                Views!(&A),
                 filter::Or<filter::Has<A>, filter::Has<B>>,
             >::new())
             .map(|result!(a)| a.0)
@@ -1221,7 +1221,7 @@ mod tests {
         struct TestSystem;
 
         impl System for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1251,7 +1251,7 @@ mod tests {
         struct TestSystem;
 
         impl System for TestSystem {
-            type Views<'a> = views!(&'a mut B);
+            type Views<'a> = Views!(&'a mut B);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1281,7 +1281,7 @@ mod tests {
         struct TestSystem;
 
         impl System for TestSystem {
-            type Views<'a> = views!(Option<&'a A>);
+            type Views<'a> = Views!(Option<&'a A>);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1313,7 +1313,7 @@ mod tests {
         struct TestSystem;
 
         impl System for TestSystem {
-            type Views<'a> = views!(Option<&'a mut B>);
+            type Views<'a> = Views!(Option<&'a mut B>);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1347,7 +1347,7 @@ mod tests {
         }
 
         impl System for TestSystem {
-            type Views<'a> = views!(entity::Identifier);
+            type Views<'a> = Views!(entity::Identifier);
             type Filter = filter::And<filter::Has<A>, filter::Has<B>>;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1378,7 +1378,7 @@ mod tests {
         struct TestSystem;
 
         impl System for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::Has<B>;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1407,7 +1407,7 @@ mod tests {
         struct TestSystem;
 
         impl System for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::Not<filter::Has<B>>;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1436,7 +1436,7 @@ mod tests {
         struct TestSystem;
 
         impl System for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::And<filter::Has<A>, filter::Has<B>>;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1465,7 +1465,7 @@ mod tests {
         struct TestSystem;
 
         impl System for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::Or<filter::Has<A>, filter::Has<B>>;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1496,7 +1496,7 @@ mod tests {
         struct TestSystem;
 
         impl ParSystem for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1537,7 +1537,7 @@ mod tests {
         struct TestSystem;
 
         impl ParSystem for TestSystem {
-            type Views<'a> = views!(&'a mut B);
+            type Views<'a> = Views!(&'a mut B);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1578,7 +1578,7 @@ mod tests {
         struct TestSystem;
 
         impl ParSystem for TestSystem {
-            type Views<'a> = views!(Option<&'a A>);
+            type Views<'a> = Views!(Option<&'a A>);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1621,7 +1621,7 @@ mod tests {
         struct TestSystem;
 
         impl ParSystem for TestSystem {
-            type Views<'a> = views!(Option<&'a mut B>);
+            type Views<'a> = Views!(Option<&'a mut B>);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1666,7 +1666,7 @@ mod tests {
         }
 
         impl ParSystem for TestSystem {
-            type Views<'a> = views!(entity::Identifier);
+            type Views<'a> = Views!(entity::Identifier);
             type Filter = filter::And<filter::Has<A>, filter::Has<B>>;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1708,7 +1708,7 @@ mod tests {
         struct TestSystem;
 
         impl ParSystem for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::Has<B>;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1748,7 +1748,7 @@ mod tests {
         struct TestSystem;
 
         impl ParSystem for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::Not<filter::Has<B>>;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1788,7 +1788,7 @@ mod tests {
         struct TestSystem;
 
         impl ParSystem for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::And<filter::Has<A>, filter::Has<B>>;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1828,7 +1828,7 @@ mod tests {
         struct TestSystem;
 
         impl ParSystem for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::Or<filter::Has<A>, filter::Has<B>>;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1869,7 +1869,7 @@ mod tests {
         struct TestSystem;
 
         impl System for TestSystem {
-            type Views<'a> = views!(&'a A);
+            type Views<'a> = Views!(&'a A);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1887,7 +1887,7 @@ mod tests {
         struct TestParSystem;
 
         impl ParSystem for TestParSystem {
-            type Views<'a> = views!(&'a mut B);
+            type Views<'a> = Views!(&'a mut B);
             type Filter = filter::None;
 
             fn run<'a, R, FI, VI, P, I, Q>(
@@ -1963,7 +1963,7 @@ mod tests {
         entry.add(A(3));
 
         let mut result = world
-            .query(Query::<views!(&A)>::new())
+            .query(Query::<Views!(&A)>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         result.sort();
@@ -1983,7 +1983,7 @@ mod tests {
         entry.add(A(3));
 
         let mut result = world
-            .query(Query::<views!(&A)>::new())
+            .query(Query::<Views!(&A)>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         result.sort();
@@ -2003,7 +2003,7 @@ mod tests {
         entry.remove::<A, _>();
 
         let mut result = world
-            .query(Query::<views!(&A)>::new())
+            .query(Query::<Views!(&A)>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         result.sort();
@@ -2022,7 +2022,7 @@ mod tests {
         let mut entry = assert_some!(world.entry(entity_identifier));
 
         let result!(queried_identifier, a, b) = assert_some!(entry.query(Query::<
-            views!(entity::Identifier, &A, Option<&B>),
+            Views!(entity::Identifier, &A, Option<&B>),
             filter::None,
         >::new()));
         assert_eq!(queried_identifier, entity_identifier);
@@ -2043,7 +2043,7 @@ mod tests {
         let mut entry = assert_some!(world.entry(entity_identifier));
 
         let result!(a, b) =
-            assert_some!(entry.query(Query::<views!(&mut A, Option<&mut B>)>::new()));
+            assert_some!(entry.query(Query::<Views!(&mut A, Option<&mut B>)>::new()));
         assert_eq!(a.0, 1);
         let b = assert_some!(b);
         assert_eq!(b.0, 'a');
@@ -2060,7 +2060,7 @@ mod tests {
 
         let mut entry = assert_some!(world.entry(entity_identifier));
 
-        assert_none!(entry.query(Query::<views!(entity::Identifier, &A, &B)>::new()));
+        assert_none!(entry.query(Query::<Views!(entity::Identifier, &A, &B)>::new()));
     }
 
     #[test]
@@ -2089,7 +2089,7 @@ mod tests {
         world.remove(entity_identifier);
 
         let mut result = world
-            .query(Query::<views!(&A)>::new())
+            .query(Query::<Views!(&A)>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         result.sort();
@@ -2125,7 +2125,7 @@ mod tests {
         world.clear();
 
         let mut result = world
-            .query(Query::<views!(&A)>::new())
+            .query(Query::<Views!(&A)>::new())
             .map(|result!(a)| a.0)
             .collect::<Vec<_>>();
         result.sort();

--- a/tests/trybuild/registry/comma_alone.rs
+++ b/tests/trybuild/registry/comma_alone.rs
@@ -1,5 +1,5 @@
-use brood::registry;
+use brood::Registry;
 
-type Registry = registry!(,);
+type Registry = Registry!(,);
 
 fn main() {}

--- a/tests/trybuild/registry/comma_alone.stderr
+++ b/tests/trybuild/registry/comma_alone.stderr
@@ -1,7 +1,7 @@
 error: no rules expected the token `,`
  --> tests/trybuild/registry/comma_alone.rs:3:27
   |
-3 | type Registry = registry!(,);
+3 | type Registry = Registry!(,);
   |                           ^ no rules expected this token in macro call
   |
 note: while trying to match meta-variable `$component:ty`

--- a/tests/trybuild/registry/unexpected_token.rs
+++ b/tests/trybuild/registry/unexpected_token.rs
@@ -1,9 +1,9 @@
-use brood::registry;
+use brood::Registry;
 
 // Define components.
 struct A;
 struct B;
 
-type Registry = registry!(A, + B,);
+type Registry = Registry!(A, + B,);
 
 fn main() {}

--- a/tests/trybuild/registry/unexpected_token.stderr
+++ b/tests/trybuild/registry/unexpected_token.stderr
@@ -1,7 +1,7 @@
 error: no rules expected the token `+`
  --> tests/trybuild/registry/unexpected_token.rs:7:30
   |
-7 | type Registry = registry!(A, + B,);
+7 | type Registry = Registry!(A, + B,);
   |                              ^ no rules expected this token in macro call
   |
 note: while trying to match meta-variable `$components:ty`

--- a/tests/trybuild/schedule/type_comma_alone.rs
+++ b/tests/trybuild/schedule/type_comma_alone.rs
@@ -1,5 +1,5 @@
 use brood::system::Schedule;
 
-type MySchedule = Schedule!(,);
+type Schedule = Schedule!(,);
 
 fn main() {}

--- a/tests/trybuild/schedule/type_comma_alone.stderr
+++ b/tests/trybuild/schedule/type_comma_alone.stderr
@@ -1,8 +1,8 @@
 error: no rules expected the token `,`
- --> tests/trybuild/schedule/type_comma_alone.rs:3:29
+ --> tests/trybuild/schedule/type_comma_alone.rs:3:27
   |
-3 | type MySchedule = Schedule!(,);
-  |                             ^ no rules expected this token in macro call
+3 | type Schedule = Schedule!(,);
+  |                           ^ no rules expected this token in macro call
   |
 note: while trying to match meta-variable `$task:ty`
  --> src/system/schedule/mod.rs

--- a/tests/trybuild/schedule/type_unexpected_token.rs
+++ b/tests/trybuild/schedule/type_unexpected_token.rs
@@ -1,4 +1,4 @@
-use brood::{query::{views, filter, result}, registry::ContainsQuery, system::{System, Schedule}};
+use brood::{query::{Views, filter, result}, registry::ContainsQuery, system::{System, Schedule}};
 // This import is technically unused, since the macro fails to compile before it would be consumed.
 // I'm leaving it here, though, for completeness; user code would use this module, and these tests
 // should do their best to simulate user code.
@@ -9,7 +9,7 @@ use brood::system::schedule::task;
 struct A;
 
 impl System for A {
-    type Views<'a> = views!();
+    type Views<'a> = Views!();
     type Filter = filter::None;
 
     fn run<'a, R, FI, VI, P, I, Q>(
@@ -22,7 +22,7 @@ impl System for A {
 struct B;
 
 impl System for B {
-    type Views<'a> = views!();
+    type Views<'a> = Views!();
     type Filter = filter::None;
 
     fn run<'a, R, FI, VI, P, I, Q>(

--- a/tests/trybuild/schedule/type_unexpected_token.rs
+++ b/tests/trybuild/schedule/type_unexpected_token.rs
@@ -32,6 +32,6 @@ impl System for B {
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
 }
 
-type MySchedule = Schedule!(task::System<A>, + task::System<B>,);
+type Schedule = Schedule!(task::System<A>, + task::System<B>,);
 
 fn main() {}

--- a/tests/trybuild/schedule/type_unexpected_token.stderr
+++ b/tests/trybuild/schedule/type_unexpected_token.stderr
@@ -1,8 +1,8 @@
 error: no rules expected the token `+`
-  --> tests/trybuild/schedule/type_unexpected_token.rs:35:46
+  --> tests/trybuild/schedule/type_unexpected_token.rs:35:44
    |
-35 | type MySchedule = Schedule!(task::System<A>, + task::System<B>,);
-   |                                              ^ no rules expected this token in macro call
+35 | type Schedule = Schedule!(task::System<A>, + task::System<B>,);
+   |                                            ^ no rules expected this token in macro call
    |
 note: while trying to match meta-variable `$tasks:ty`
   --> src/system/schedule/mod.rs

--- a/tests/trybuild/schedule/unexpected_token.rs
+++ b/tests/trybuild/schedule/unexpected_token.rs
@@ -1,4 +1,4 @@
-use brood::{query::{views, filter, result}, registry::ContainsQuery, system::{System, schedule}};
+use brood::{query::{Views, filter, result}, registry::ContainsQuery, system::{System, schedule}};
 // This import is technically unused, since the macro fails to compile before it would be consumed.
 // I'm leaving it here, though, for completeness; user code would use this module, and these tests
 // should do their best to simulate user code.
@@ -9,7 +9,7 @@ use brood::system::schedule::task;
 struct A;
 
 impl System for A {
-    type Views<'a> = views!();
+    type Views<'a> = Views!();
     type Filter = filter::None;
 
     fn run<'a, R, FI, VI, P, I, Q>(
@@ -22,7 +22,7 @@ impl System for A {
 struct B;
 
 impl System for B {
-    type Views<'a> = views!();
+    type Views<'a> = Views!();
     type Filter = filter::None;
 
     fn run<'a, R, FI, VI, P, I, Q>(

--- a/tests/trybuild/views/comma_alone.rs
+++ b/tests/trybuild/views/comma_alone.rs
@@ -1,5 +1,5 @@
-use brood::query::views;
+use brood::query::Views;
 
-type Views = views!(,);
+type MyViews = Views!(,);
 
 fn main() {}

--- a/tests/trybuild/views/comma_alone.rs
+++ b/tests/trybuild/views/comma_alone.rs
@@ -1,5 +1,5 @@
 use brood::query::Views;
 
-type MyViews = Views!(,);
+type Views = Views!(,);
 
 fn main() {}

--- a/tests/trybuild/views/comma_alone.stderr
+++ b/tests/trybuild/views/comma_alone.stderr
@@ -1,8 +1,8 @@
 error: no rules expected the token `,`
- --> tests/trybuild/views/comma_alone.rs:3:23
+ --> tests/trybuild/views/comma_alone.rs:3:21
   |
-3 | type MyViews = Views!(,);
-  |                       ^ no rules expected this token in macro call
+3 | type Views = Views!(,);
+  |                     ^ no rules expected this token in macro call
   |
 note: while trying to match meta-variable `$view:ty`
  --> src/query/view/mod.rs

--- a/tests/trybuild/views/comma_alone.stderr
+++ b/tests/trybuild/views/comma_alone.stderr
@@ -1,11 +1,11 @@
 error: no rules expected the token `,`
- --> tests/trybuild/views/comma_alone.rs:3:21
+ --> tests/trybuild/views/comma_alone.rs:3:23
   |
-3 | type Views = views!(,);
-  |                     ^ no rules expected this token in macro call
+3 | type MyViews = Views!(,);
+  |                       ^ no rules expected this token in macro call
   |
 note: while trying to match meta-variable `$view:ty`
  --> src/query/view/mod.rs
   |
-  |         ($view:ty $(,$views:ty)* $(,)?) => (
-  |          ^^^^^^^^
+  |             ($view:ty $(,$views:ty)* $(,)?) => (
+  |              ^^^^^^^^

--- a/tests/trybuild/views/unexpected_token.rs
+++ b/tests/trybuild/views/unexpected_token.rs
@@ -1,9 +1,9 @@
-use brood::query::views;
+use brood::query::Views;
 
 // Define components.
 struct A;
 struct B;
 
-type Views = views!(&A, + &B,);
+type MyViews = Views!(&A, + &B,);
 
 fn main() {}

--- a/tests/trybuild/views/unexpected_token.rs
+++ b/tests/trybuild/views/unexpected_token.rs
@@ -4,6 +4,6 @@ use brood::query::Views;
 struct A;
 struct B;
 
-type MyViews = Views!(&A, + &B,);
+type Views = Views!(&A, + &B,);
 
 fn main() {}

--- a/tests/trybuild/views/unexpected_token.stderr
+++ b/tests/trybuild/views/unexpected_token.stderr
@@ -1,11 +1,11 @@
 error: no rules expected the token `+`
- --> tests/trybuild/views/unexpected_token.rs:7:25
+ --> tests/trybuild/views/unexpected_token.rs:7:27
   |
-7 | type Views = views!(&A, + &B,);
-  |                         ^ no rules expected this token in macro call
+7 | type MyViews = Views!(&A, + &B,);
+  |                           ^ no rules expected this token in macro call
   |
 note: while trying to match meta-variable `$views:ty`
  --> src/query/view/mod.rs
   |
-  |         ($view:ty $(,$views:ty)* $(,)?) => (
-  |                      ^^^^^^^^^
+  |             ($view:ty $(,$views:ty)* $(,)?) => (
+  |                          ^^^^^^^^^

--- a/tests/trybuild/views/unexpected_token.stderr
+++ b/tests/trybuild/views/unexpected_token.stderr
@@ -1,8 +1,8 @@
 error: no rules expected the token `+`
- --> tests/trybuild/views/unexpected_token.rs:7:27
+ --> tests/trybuild/views/unexpected_token.rs:7:25
   |
-7 | type MyViews = Views!(&A, + &B,);
-  |                           ^ no rules expected this token in macro call
+7 | type Views = Views!(&A, + &B,);
+  |                         ^ no rules expected this token in macro call
   |
 note: while trying to match meta-variable `$views:ty`
  --> src/query/view/mod.rs


### PR DESCRIPTION
Fixes #141.

This renames the `registry!` and `views!` macros to `Registry!` and `Views!`, respectively. It also ensures that only the macros are reexported, while the traits are kept private.

This ultimately helps with clarity over which macros are for types and which macros are not. While this isn't officially part of the Rust API guidelines, since it has passed a final comment period and is currently in use in big crates like `syn` (see `syn::Token!`, I think it's the right direction to go.