### PR TITLE
Configure rustfmt to use field initialize shorthand.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,4 +2,5 @@ comment_width = 100
 format_code_in_doc_comments = true
 imports_granularity = "Crate"
 imports_layout = "Vertical"
+use_field_init_shorthand = true
 wrap_comments = true


### PR DESCRIPTION
Doesn't actually change anything now, since the code already uses field initialize shorthand, but this ensures future code will continue using it.