### PR TITLE
Fix endless loop when querying with empty views.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Fixed
+- Querying with empty component views no longer iterates endlessly. It now iterates once for each entity filtered, despite no components being viewed.
 
 ## 0.6.0 - 2023-03-20
 ### Added

--- a/src/query/result/reshape.rs
+++ b/src/query/result/reshape.rs
@@ -13,8 +13,8 @@ pub trait Reshape<R, I> {
     fn reshape(self) -> R;
 }
 
-impl Reshape<iter::Repeat<view::Null>, Null> for iter::Repeat<view::Null> {
-    fn reshape(self) -> iter::Repeat<view::Null> {
+impl Reshape<iter::Take<iter::Repeat<view::Null>>, Null> for iter::Take<iter::Repeat<view::Null>> {
+    fn reshape(self) -> iter::Take<iter::Repeat<view::Null>> {
         self
     }
 }

--- a/src/query/result/sealed/mod.rs
+++ b/src/query/result/sealed/mod.rs
@@ -14,7 +14,7 @@ pub trait Results {
     fn into_iterator(self) -> Self::Iterator;
 }
 
-impl Results for iter::Repeat<view::Null> {
+impl Results for iter::Take<iter::Repeat<view::Null>> {
     type View = view::Null;
     type Iterator = Self;
 

--- a/src/query/view/sealed.rs
+++ b/src/query/view/sealed.rs
@@ -59,7 +59,7 @@ pub trait ViewsSealed<'a> {
 }
 
 impl<'a> ViewsSealed<'a> for Null {
-    type Results = iter::Repeat<Null>;
+    type Results = iter::Take<iter::Repeat<Null>>;
 }
 
 impl<'a, V, W> ViewsSealed<'a> for (V, W)

--- a/src/registry/sealed/par_view.rs
+++ b/src/registry/sealed/par_view.rs
@@ -49,13 +49,13 @@ where
 impl<'a> CanonicalParViews<'a, view::Null, Null> for registry::Null {
     unsafe fn par_view<R>(
         _columns: &[(*mut u8, usize)],
-        _length: usize,
+        length: usize,
         _archetype_identifier: archetype::identifier::Iter<R>,
     ) -> <view::Null as ParViewsSeal<'a>>::ParResults
     where
         R: Registry,
     {
-        iter::repeatn(view::Null, usize::MAX)
+        iter::repeatn(view::Null, length)
     }
 }
 

--- a/src/registry/sealed/view.rs
+++ b/src/registry/sealed/view.rs
@@ -69,13 +69,13 @@ where
 impl<'a> CanonicalViews<'a, view::Null, Null> for registry::Null {
     unsafe fn view<R>(
         _columns: &[(*mut u8, usize)],
-        _length: usize,
+        length: usize,
         _archetype_identifier: archetype::identifier::Iter<R>,
     ) -> <view::Null as ViewsSealed<'a>>::Results
     where
         R: Registry,
     {
-        iter::repeat(view::Null)
+        iter::repeat(view::Null).take(length)
     }
 
     unsafe fn view_one<R>(

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1445,10 +1445,7 @@ mod tests {
         world.insert(entity!(B('b')));
         world.insert(entity!());
 
-        let count = world
-            .query(Query::<Views!()>::new())
-            .iter
-            .count();
+        let count = world.query(Query::<Views!()>::new()).iter.count();
 
         assert_eq!(count, 4);
     }
@@ -1655,6 +1652,21 @@ mod tests {
 
         assert_eq!(a, &A(100));
         assert_eq!(b, &mut B('a'));
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn par_query_empty() {
+        let mut world = World::<Registry>::new();
+
+        world.insert(entity!(B('a'), A(1)));
+        world.insert(entity!(A(2)));
+        world.insert(entity!(B('b')));
+        world.insert(entity!());
+
+        let count = world.par_query(Query::<Views!()>::new()).iter.count();
+
+        assert_eq!(count, 4);
     }
 
     #[test]

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1436,6 +1436,24 @@ mod tests {
         assert_eq!(b, &mut B('a'));
     }
 
+    #[test]
+    fn query_empty() {
+        let mut world = World::<Registry>::new();
+
+        world.insert(entity!(B('a'), A(1)));
+        world.insert(entity!(A(2)));
+        world.insert(entity!(B('b')));
+        world.insert(entity!());
+
+        let count = world
+            .query(Query::<Views!()>::new())
+            .iter
+            .collect::<Vec<_>>()
+            .len();
+
+        assert_eq!(count, 4);
+    }
+
     #[cfg(feature = "rayon")]
     #[test]
     fn par_query_refs() {

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1448,8 +1448,7 @@ mod tests {
         let count = world
             .query(Query::<Views!()>::new())
             .iter
-            .collect::<Vec<_>>()
-            .len();
+            .count();
 
         assert_eq!(count, 4);
     }


### PR DESCRIPTION
Fixes #180.

Since the only changes are in the associated types of sealed traits, this is not a breaking change. The return type of queries is the same, with only their behavior changing.