### PR TITLE
Update continuous integration shields.io badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # brood
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Anders429/brood/test.yaml?branch=master)](https://github.com/Anders429/brood/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Anders429/brood/workflows/test.yaml?branch=master)](https://github.com/Anders429/brood/actions)
 [![codecov.io](https://img.shields.io/codecov/c/gh/Anders429/brood)](https://codecov.io/gh/Anders429/brood)
 [![crates.io](https://img.shields.io/crates/v/brood)](https://crates.io/crates/brood)
 [![docs.rs](https://docs.rs/brood/badge.svg)](https://docs.rs/brood)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # brood
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Anders429/brood/test.yaml?branch=master)](https://github.com/Anders429/brood/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Anders429/brood/test.yaml?branch=master)](https://github.com/Anders429/brood/actions/workflows/test.yaml)
 [![codecov.io](https://img.shields.io/codecov/c/gh/Anders429/brood)](https://codecov.io/gh/Anders429/brood)
 [![crates.io](https://img.shields.io/crates/v/brood)](https://crates.io/crates/brood)
 [![docs.rs](https://docs.rs/brood/badge.svg)](https://docs.rs/brood)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # brood
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Anders429/brood/workflows/test.yaml?branch=master)](https://github.com/Anders429/brood/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Anders429/brood/test.yaml?branch=master)](https://github.com/Anders429/brood/actions)
 [![codecov.io](https://img.shields.io/codecov/c/gh/Anders429/brood)](https://codecov.io/gh/Anders429/brood)
 [![crates.io](https://img.shields.io/crates/v/brood)](https://crates.io/crates/brood)
 [![docs.rs](https://docs.rs/brood/badge.svg)](https://docs.rs/brood)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # brood
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/Anders429/brood/CI)](https://github.com/Anders429/brood/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Anders429/brood/test.yml?branch=master)](https://github.com/Anders429/brood/actions)
 [![codecov.io](https://img.shields.io/codecov/c/gh/Anders429/brood)](https://codecov.io/gh/Anders429/brood)
 [![crates.io](https://img.shields.io/crates/v/brood)](https://crates.io/crates/brood)
 [![docs.rs](https://docs.rs/brood/badge.svg)](https://docs.rs/brood)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # brood
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Anders429/brood/test.yml?branch=master)](https://github.com/Anders429/brood/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Anders429/brood/test.yaml?branch=master)](https://github.com/Anders429/brood/actions)
 [![codecov.io](https://img.shields.io/codecov/c/gh/Anders429/brood)](https://codecov.io/gh/Anders429/brood)
 [![crates.io](https://img.shields.io/crates/v/brood)](https://crates.io/crates/brood)
 [![docs.rs](https://docs.rs/brood/badge.svg)](https://docs.rs/brood)


### PR DESCRIPTION
This updates the CI badge to use the new URL format, as specified in https://github.com/badges/shields/issues/8671. I also changed the URL the badge points to, leading directly to the CI workflows, rather than all workflows (though admittedly, these are currently the same, but in the future they may not be).