### PR TITLE
Add capacity reservation methods to `World`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Added
+- `Entity!` macro for defining the type of an entity.
 
 ## 0.4.0 - 2022-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Added
 - `Entity!` macro for defining the type of an entity.
+- `reserve()` method on `World` for reserving capacity for additional entities made up of a specific set of components.
 
 ## 0.4.0 - 2022-12-03
 ### Added

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -121,6 +121,29 @@ macro_rules! entity {
     };
 }
 
+/// Defines the type of an entity containing the provided components.
+/// 
+/// # Example
+/// ``` rust
+/// use brood::Entity;
+/// 
+/// // Define components `Foo` and `Bar`.
+/// struct Foo(u16);
+/// struct Bar(f32);
+/// 
+/// // Define the type for an entity containing the components `Foo` and `Bar`.
+/// type Entity = Entity!(Foo, Bar);
+/// ```
+#[macro_export]
+macro_rules! Entity {
+    ($component:ty $(,$components:ty)* $(,)?) => {
+        ($component, $crate::Entity!($($components,)*))
+    };
+    () => {
+        $crate::entity::Null
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -122,15 +122,15 @@ macro_rules! entity {
 }
 
 /// Defines the type of an entity containing the provided components.
-/// 
+///
 /// # Example
 /// ``` rust
 /// use brood::Entity;
-/// 
+///
 /// // Define components `Foo` and `Bar`.
 /// struct Foo(u16);
 /// struct Bar(f32);
-/// 
+///
 /// // Define the type for an entity containing the components `Foo` and `Bar`.
 /// type Entity = Entity!(Foo, Bar);
 /// ```

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -777,6 +777,9 @@ where
     /// Note that the capacity is reserved for all future entities that contain the components of
     /// `E`, regardless of order.
     ///
+    /// # Panics
+    /// Panics if the new capacity for entities of type `E` exceeds `isize::MAX` bytes.
+    ///
     /// # Example
     /// ``` rust
     /// use brood::{

--- a/tests/trybuild/entity/type_comma_alone.rs
+++ b/tests/trybuild/entity/type_comma_alone.rs
@@ -1,0 +1,5 @@
+use brood::Entity;
+
+type Entity = Entity!(,);
+
+fn main() {}

--- a/tests/trybuild/entity/type_comma_alone.stderr
+++ b/tests/trybuild/entity/type_comma_alone.stderr
@@ -1,0 +1,11 @@
+error: no rules expected the token `,`
+ --> tests/trybuild/entity/type_comma_alone.rs:3:23
+  |
+3 | type Entity = Entity!(,);
+  |                       ^ no rules expected this token in macro call
+  |
+note: while trying to match meta-variable `$component:ty`
+ --> src/entity/mod.rs
+  |
+  |     ($component:ty $(,$components:ty)* $(,)?) => {
+  |      ^^^^^^^^^^^^^

--- a/tests/trybuild/entity/type_unexpected_token.rs
+++ b/tests/trybuild/entity/type_unexpected_token.rs
@@ -1,0 +1,8 @@
+use brood::Entity;
+
+struct A;
+struct B;
+
+type Entity = Entity!(A, + B,);
+
+fn main() {}

--- a/tests/trybuild/entity/type_unexpected_token.stderr
+++ b/tests/trybuild/entity/type_unexpected_token.stderr
@@ -1,0 +1,11 @@
+error: no rules expected the token `+`
+ --> tests/trybuild/entity/type_unexpected_token.rs:6:26
+  |
+6 | type Entity = Entity!(A, + B,);
+  |                          ^ no rules expected this token in macro call
+  |
+note: while trying to match meta-variable `$components:ty`
+ --> src/entity/mod.rs
+  |
+  |     ($component:ty $(,$components:ty)* $(,)?) => {
+  |                       ^^^^^^^^^^^^^^


### PR DESCRIPTION
Adds `reserve()` methods to `World`. Also adds an `Entity!` macro for defining the type of an entity.

This hits the last checkbox on #59, and should close that issue.