### PR TITLE
Allow `Entry` access from system run method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 ### Added
+- `view::ContainsFilter` trait to indicate that a filter can be expressed over a view.
+### Changed
+- `query::Entry::query()` is now bound on `Registry` implementing `ContainsViews<Views>` over the superview `Views`, instead of the `SubViews`.
+- `query::Entry::query()` is now bound on `Views` implementing `view::ContainsFilter<Filter`.
+- `view::SubSet` is no longer required to be generic over `Registry`. 
+### Fixed
+- Entries can now be accessed from within `System::run()` and `ParSystem::run()`.
+
+### Added
 - `query::Entries` struct to allow access to certain component columns through an `Entry` API.
 - `query::Entry` struct to allow access to an individual entity's components, respecting a restricting superset of views.
 - `view::SubSet` trait, defining one `Views` as a subset of another.

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ impl System for UpdatePosition {
     type ResourceViews: Views!();
     type EntryViews: Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q>(
+    fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         &mut self,
-        query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+        query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
     ) where
         R: ContainsQuery<Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     {
@@ -195,9 +195,9 @@ impl ParSystem for UpdatePosition {
     type ResourceViews: Views!();
     type EntryViews: Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q>(
+    fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         &mut self,
-        query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+        query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
     ) where
         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     {
@@ -256,9 +256,9 @@ impl System for UpdatePosition {
     type ResourceViews: Views!();
     type EntryViews: Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q>(
+    fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         &mut self,
-        query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+        query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     {
@@ -277,9 +277,9 @@ impl System for UpdateIsMoving {
     type ResourceViews: Views!();
     type EntryViews: Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q>(
+    fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         &mut self,
-        query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+        query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     {

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -344,6 +344,31 @@ where
         }
     }
 
+    pub(crate) unsafe fn view_row_maybe_uninit_unchecked<'a, V, P, I, Q>(
+        &mut self,
+        index: usize,
+    ) -> <<<R as ContainsViewsSealed<'a, V, P, I, Q>>::Viewable as ContainsViewsOuter<
+        'a,
+        V,
+        P,
+        I,
+        Q,
+    >>::Canonical as ViewsSealed<'a>>::MaybeUninit
+    where
+        V: Views<'a>,
+        R: ContainsViews<'a, V, P, I, Q>,
+    {
+        unsafe {
+            <R as ContainsViewsSealed<'a, V, P, I, Q>>::Viewable::view_one_maybe_uninit(
+                index,
+                &self.components,
+                self.entity_identifiers,
+                self.length,
+                self.identifier.iter(),
+            )
+        }
+    }
+
     /// # Safety
     /// `C` must be a component type that is contained within this archetype, meaning the
     /// archetype's `Identifier` must have the `C` bit set.

--- a/src/archetype/mod.rs
+++ b/src/archetype/mod.rs
@@ -344,6 +344,8 @@ where
         }
     }
 
+    /// # Safety
+    /// The index `index` must be a valid index into this archetype.
     pub(crate) unsafe fn view_row_maybe_uninit_unchecked<'a, V, P, I, Q>(
         &mut self,
         index: usize,
@@ -358,6 +360,16 @@ where
         V: Views<'a>,
         R: ContainsViews<'a, V, P, I, Q>,
     {
+        // SAFETY: `self.components` contains the raw parts for `Vec<C>`s of size `self.length`
+        // for each component `C` identified in `self.identifier` in the canonical order defined by
+        // the registry.
+        //
+        // `self.entity_identifiers` also contains the raw parts for a valid
+        // `Vec<entity::Identifier>` of size `self.length`.
+        //
+        // `index` is guaranteed by the safety contract of this method to be within the bounds of
+        // this archetype, and therefore within the bounds of each column and the entity
+        // identifiers of this archetype.
         unsafe {
             <R as ContainsViewsSealed<'a, V, P, I, Q>>::Viewable::view_one_maybe_uninit(
                 index,

--- a/src/query/entries.rs
+++ b/src/query/entries.rs
@@ -100,6 +100,9 @@ where
                                                         Indices,
                                                         ReshapeIndices
                                                     >>::Canonical::reshape_maybe_uninit(
+                                                        // SAFETY: `self.location.index` is a valid
+                                                        // index into this archetype, as guaranteed
+                                                        // by the entity allocator.
                                                         unsafe {
                                                             (*self.entries.world).archetypes
                                                                 .get_mut(self.location.identifier)?
@@ -111,6 +114,9 @@ where
                                                                 >(self.location.index)
                                                             });
 
+            // SAFETY: `super_views` is viewed on the archetype identified by
+            // `self.location.identifier`. The `indices` also correspond to the registry the
+            // archetype is generic over. Finally, the `SubViews` filter has already been applied.
             Some(unsafe { SubViews::view(super_views, indices, self.location.identifier) })
         } else {
             None

--- a/src/query/entries.rs
+++ b/src/query/entries.rs
@@ -297,6 +297,87 @@ mod tests {
     }
 
     #[test]
+    fn empty_query_with_filter_on_mutable_ref_in_super_views() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(&mut A), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        assert_some!(entry.query(Query::<Views!(), filter::Has<A>>::new()));
+    }
+
+    #[test]
+    fn empty_query_with_filter_on_optional_ref_in_super_views() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(Option<&A>), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        assert_some!(entry.query(Query::<Views!(), filter::Has<A>>::new()));
+    }
+
+    #[test]
+    fn empty_query_with_filter_on_optional_mutable_ref_in_super_views() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(Option<&mut A>), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        assert_some!(entry.query(Query::<Views!(), filter::Has<A>>::new()));
+    }
+
+    #[test]
+    fn empty_query_with_filter_on_second_view_in_super_views() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(&C, &A), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        assert_some!(entry.query(Query::<Views!(), filter::Has<A>>::new()));
+    }
+
+    #[test]
+    fn empty_query_with_or_filter() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(&A, &B), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        assert_some!(
+            entry.query(Query::<Views!(), filter::Or<filter::Has<A>, filter::Has<B>>>::new())
+        );
+    }
+
+    #[test]
+    fn empty_query_with_and_filter() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42), B('a')));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(&A, &B), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        assert_some!(
+            entry.query(Query::<Views!(), filter::And<filter::Has<A>, filter::Has<B>>>::new())
+        );
+    }
+
+    #[test]
+    fn empty_query_with_not_filter() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(&B), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        assert_some!(entry.query(Query::<Views!(), filter::Not<filter::Has<B>>>::new()));
+    }
+
+    #[test]
     fn empty_query_with_nonempty_superset() {
         let mut world = World::<Registry>::new();
         let identifier = world.insert(entity!());
@@ -419,5 +500,41 @@ mod tests {
         assert_eq!(queried_identifier, identifier);
         assert_eq!(a, None);
         assert_eq!(b, &B('a'));
+    }
+
+    #[test]
+    fn query_ref_with_optional_super_view() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(Option<&A>), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        let result!(a) = assert_some!(entry.query(Query::<Views!(&A)>::new()));
+        assert_eq!(a, &A(42));
+    }
+
+    #[test]
+    fn query_ref_with_optional_mutable_super_view() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(Option<&mut A>), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        let result!(a) = assert_some!(entry.query(Query::<Views!(&A)>::new()));
+        assert_eq!(a, &A(42));
+    }
+
+    #[test]
+    fn query_mutable_ref_with_optional_mutable_super_view() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(Option<&mut A>), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        let result!(a) = assert_some!(entry.query(Query::<Views!(&mut A)>::new()));
+        assert_eq!(a, &mut A(42));
     }
 }

--- a/src/query/entries.rs
+++ b/src/query/entries.rs
@@ -64,26 +64,13 @@ where
         Containments,
         Indices,
         ReshapeIndices,
-        ViewContainments,
-        ViewIndices,
-        ViewsReshapeIndices,
-        CanonicalContainments,
+        SubSetIndices,
     >(
         &mut self,
         #[allow(unused_variables)] query: Query<SubViews, Filter>,
     ) -> Option<SubViews>
     where
-        SubViews: SubSet<
-                Registry,
-                Views,
-                Containments,
-                Indices,
-                ReshapeIndices,
-                ViewContainments,
-                ViewIndices,
-                ViewsReshapeIndices,
-                CanonicalContainments,
-            > + view::Views<'a>,
+        SubViews: SubSet<Views, SubSetIndices> + view::Views<'a>,
         Registry: ContainsQuery<
             'a,
             Filter,

--- a/src/query/entries.rs
+++ b/src/query/entries.rs
@@ -354,6 +354,19 @@ mod tests {
     }
 
     #[test]
+    fn empty_query_with_or_filter_second() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(&A, &B), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        assert_some!(
+            entry.query(Query::<Views!(), filter::Or<filter::Has<B>, filter::Has<A>>>::new())
+        );
+    }
+
+    #[test]
     fn empty_query_with_and_filter() {
         let mut world = World::<Registry>::new();
         let identifier = world.insert(entity!(A(42), B('a')));

--- a/src/query/entries.rs
+++ b/src/query/entries.rs
@@ -462,6 +462,18 @@ mod tests {
     }
 
     #[test]
+    fn query_optional_immutable_superset_mutable_not_present() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42), B('a')));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(&A, &mut C), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        let result!(c) = assert_some!(entry.query(Query::<Views!(Option<&C>)>::new()));
+        assert_eq!(c, None);
+    }
+
+    #[test]
     fn query_optional_mutable_superset_mutable() {
         let mut world = World::<Registry>::new();
         let identifier = world.insert(entity!(A(42), B('a'), C(3.14)));
@@ -471,6 +483,18 @@ mod tests {
 
         let result!(c) = assert_some!(entry.query(Query::<Views!(Option<&mut C>)>::new()));
         assert_eq!(c, Some(&mut C(3.14)));
+    }
+
+    #[test]
+    fn query_optional_mutable_superset_mutable_not_present() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42), B('a')));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(&A, &mut C), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        let result!(c) = assert_some!(entry.query(Query::<Views!(Option<&mut C>)>::new()));
+        assert_eq!(c, None);
     }
 
     #[test]
@@ -549,5 +573,41 @@ mod tests {
 
         let result!(a) = assert_some!(entry.query(Query::<Views!(&mut A)>::new()));
         assert_eq!(a, &mut A(42));
+    }
+
+    #[test]
+    fn query_optional_with_optional_super_view() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(Option<&A>), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        let result!(a) = assert_some!(entry.query(Query::<Views!(Option<&A>)>::new()));
+        assert_eq!(a, Some(&A(42)));
+    }
+
+    #[test]
+    fn query_optional_with_optional_mutable_super_view() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(Option<&mut A>), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        let result!(a) = assert_some!(entry.query(Query::<Views!(Option<&A>)>::new()));
+        assert_eq!(a, Some(&A(42)));
+    }
+
+    #[test]
+    fn query_optional_mutable_with_optional_mutable_super_view() {
+        let mut world = World::<Registry>::new();
+        let identifier = world.insert(entity!(A(42)));
+
+        let mut entries = unsafe { Entries::<_, _, Views!(Option<&mut A>), _>::new(&mut world) };
+        let mut entry = assert_some!(entries.entry(identifier));
+
+        let result!(a) = assert_some!(entry.query(Query::<Views!(Option<&mut A>)>::new()));
+        assert_eq!(a, Some(&mut A(42)));
     }
 }

--- a/src/query/result/mod.rs
+++ b/src/query/result/mod.rs
@@ -113,7 +113,7 @@ use crate::{
 /// assert_eq!(world.get::<Count, _>(), &Count(100));
 /// ```
 #[non_exhaustive]
-pub struct Result<'a, Registry, Resources, Iterator, ResourceViews, EntryViews>
+pub struct Result<'a, Registry, Resources, Iterator, ResourceViews, EntryViews, EntryIndices>
 where
     Registry: registry::Registry,
 {
@@ -126,7 +126,7 @@ where
     /// This allows entity [`Entry`] lookup while iterating over the entities viewed by this query.
     ///
     /// [`Entry`]: crate::query::entries::Entry
-    pub entries: Entries<'a, Registry, Resources, EntryViews>,
+    pub entries: Entries<'a, Registry, Resources, EntryViews, EntryIndices>,
 }
 
 doc::non_root_macro! {

--- a/src/query/view/contains/filter.rs
+++ b/src/query/view/contains/filter.rs
@@ -1,0 +1,446 @@
+//! Denotes that a filter can be applied upon a set of views.
+
+use crate::{
+    archetype,
+    component,
+    entity,
+    query::{
+        filter::{
+            And,
+            Has,
+            None,
+            Not,
+            Or,
+        },
+        view,
+    },
+    registry,
+};
+
+mod index {
+    pub enum Index {}
+}
+
+/// Denotes that a filter can be applied upon views.
+///
+/// This means that any components viewed can also be filtered on, treating the views as a
+/// sub-registry.
+pub trait ContainsFilter<'a, Filter, Index>: Sealed<'a, Filter, Index> {}
+
+impl<'a, Views, Filter, Index> ContainsFilter<'a, Filter, Index> for Views where
+    Views: Sealed<'a, Filter, Index>
+{
+}
+
+pub trait Sealed<'a, Filter, Index>: view::Views<'a> + Sized {
+    /// # Safety
+    /// `indices` must contain valid indices into `Registry` (and therefore valid indices into
+    /// `identifier`).
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry;
+}
+
+impl<'a, Component, Views> Sealed<'a, Has<Component>, index::Index> for (&'a Component, Views)
+where
+    Component: component::Component,
+    Views: view::Views<'a>,
+    Self: view::Views<'a, Indices = (usize, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        let index = indices.0;
+        // SAFETY: `index` is guaranteed to be a valid index into the `Registry`.
+        unsafe { identifier.get_unchecked(index) }
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, Has<Component>, index::Index> for (&'a mut Component, Views)
+where
+    Component: component::Component,
+    Views: view::Views<'a>,
+    Self: view::Views<'a, Indices = (usize, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        let index = indices.0;
+        // SAFETY: `index` is guaranteed to be a valid index into the `Registry`.
+        unsafe { identifier.get_unchecked(index) }
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, Has<Component>, index::Index>
+    for (Option<&'a Component>, Views)
+where
+    Component: component::Component,
+    Views: view::Views<'a>,
+    Self: view::Views<'a, Indices = (usize, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        let index = indices.0;
+        // SAFETY: `index` is guaranteed to be a valid index into the `Registry`.
+        unsafe { identifier.get_unchecked(index) }
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, Has<Component>, index::Index>
+    for (Option<&'a mut Component>, Views)
+where
+    Component: component::Component,
+    Views: view::Views<'a>,
+    Self: view::Views<'a, Indices = (usize, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        let index = indices.0;
+        // SAFETY: `index` is guaranteed to be a valid index into the `Registry`.
+        unsafe { identifier.get_unchecked(index) }
+    }
+}
+
+impl<'a, Component, View, Views, Index> Sealed<'a, Has<Component>, (Index,)> for (View, Views)
+where
+    Component: component::Component,
+    View: view::View<'a>,
+    Views: Sealed<'a, Has<Component>, Index>,
+    Self: view::Views<'a, Indices = (View::Index, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        // SAFETY: `indices.1` is guaranteed to contain valid indices into `Registry`.
+        unsafe { Views::filter(&indices.1, identifier) }
+    }
+}
+
+impl<'a, FilterA, FilterB, Views, IndexA, IndexB>
+    Sealed<'a, And<FilterA, FilterB>, And<IndexA, IndexB>> for Views
+where
+    Views: Sealed<'a, FilterA, IndexA> + Sealed<'a, FilterB, IndexB>,
+    Self: view::Views<'a>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        // SAFETY: `indices` is guaranteed to contain valid indices into `Registry`.
+        unsafe {
+            <Views as Sealed<'a, FilterA, IndexA>>::filter(indices, identifier)
+                && <Views as Sealed<'a, FilterB, IndexB>>::filter(indices, identifier)
+        }
+    }
+}
+
+impl<'a, FilterA, FilterB, Views, IndexA, IndexB>
+    Sealed<'a, Or<FilterA, FilterB>, Or<IndexA, IndexB>> for Views
+where
+    Views: Sealed<'a, FilterA, IndexA> + Sealed<'a, FilterB, IndexB>,
+    Self: view::Views<'a>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        // SAFETY: `indices` is guaranteed to contain valid indices into `Registry`.
+        unsafe {
+            <Views as Sealed<'a, FilterA, IndexA>>::filter(indices, identifier)
+                || <Views as Sealed<'a, FilterB, IndexB>>::filter(indices, identifier)
+        }
+    }
+}
+
+impl<'a, Filter, Views, Index> Sealed<'a, Not<Filter>, Index> for Views
+where
+    Views: Sealed<'a, Filter, Index>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        // SAFETY: `indices` is guaranteed to contain valid indices into `Registry`.
+        unsafe { Views::filter(indices, identifier) }
+    }
+}
+
+impl<'a, Views> Sealed<'a, None, index::Index> for Views
+where
+    Self: view::Views<'a>,
+{
+    unsafe fn filter<Registry>(
+        _indices: &Self::Indices,
+        _identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        true
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, &'a Component, index::Index> for (&'a Component, Views)
+where
+    Views: view::Views<'a>,
+    Self: view::Views<'a, Indices = (usize, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        let index = indices.0;
+        // SAFETY: `index` is guaranteed to be a valid index into the `Registry`.
+        unsafe { identifier.get_unchecked(index) }
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, Option<&'a Component>, index::Index> for Views
+where
+    Self: view::Views<'a>,
+{
+    unsafe fn filter<Registry>(
+        _indices: &Self::Indices,
+        _identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        true
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, &'a Component, index::Index> for (&'a mut Component, Views)
+where
+    Views: view::Views<'a>,
+    Self: view::Views<'a, Indices = (usize, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        let index = indices.0;
+        // SAFETY: `index` is guaranteed to be a valid index into the `Registry`.
+        unsafe { identifier.get_unchecked(index) }
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, &'a mut Component, index::Index>
+    for (&'a mut Component, Views)
+where
+    Views: view::Views<'a>,
+    Self: view::Views<'a, Indices = (usize, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        let index = indices.0;
+        // SAFETY: `index` is guaranteed to be a valid index into the `Registry`.
+        unsafe { identifier.get_unchecked(index) }
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, Option<&'a mut Component>, index::Index> for Views
+where
+    Self: view::Views<'a>,
+{
+    unsafe fn filter<Registry>(
+        _indices: &Self::Indices,
+        _identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        true
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, &'a Component, index::Index>
+    for (Option<&'a Component>, Views)
+where
+    Views: view::Views<'a>,
+    Self: view::Views<'a, Indices = (usize, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        let index = indices.0;
+        // SAFETY: `index` is guaranteed to be a valid index into the `Registry`.
+        unsafe { identifier.get_unchecked(index) }
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, &'a Component, index::Index>
+    for (Option<&'a mut Component>, Views)
+where
+    Views: view::Views<'a>,
+    Self: view::Views<'a, Indices = (usize, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        let index = indices.0;
+        // SAFETY: `index` is guaranteed to be a valid index into the `Registry`.
+        unsafe { identifier.get_unchecked(index) }
+    }
+}
+
+impl<'a, Component, Views> Sealed<'a, &'a mut Component, index::Index>
+    for (Option<&'a mut Component>, Views)
+where
+    Views: view::Views<'a>,
+    Self: view::Views<'a, Indices = (usize, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        let index = indices.0;
+        // SAFETY: `index` is guaranteed to be a valid index into the `Registry`.
+        unsafe { identifier.get_unchecked(index) }
+    }
+}
+
+impl<'a, Component, View, Views, Index> Sealed<'a, &'a Component, (Index,)> for (View, Views)
+where
+    Component: component::Component,
+    View: view::View<'a>,
+    Views: Sealed<'a, &'a Component, Index>,
+    Self: view::Views<'a, Indices = (View::Index, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        // SAFETY: `indices.1` is guaranteed to contain valid indices into `Registry`.
+        unsafe { Views::filter(&indices.1, identifier) }
+    }
+}
+
+impl<'a, Component, View, Views, Index> Sealed<'a, &'a mut Component, (Index,)> for (View, Views)
+where
+    Component: component::Component,
+    View: view::View<'a>,
+    Views: Sealed<'a, &'a mut Component, Index>,
+    Self: view::Views<'a, Indices = (View::Index, Views::Indices)>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        // SAFETY: `indices.1` is guaranteed to contain valid indices into `Registry`.
+        unsafe { Views::filter(&indices.1, identifier) }
+    }
+}
+
+impl<'a, Views> Sealed<'a, entity::Identifier, index::Index> for Views
+where
+    Self: view::Views<'a>,
+{
+    unsafe fn filter<Registry>(
+        _indices: &Self::Indices,
+        _identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        true
+    }
+}
+
+impl<'a, Views> Sealed<'a, view::Null, index::Index> for Views
+where
+    Self: view::Views<'a>,
+{
+    unsafe fn filter<Registry>(
+        _indices: &Self::Indices,
+        _identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        true
+    }
+}
+
+impl<'a, Views, Filter, Filters, Index, Indices> Sealed<'a, (Filter, Filters), (Index, Indices)>
+    for Views
+where
+    Self: view::Views<'a>,
+    Views: Sealed<'a, Filter, Index> + Sealed<'a, Filters, Indices>,
+{
+    unsafe fn filter<Registry>(
+        indices: &Self::Indices,
+        identifier: archetype::IdentifierRef<Registry>,
+    ) -> bool
+    where
+        Registry: registry::Registry,
+    {
+        // SAFETY: `indices` is guaranteed to contain valid indices into `Registry`.
+        unsafe {
+            <Views as Sealed<'a, Filter, Index>>::filter(indices, identifier)
+                && <Views as Sealed<'a, Filters, Indices>>::filter(indices, identifier)
+        }
+    }
+}

--- a/src/query/view/contains/filter.rs
+++ b/src/query/view/contains/filter.rs
@@ -195,7 +195,7 @@ where
         Registry: registry::Registry,
     {
         // SAFETY: `indices` is guaranteed to contain valid indices into `Registry`.
-        unsafe { Views::filter(indices, identifier) }
+        !unsafe { Views::filter(indices, identifier) }
     }
 }
 

--- a/src/query/view/contains/mod.rs
+++ b/src/query/view/contains/mod.rs
@@ -1,0 +1,3 @@
+mod filter;
+
+pub use filter::ContainsFilter;

--- a/src/query/view/get.rs
+++ b/src/query/view/get.rs
@@ -1,61 +1,91 @@
 use crate::{
+    component,
     entity,
     query::{
         result::get::Index,
+        view,
         view::{
+            sealed::ViewsSealed,
             View,
             Views,
         },
     },
 };
 
-pub trait Get<'a, T, I> {
+pub trait Get<'a, T, I>: Views<'a>
+where
+    T: View<'a>,
+{
     type Remainder: Views<'a>;
 
     fn get(self) -> (T, Self::Remainder);
+
+    fn get_index(
+        indices: Self::Indices,
+    ) -> (T::Index, <Self::Remainder as ViewsSealed<'a>>::Indices);
 }
 
 impl<'a, T, V> Get<'a, &'a T, Index> for (&'a T, V)
 where
     V: Views<'a>,
+    T: component::Component,
 {
     type Remainder = V;
 
     fn get(self) -> (&'a T, Self::Remainder) {
         self
     }
+
+    fn get_index(indices: Self::Indices) -> (usize, <Self::Remainder as ViewsSealed<'a>>::Indices) {
+        indices
+    }
 }
 
 impl<'a, T, V> Get<'a, &'a mut T, Index> for (&'a mut T, V)
 where
     V: Views<'a>,
+    T: component::Component,
 {
     type Remainder = V;
 
     fn get(self) -> (&'a mut T, Self::Remainder) {
         self
     }
+
+    fn get_index(indices: Self::Indices) -> (usize, <Self::Remainder as ViewsSealed<'a>>::Indices) {
+        indices
+    }
 }
 
 impl<'a, T, V> Get<'a, Option<&'a T>, Index> for (Option<&'a T>, V)
 where
     V: Views<'a>,
+    T: component::Component,
 {
     type Remainder = V;
 
     fn get(self) -> (Option<&'a T>, Self::Remainder) {
         self
     }
+
+    fn get_index(indices: Self::Indices) -> (usize, <Self::Remainder as ViewsSealed<'a>>::Indices) {
+        indices
+    }
 }
 
 impl<'a, T, V> Get<'a, Option<&'a mut T>, Index> for (Option<&'a mut T>, V)
 where
     V: Views<'a>,
+    T: component::Component,
 {
     type Remainder = V;
 
     fn get(self) -> (Option<&'a mut T>, Self::Remainder) {
         self
+    }
+
+    fn get_index(indices: Self::Indices) -> (usize, <Self::Remainder as ViewsSealed<'a>>::Indices) {
+        indices
     }
 }
 
@@ -68,17 +98,31 @@ where
     fn get(self) -> (entity::Identifier, Self::Remainder) {
         self
     }
+
+    fn get_index(
+        indices: Self::Indices,
+    ) -> (view::Null, <Self::Remainder as ViewsSealed<'a>>::Indices) {
+        indices
+    }
 }
 
 impl<'a, I, T, V, W> Get<'a, T, (I,)> for (V, W)
 where
     V: View<'a>,
     W: Get<'a, T, I>,
+    T: View<'a>,
 {
     type Remainder = (V, <W as Get<'a, T, I>>::Remainder);
 
     fn get(self) -> (T, Self::Remainder) {
         let (target, remainder) = self.1.get();
         (target, (self.0, remainder))
+    }
+
+    fn get_index(
+        indices: Self::Indices,
+    ) -> (T::Index, <Self::Remainder as ViewsSealed<'a>>::Indices) {
+        let (target, remainder) = W::get_index(indices.1);
+        (target, (indices.0, remainder))
     }
 }

--- a/src/query/view/get.rs
+++ b/src/query/view/get.rs
@@ -11,14 +11,22 @@ use crate::{
         },
     },
 };
+use core::mem::MaybeUninit;
 
-pub trait Get<'a, T, I>: Views<'a>
+pub trait Get<'a, T, I>: Views<'a> + Sized
 where
     T: View<'a>,
 {
     type Remainder: Views<'a>;
 
     fn get(self) -> (T, Self::Remainder);
+
+    fn get_maybe_uninit(
+        views: Self::MaybeUninit,
+    ) -> (
+        T::MaybeUninit,
+        <Self::Remainder as ViewsSealed<'a>>::MaybeUninit,
+    );
 
     fn get_index(
         indices: Self::Indices,
@@ -34,6 +42,15 @@ where
 
     fn get(self) -> (&'a T, Self::Remainder) {
         self
+    }
+
+    fn get_maybe_uninit(
+        views: Self::MaybeUninit,
+    ) -> (
+        MaybeUninit<&'a T>,
+        <Self::Remainder as ViewsSealed<'a>>::MaybeUninit,
+    ) {
+        views
     }
 
     fn get_index(indices: Self::Indices) -> (usize, <Self::Remainder as ViewsSealed<'a>>::Indices) {
@@ -52,6 +69,15 @@ where
         self
     }
 
+    fn get_maybe_uninit(
+        views: Self::MaybeUninit,
+    ) -> (
+        MaybeUninit<&'a mut T>,
+        <Self::Remainder as ViewsSealed<'a>>::MaybeUninit,
+    ) {
+        views
+    }
+
     fn get_index(indices: Self::Indices) -> (usize, <Self::Remainder as ViewsSealed<'a>>::Indices) {
         indices
     }
@@ -66,6 +92,15 @@ where
 
     fn get(self) -> (Option<&'a T>, Self::Remainder) {
         self
+    }
+
+    fn get_maybe_uninit(
+        views: Self::MaybeUninit,
+    ) -> (
+        Option<&'a T>,
+        <Self::Remainder as ViewsSealed<'a>>::MaybeUninit,
+    ) {
+        views
     }
 
     fn get_index(indices: Self::Indices) -> (usize, <Self::Remainder as ViewsSealed<'a>>::Indices) {
@@ -84,6 +119,15 @@ where
         self
     }
 
+    fn get_maybe_uninit(
+        views: Self::MaybeUninit,
+    ) -> (
+        Option<&'a mut T>,
+        <Self::Remainder as ViewsSealed<'a>>::MaybeUninit,
+    ) {
+        views
+    }
+
     fn get_index(indices: Self::Indices) -> (usize, <Self::Remainder as ViewsSealed<'a>>::Indices) {
         indices
     }
@@ -97,6 +141,15 @@ where
 
     fn get(self) -> (entity::Identifier, Self::Remainder) {
         self
+    }
+
+    fn get_maybe_uninit(
+        views: Self::MaybeUninit,
+    ) -> (
+        entity::Identifier,
+        <Self::Remainder as ViewsSealed<'a>>::MaybeUninit,
+    ) {
+        views
     }
 
     fn get_index(
@@ -117,6 +170,16 @@ where
     fn get(self) -> (T, Self::Remainder) {
         let (target, remainder) = self.1.get();
         (target, (self.0, remainder))
+    }
+
+    fn get_maybe_uninit(
+        views: Self::MaybeUninit,
+    ) -> (
+        T::MaybeUninit,
+        <(V, <W as Get<'a, T, I>>::Remainder) as ViewsSealed<'a>>::MaybeUninit,
+    ) {
+        let (target, remainder) = W::get_maybe_uninit(views.1);
+        (target, (views.0, remainder))
     }
 
     fn get_index(

--- a/src/query/view/mod.rs
+++ b/src/query/view/mod.rs
@@ -51,6 +51,7 @@
 pub(crate) mod claim;
 pub(crate) mod resource;
 
+mod contains;
 mod disjoint;
 mod get;
 #[cfg(feature = "rayon")]
@@ -61,6 +62,7 @@ mod reshape;
 mod sealed;
 mod subset;
 
+pub use contains::ContainsFilter;
 pub use disjoint::Disjoint;
 #[cfg(feature = "rayon")]
 pub use par::{

--- a/src/query/view/reshape.rs
+++ b/src/query/view/reshape.rs
@@ -4,23 +4,50 @@ use crate::query::{
     view::Get,
 };
 
-pub trait Reshape<'a, R, I> {
+pub trait Reshape<'a, R, I>: view::Views<'a>
+where
+    R: view::Views<'a>,
+{
     fn reshape(self) -> R;
+
+    fn reshape_indices(indices: Self::Indices) -> R::Indices;
 }
 
 impl Reshape<'_, view::Null, Null> for view::Null {
     fn reshape(self) -> view::Null {
         self
     }
+
+    fn reshape_indices(indices: view::Null) -> view::Null {
+        indices
+    }
 }
 
 impl<'a, I, IS, R, S, T> Reshape<'a, (R, S), (I, IS)> for T
 where
-    T: Get<'a, R, I>,
+    T: Get<'a, R, I> + view::Views<'a>,
     T::Remainder: Reshape<'a, S, IS>,
+    R: view::View<'a>,
+    (R, S): view::Views<'a>
+        + view::ViewsSealed<
+            'a,
+            Indices = (
+                <R as view::ViewSealed<'a>>::Index,
+                <S as view::ViewsSealed<'a>>::Indices,
+            ),
+        >,
+    S: view::Views<'a>,
 {
     fn reshape(self) -> (R, S) {
         let (target, remainder) = self.get();
         (target, remainder.reshape())
+    }
+
+    fn reshape_indices(indices: Self::Indices) -> <(R, S) as view::ViewsSealed<'a>>::Indices {
+        let (target, remainder) = T::get_index(indices);
+        (
+            target,
+            <T as Get<R, I>>::Remainder::reshape_indices(remainder),
+        )
     }
 }

--- a/src/query/view/reshape.rs
+++ b/src/query/view/reshape.rs
@@ -4,11 +4,13 @@ use crate::query::{
     view::Get,
 };
 
-pub trait Reshape<'a, R, I>: view::Views<'a>
+pub trait Reshape<'a, R, I>: view::Views<'a> + Sized
 where
     R: view::Views<'a>,
 {
     fn reshape(self) -> R;
+
+    fn reshape_maybe_uninit(views: Self::MaybeUninit) -> R::MaybeUninit;
 
     fn reshape_indices(indices: Self::Indices) -> R::Indices;
 }
@@ -16,6 +18,10 @@ where
 impl Reshape<'_, view::Null, Null> for view::Null {
     fn reshape(self) -> view::Null {
         self
+    }
+
+    fn reshape_maybe_uninit(views: view::Null) -> view::Null {
+        views
     }
 
     fn reshape_indices(indices: view::Null) -> view::Null {
@@ -35,12 +41,23 @@ where
                 <R as view::ViewSealed<'a>>::Index,
                 <S as view::ViewsSealed<'a>>::Indices,
             ),
+            MaybeUninit = (
+                <R as view::ViewSealed<'a>>::MaybeUninit,
+                <S as view::ViewsSealed<'a>>::MaybeUninit,
+            ),
         >,
     S: view::Views<'a>,
 {
     fn reshape(self) -> (R, S) {
         let (target, remainder) = self.get();
         (target, remainder.reshape())
+    }
+
+    fn reshape_maybe_uninit(
+        views: Self::MaybeUninit,
+    ) -> <(R, S) as view::ViewsSealed<'a>>::MaybeUninit {
+        let (target, remainder) = T::get_maybe_uninit(views);
+        (target, T::Remainder::reshape_maybe_uninit(remainder))
     }
 
     fn reshape_indices(indices: Self::Indices) -> <(R, S) as view::ViewsSealed<'a>>::Indices {

--- a/src/query/view/sealed.rs
+++ b/src/query/view/sealed.rs
@@ -14,6 +14,7 @@ use either::Either;
 
 pub trait ViewSealed<'a> {
     type Result: Iterator<Item = Self>;
+    type Index;
 }
 
 impl<'a, C> ViewSealed<'a> for &'a C
@@ -21,6 +22,7 @@ where
     C: Component,
 {
     type Result = slice::Iter<'a, C>;
+    type Index = usize;
 }
 
 impl<'a, C> ViewSealed<'a> for &'a mut C
@@ -28,6 +30,7 @@ where
     C: Component,
 {
     type Result = slice::IterMut<'a, C>;
+    type Index = usize;
 }
 
 impl<'a, C> ViewSealed<'a> for Option<&'a C>
@@ -38,6 +41,7 @@ where
         iter::Take<iter::Repeat<Option<&'a C>>>,
         iter::Map<slice::Iter<'a, C>, fn(&'a C) -> Option<&'a C>>,
     >;
+    type Index = usize;
 }
 
 impl<'a, C> ViewSealed<'a> for Option<&'a mut C>
@@ -48,18 +52,22 @@ where
         iter::Take<iter::RepeatWith<fn() -> Option<&'a mut C>>>,
         iter::Map<slice::IterMut<'a, C>, fn(&'a mut C) -> Option<&'a mut C>>,
     >;
+    type Index = usize;
 }
 
 impl<'a> ViewSealed<'a> for entity::Identifier {
     type Result = iter::Copied<slice::Iter<'a, Self>>;
+    type Index = Null;
 }
 
 pub trait ViewsSealed<'a> {
     type Results: Results<View = Self>;
+    type Indices;
 }
 
 impl<'a> ViewsSealed<'a> for Null {
     type Results = iter::Take<iter::Repeat<Null>>;
+    type Indices = Null;
 }
 
 impl<'a, V, W> ViewsSealed<'a> for (V, W)
@@ -68,4 +76,5 @@ where
     W: ViewsSealed<'a>,
 {
     type Results = (V::Result, W::Results);
+    type Indices = (V::Index, W::Indices);
 }

--- a/src/query/view/subset.rs
+++ b/src/query/view/subset.rs
@@ -106,11 +106,16 @@ where
         Registry: registry::Registry,
     {
         let (target, (remainder, remainder_indices)) =
+            // SAFETY: The safety contract of this method applies to the safety contract of this
+            // call.
             unsafe { Views::view(views, indices, identifier) };
 
-        (target, unsafe {
-            SubViews::view(remainder, remainder_indices, identifier)
-        })
+        (
+            target,
+            // SAFETY: The safety contract of this method applies to the safety contract of this
+            // call.
+            unsafe { SubViews::view(remainder, remainder_indices, identifier) },
+        )
     }
 }
 
@@ -616,9 +621,9 @@ where
     where
         Registry: registry::Registry,
     {
-        // SAFETY: The invariants are guaranteed to be upheld by the safety contract of this
-        // function.
         let (target, (remainder, remainder_indices)) =
+            // SAFETY: The invariants are guaranteed to be upheld by the safety contract of this
+            // function.
             unsafe { Views::view(views.1, indices.1, identifier) };
         (
             target,

--- a/src/query/view/subset.rs
+++ b/src/query/view/subset.rs
@@ -7,7 +7,7 @@
 //! The basic algorithm here is to:
 //! - "Get" each view within the subview inside the superview.
 //! - The Get trait only is implemented for the subset relationship for each component.
-//! - End case is having null::Views in subset.
+//! - End case is having `null::Views` in subset.
 
 use crate::{
     entity,

--- a/src/registry/contains/mod.rs
+++ b/src/registry/contains/mod.rs
@@ -27,10 +27,10 @@ pub use entity::ContainsEntity;
 #[cfg(feature = "rayon")]
 pub use par_query::ContainsParQuery;
 pub use query::ContainsQuery;
+pub use views::ContainsViews;
 
 #[cfg(feature = "rayon")]
 pub(crate) use par_views::ContainsParViews;
-pub(crate) use views::ContainsViews;
 
 use filter::ContainsFilter;
 

--- a/src/registry/contains/views/sealed.rs
+++ b/src/registry/contains/views/sealed.rs
@@ -365,6 +365,7 @@ where
     where
         R_: Registry,
     {
+        // SAFETY: The safety contract of this function applies to this function call.
         unsafe { R::view_one_maybe_uninit(index, columns, length, archetype_identifier) }
     }
 

--- a/src/registry/sealed/view.rs
+++ b/src/registry/sealed/view.rs
@@ -64,6 +64,11 @@ where
     #[cfg(feature = "rayon")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     fn claims() -> Self::Claims;
+
+    /// Return the indices for each view into the registry.
+    fn indices<R>() -> V::Indices
+    where
+        R: registry::Length;
 }
 
 impl<'a> CanonicalViews<'a, view::Null, Null> for registry::Null {
@@ -94,6 +99,13 @@ impl<'a> CanonicalViews<'a, view::Null, Null> for registry::Null {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     fn claims() -> Self::Claims {
         claim::Null
+    }
+
+    fn indices<R>() -> view::Null
+    where
+        R: registry::Length,
+    {
+        view::Null
     }
 }
 
@@ -164,6 +176,13 @@ where
     fn claims() -> Self::Claims {
         (Claim::Immutable, R::claims())
     }
+
+    fn indices<R_>() -> (usize, V::Indices)
+    where
+        R_: registry::Length,
+    {
+        (R_::LEN - R::LEN - 1, R::indices::<R_>())
+    }
 }
 
 impl<'a, C, P, R, V> CanonicalViews<'a, (&'a mut C, V), (&'a mut Contained, P)> for (C, R)
@@ -232,6 +251,13 @@ where
     #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     fn claims() -> Self::Claims {
         (Claim::Mutable, R::claims())
+    }
+
+    fn indices<R_>() -> (usize, V::Indices)
+    where
+        R_: registry::Length,
+    {
+        (R_::LEN - R::LEN - 1, R::indices::<R_>())
     }
 }
 
@@ -326,6 +352,13 @@ where
     fn claims() -> Self::Claims {
         (Claim::Immutable, R::claims())
     }
+
+    fn indices<R_>() -> (usize, V::Indices)
+    where
+        R_: registry::Length,
+    {
+        (R_::LEN - R::LEN - 1, R::indices::<R_>())
+    }
 }
 
 impl<'a, C, P, R, V> CanonicalViews<'a, (Option<&'a mut C>, V), (Option<&'a mut Contained>, P)>
@@ -419,6 +452,13 @@ where
     fn claims() -> Self::Claims {
         (Claim::Mutable, R::claims())
     }
+
+    fn indices<R_>() -> (usize, V::Indices)
+    where
+        R_: registry::Length,
+    {
+        (R_::LEN - R::LEN - 1, R::indices::<R_>())
+    }
 }
 
 impl<'a, C, P, R, V> CanonicalViews<'a, V, (NotContained, P)> for (C, R)
@@ -476,5 +516,12 @@ where
     #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     fn claims() -> Self::Claims {
         (Claim::None, R::claims())
+    }
+
+    fn indices<R_>() -> V::Indices
+    where
+        R_: registry::Length,
+    {
+        R::indices::<R_>()
     }
 }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -30,7 +30,7 @@
 //!     type ResourceViews<'a> = Views!();
 //!     type EntryViews<'a> = Views!();
 //!
-//!     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+//!     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
 //!         &mut self,
 //!         query_results: Result<
 //!             R,
@@ -38,7 +38,7 @@
 //!             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
 //!             Self::ResourceViews<'a>,
 //!             Self::EntryViews<'a>,
-//!             E,
+//!             (EP, EI, EQ),
 //!         >,
 //!     ) where
 //!         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -82,7 +82,10 @@ use crate::{
         view::Views,
         Result,
     },
-    registry::ContainsQuery,
+    registry::{
+        ContainsQuery,
+        ContainsViews,
+    },
 };
 
 /// An executable type which operates over the entities within a [`World`].
@@ -122,7 +125,7 @@ use crate::{
 ///     type ResourceViews<'a> = Views!();
 ///     type EntryViews<'a> = Views!();
 ///
-///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
 ///         &mut self,
 ///         query_results: Result<
 ///             R,
@@ -130,7 +133,7 @@ use crate::{
 ///             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
 ///             Self::ResourceViews<'a>,
 ///             Self::EntryViews<'a>,
-///             E,
+///             (EP, EI, EQ),
 ///         >,
 ///     ) where
 ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -162,7 +165,7 @@ pub trait System {
     /// The views here must be [`Disjoint`] with `Self::Views`
     ///
     /// [`Disjoint`]: crate::query::view::Disjoint
-    type EntryViews<'a>;
+    type EntryViews<'a>: Views<'a>;
 
     /// Logic to be run over the query result.
     ///
@@ -197,7 +200,7 @@ pub trait System {
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -205,7 +208,7 @@ pub trait System {
     ///             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
-    ///             E,
+    ///             (EP, EI, EQ),
     ///         >,
     ///     ) where
     ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -220,16 +223,18 @@ pub trait System {
     /// ```
     ///
     /// [`World`]: crate::world::World
-    fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         &mut self,
         query_result: Result<
+            'a,
             R,
             S,
             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
             Self::ResourceViews<'a>,
             Self::EntryViews<'a>,
-            E,
+            (EP, EI, EQ),
         >,
     ) where
-        R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>;
+        R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>
+            + ContainsViews<'a, Self::EntryViews<'a>, EP, EI, EQ>;
 }

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -30,7 +30,7 @@
 //!     type ResourceViews<'a> = Views!();
 //!     type EntryViews<'a> = Views!();
 //!
-//!     fn run<'a, R, S, FI, VI, P, I, Q>(
+//!     fn run<'a, R, S, FI, VI, P, I, Q, E>(
 //!         &mut self,
 //!         query_results: Result<
 //!             R,
@@ -38,6 +38,7 @@
 //!             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
 //!             Self::ResourceViews<'a>,
 //!             Self::EntryViews<'a>,
+//!             E,
 //!         >,
 //!     ) where
 //!         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -121,7 +122,7 @@ use crate::{
 ///     type ResourceViews<'a> = Views!();
 ///     type EntryViews<'a> = Views!();
 ///
-///     fn run<'a, R, S, FI, VI, P, I, Q>(
+///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
 ///         &mut self,
 ///         query_results: Result<
 ///             R,
@@ -129,6 +130,7 @@ use crate::{
 ///             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
 ///             Self::ResourceViews<'a>,
 ///             Self::EntryViews<'a>,
+///             E,
 ///         >,
 ///     ) where
 ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -195,7 +197,7 @@ pub trait System {
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -203,6 +205,7 @@ pub trait System {
     ///             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
+    ///             E,
     ///         >,
     ///     ) where
     ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -217,7 +220,7 @@ pub trait System {
     /// ```
     ///
     /// [`World`]: crate::world::World
-    fn run<'a, R, S, FI, VI, P, I, Q>(
+    fn run<'a, R, S, FI, VI, P, I, Q, E>(
         &mut self,
         query_result: Result<
             R,
@@ -225,6 +228,7 @@ pub trait System {
             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
             Self::ResourceViews<'a>,
             Self::EntryViews<'a>,
+            E,
         >,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>;

--- a/src/system/par.rs
+++ b/src/system/par.rs
@@ -2,10 +2,16 @@ use crate::{
     query::{
         filter::Filter,
         result,
-        view::ParViews,
+        view::{
+            ParViews,
+            Views,
+        },
         Result,
     },
-    registry::ContainsParQuery,
+    registry::{
+        ContainsParQuery,
+        ContainsViews,
+    },
 };
 
 /// An executable type which operates over the entities within a [`World`] in parallel.
@@ -42,7 +48,7 @@ use crate::{
 ///     type ResourceViews<'a> = Views!();
 ///     type EntryViews<'a> = Views!();
 ///
-///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
 ///         &mut self,
 ///         query_results: Result<
 ///             R,
@@ -50,7 +56,7 @@ use crate::{
 ///             result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
 ///             Self::ResourceViews<'a>,
 ///             Self::EntryViews<'a>,
-///             E,
+///             (EP, EI, EQ),
 ///         >,
 ///     ) where
 ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -87,7 +93,7 @@ pub trait ParSystem {
     /// The views here must be [`Disjoint`] with `Self::Views`
     ///
     /// [`Disjoint`]: crate::query::view::Disjoint
-    type EntryViews<'a>;
+    type EntryViews<'a>: Views<'a>;
 
     /// Logic to be run over the parallel query result.
     ///
@@ -123,7 +129,7 @@ pub trait ParSystem {
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -131,7 +137,7 @@ pub trait ParSystem {
     ///             result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
-    ///             E,
+    ///             (EP, EI, EQ),
     ///         >,
     ///     ) where
     ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -146,16 +152,18 @@ pub trait ParSystem {
     /// ```
     ///
     /// [`World`]: crate::world::World
-    fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         &mut self,
         query_result: Result<
+            'a,
             R,
             S,
             result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
             Self::ResourceViews<'a>,
             Self::EntryViews<'a>,
-            E,
+            (EP, EI, EQ),
         >,
     ) where
-        R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>;
+        R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>
+            + ContainsViews<'a, Self::EntryViews<'a>, EP, EI, EQ>;
 }

--- a/src/system/par.rs
+++ b/src/system/par.rs
@@ -42,7 +42,7 @@ use crate::{
 ///     type ResourceViews<'a> = Views!();
 ///     type EntryViews<'a> = Views!();
 ///
-///     fn run<'a, R, S, FI, VI, P, I, Q>(
+///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
 ///         &mut self,
 ///         query_results: Result<
 ///             R,
@@ -50,6 +50,7 @@ use crate::{
 ///             result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
 ///             Self::ResourceViews<'a>,
 ///             Self::EntryViews<'a>,
+///             E,
 ///         >,
 ///     ) where
 ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -122,7 +123,7 @@ pub trait ParSystem {
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -130,6 +131,7 @@ pub trait ParSystem {
     ///             result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
+    ///             E,
     ///         >,
     ///     ) where
     ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -144,7 +146,7 @@ pub trait ParSystem {
     /// ```
     ///
     /// [`World`]: crate::world::World
-    fn run<'a, R, S, FI, VI, P, I, Q>(
+    fn run<'a, R, S, FI, VI, P, I, Q, E>(
         &mut self,
         query_result: Result<
             R,
@@ -152,6 +154,7 @@ pub trait ParSystem {
             result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
             Self::ResourceViews<'a>,
             Self::EntryViews<'a>,
+            E,
         >,
     ) where
         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>;

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -38,7 +38,7 @@
 //!     type ResourceViews<'a> = Views!();
 //!     type EntryViews<'a> = Views!();
 //!
-//!     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+//!     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
 //!         &mut self,
 //!         query_results: Result<
 //!             R,
@@ -46,7 +46,7 @@
 //!             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
 //!             Self::ResourceViews<'a>,
 //!             Self::EntryViews<'a>,
-//!             E,
+//!             (EP, EI, EQ),
 //!         >,
 //!     ) where
 //!         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -65,7 +65,7 @@
 //!     type ResourceViews<'a> = Views!();
 //!     type EntryViews<'a> = Views!();
 //!
-//!     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+//!     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
 //!         &mut self,
 //!         query_results: Result<
 //!             R,
@@ -73,7 +73,7 @@
 //!             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
 //!             Self::ResourceViews<'a>,
 //!             Self::EntryViews<'a>,
-//!             E,
+//!             (EP, EI, EQ),
 //!         >,
 //!     ) where
 //!         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -337,9 +337,9 @@ doc::non_root_macro! {
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
     ///         &mut self,
-    ///         query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
+    ///         query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
     ///     ) where
     ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///     {
@@ -355,9 +355,9 @@ doc::non_root_macro! {
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
     ///         &mut self,
-    ///         query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
+    ///         query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
     ///     ) where
     ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///     {
@@ -424,9 +424,9 @@ pub(crate) mod inner {
         ///     type ResourceViews<'a> = Views!();
         ///     type EntryViews<'a> = Views!();
         ///
-        ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+        ///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         ///         &mut self,
-        ///         query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
+        ///         query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
         ///     ) where
         ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
         ///     {
@@ -442,9 +442,9 @@ pub(crate) mod inner {
         ///     type ResourceViews<'a> = Views!();
         ///     type EntryViews<'a> = Views!();
         ///
-        ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+        ///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         ///         &mut self,
-        ///         query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
+        ///         query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
         ///     ) where
         ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
         ///     {
@@ -637,7 +637,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -645,7 +645,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -703,7 +703,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -711,7 +711,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -769,7 +769,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -777,7 +777,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -835,7 +835,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -843,7 +843,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -901,7 +901,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -909,7 +909,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -970,7 +970,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -978,7 +978,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1036,7 +1036,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1044,7 +1044,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1102,7 +1102,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1110,7 +1110,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1171,7 +1171,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1179,7 +1179,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1240,7 +1240,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1248,7 +1248,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1309,7 +1309,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1317,7 +1317,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1334,7 +1334,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1342,7 +1342,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1359,7 +1359,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1367,7 +1367,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1431,7 +1431,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a A);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1439,7 +1439,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1456,7 +1456,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a A, &'a B);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1464,7 +1464,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1528,7 +1528,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a mut A);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1536,7 +1536,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1553,7 +1553,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a mut A, &'a B);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1561,7 +1561,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1578,7 +1578,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a mut B, &'a C);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1586,7 +1586,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1653,7 +1653,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A);
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1661,7 +1661,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1678,7 +1678,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A, &'a B);
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1686,7 +1686,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1750,7 +1750,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A);
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1758,7 +1758,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1775,7 +1775,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a mut A, &'a B);
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1783,7 +1783,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1844,7 +1844,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A);
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1852,7 +1852,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1869,7 +1869,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A, &'a C);
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1877,7 +1877,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1941,7 +1941,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A);
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1949,7 +1949,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1966,7 +1966,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A, &'a B);
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1974,7 +1974,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,

--- a/src/system/schedule/mod.rs
+++ b/src/system/schedule/mod.rs
@@ -38,7 +38,7 @@
 //!     type ResourceViews<'a> = Views!();
 //!     type EntryViews<'a> = Views!();
 //!
-//!     fn run<'a, R, S, FI, VI, P, I, Q>(
+//!     fn run<'a, R, S, FI, VI, P, I, Q, E>(
 //!         &mut self,
 //!         query_results: Result<
 //!             R,
@@ -46,6 +46,7 @@
 //!             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
 //!             Self::ResourceViews<'a>,
 //!             Self::EntryViews<'a>,
+//!             E,
 //!         >,
 //!     ) where
 //!         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -64,7 +65,7 @@
 //!     type ResourceViews<'a> = Views!();
 //!     type EntryViews<'a> = Views!();
 //!
-//!     fn run<'a, R, S, FI, VI, P, I, Q>(
+//!     fn run<'a, R, S, FI, VI, P, I, Q, E>(
 //!         &mut self,
 //!         query_results: Result<
 //!             R,
@@ -72,6 +73,7 @@
 //!             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
 //!             Self::ResourceViews<'a>,
 //!             Self::EntryViews<'a>,
+//!             E,
 //!         >,
 //!     ) where
 //!         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -152,6 +154,9 @@ pub trait Schedule<
     EntryViewsOppositeIndicesLists,
     EntryViewsOppositeReshapeIndicesLists,
     EntryViewsOppositeInverseIndicesLists,
+    EntryContainmentsLists,
+    EntryIndicesLists,
+    EntryReshapeIndicesLists,
 >:
     Sealed<
     'a,
@@ -181,6 +186,9 @@ pub trait Schedule<
     EntryViewsOppositeIndicesLists,
     EntryViewsOppositeReshapeIndicesLists,
     EntryViewsOppositeInverseIndicesLists,
+    EntryContainmentsLists,
+    EntryIndicesLists,
+    EntryReshapeIndicesLists,
 > where
     R: Registry,
 {
@@ -215,6 +223,9 @@ impl<
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     >
     Schedule<
         'a,
@@ -244,6 +255,9 @@ impl<
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     > for T
 where
     R: Registry,
@@ -275,6 +289,9 @@ where
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     >,
 {
 }
@@ -320,9 +337,9 @@ doc::non_root_macro! {
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
     ///         &mut self,
-    ///         query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+    ///         query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
     ///     ) where
     ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///     {
@@ -338,9 +355,9 @@ doc::non_root_macro! {
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
     ///         &mut self,
-    ///         query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+    ///         query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
     ///     ) where
     ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///     {
@@ -407,9 +424,9 @@ pub(crate) mod inner {
         ///     type ResourceViews<'a> = Views!();
         ///     type EntryViews<'a> = Views!();
         ///
-        ///     fn run<'a, R, S, FI, VI, P, I, Q>(
+        ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
         ///         &mut self,
-        ///         query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+        ///         query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
         ///     ) where
         ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
         ///     {
@@ -425,9 +442,9 @@ pub(crate) mod inner {
         ///     type ResourceViews<'a> = Views!();
         ///     type EntryViews<'a> = Views!();
         ///
-        ///     fn run<'a, R, S, FI, VI, P, I, Q>(
+        ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
         ///         &mut self,
-        ///         query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+        ///         query_results: Result<R, S, result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
         ///     ) where
         ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
         ///     {
@@ -519,6 +536,9 @@ mod tests {
                     _,
                     _,
                     _,
+                    _,
+                    _,
+                    _,
                 >>::Stages,
             >(),
             TypeId::of::<stages::Null>()
@@ -533,6 +553,9 @@ mod tests {
                     '_,
                     Registry!(),
                     Resources!(A, B, C, D, E),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -595,6 +618,9 @@ mod tests {
                     _,
                     _,
                     _,
+                    _,
+                    _,
+                    _,
                 >>::Stages,
             >(),
             TypeId::of::<stages::Null>()
@@ -611,7 +637,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -619,6 +645,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -633,6 +660,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -673,7 +703,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -681,6 +711,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -695,6 +726,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -735,7 +769,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -743,6 +777,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -757,6 +792,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -797,7 +835,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -805,6 +843,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -819,6 +858,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -859,7 +901,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -867,6 +909,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -881,6 +924,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -924,7 +970,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -932,6 +978,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -946,6 +993,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -986,7 +1036,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -994,6 +1044,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1008,6 +1059,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -1048,7 +1102,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1056,6 +1110,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1070,6 +1125,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -1113,7 +1171,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1121,6 +1179,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1135,6 +1194,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -1178,7 +1240,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1186,6 +1248,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1200,6 +1263,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -1243,7 +1309,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1251,6 +1317,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1267,7 +1334,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1275,6 +1342,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1291,7 +1359,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1299,6 +1367,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1316,6 +1385,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -1359,7 +1431,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a A);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1367,6 +1439,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1383,7 +1456,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a A, &'a B);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1391,6 +1464,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1405,6 +1479,9 @@ mod tests {
                     '_,
                     Registry!(),
                     Resources!(A, B),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -1451,7 +1528,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a mut A);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1459,6 +1536,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1475,7 +1553,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a mut A, &'a B);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1483,6 +1561,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1499,7 +1578,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a mut B, &'a C);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1507,6 +1586,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1524,6 +1604,9 @@ mod tests {
                     '_,
                     Registry!(),
                     Resources!(A, B, C),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -1570,7 +1653,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A);
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1578,6 +1661,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1594,7 +1678,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A, &'a B);
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1602,6 +1686,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1616,6 +1701,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -1662,7 +1750,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A);
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1670,6 +1758,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1686,7 +1775,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a mut A, &'a B);
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1694,6 +1783,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1708,6 +1798,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -1751,7 +1844,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A);
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1759,6 +1852,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1775,7 +1869,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A, &'a C);
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1783,6 +1877,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1797,6 +1892,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,
@@ -1843,7 +1941,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A);
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1851,6 +1949,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1867,7 +1966,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!(&'a A, &'a B);
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 _query_results: Result<
                     R,
@@ -1875,6 +1974,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1889,6 +1989,9 @@ mod tests {
                     '_,
                     Registry,
                     Resources!(),
+                    _,
+                    _,
+                    _,
                     _,
                     _,
                     _,

--- a/src/system/schedule/scheduler.rs
+++ b/src/system/schedule/scheduler.rs
@@ -40,6 +40,9 @@ pub trait Scheduler<
     EntryViewsOppositeIndicesLists,
     EntryViewsOppositeReshapeIndicesLists,
     EntryViewsOppositeInverseIndicesLists,
+    EntryContainmentsLists,
+    EntryIndicesLists,
+    EntryReshapeIndicesLists,
 > where
     R: Registry,
 {
@@ -64,6 +67,9 @@ pub trait Scheduler<
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     >;
 
     fn as_stages(&'a mut self) -> Self::Stages;
@@ -81,6 +87,9 @@ impl<'a, R, Resources>
         Null,
         Null,
         Null,
+        stages::Null,
+        stages::Null,
+        stages::Null,
         stages::Null,
         stages::Null,
         stages::Null,
@@ -164,6 +173,12 @@ impl<
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesList,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsList,
+        EntryContainmentsLists,
+        EntryIndicesList,
+        EntryIndicesLists,
+        EntryReshapeIndicesList,
+        EntryReshapeIndicesLists,
     >
     Scheduler<
         'a,
@@ -214,6 +229,9 @@ impl<
             EntryViewsOppositeInverseIndicesList,
             EntryViewsOppositeInverseIndicesLists,
         ),
+        (EntryContainmentsList, EntryContainmentsLists),
+        (EntryIndicesList, EntryIndicesLists),
+        (EntryReshapeIndicesList, EntryReshapeIndicesLists),
     > for (T, U)
 where
     (T, U): Stager<
@@ -246,6 +264,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >,
     <(T, U) as Stager<
         'a,
@@ -277,6 +298,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >>::Remainder: Scheduler<
         'a,
         R,
@@ -305,6 +329,9 @@ where
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     >,
     R: Registry + 'a,
     Resources: 'a,
@@ -332,6 +359,9 @@ where
     EntryViewsOppositeIndicesList: 'a,
     EntryViewsOppositeReshapeIndicesList: 'a,
     EntryViewsOppositeInverseIndicesList: 'a,
+    EntryContainmentsList: 'a,
+    EntryIndicesList: 'a,
+    EntryReshapeIndicesList: 'a,
 {
     type Stages = (
         <(T, U) as Stager<
@@ -364,6 +394,9 @@ where
             EntryViewsOppositeIndicesList,
             EntryViewsOppositeReshapeIndicesList,
             EntryViewsOppositeInverseIndicesList,
+            EntryContainmentsList,
+            EntryIndicesList,
+            EntryReshapeIndicesList,
         >>::Stage,
         <<(T, U) as Stager<
             'a,
@@ -395,6 +428,9 @@ where
             EntryViewsOppositeIndicesList,
             EntryViewsOppositeReshapeIndicesList,
             EntryViewsOppositeInverseIndicesList,
+            EntryContainmentsList,
+            EntryIndicesList,
+            EntryReshapeIndicesList,
         >>::Remainder as Scheduler<
             'a,
             R,
@@ -423,6 +459,9 @@ where
             EntryViewsOppositeIndicesLists,
             EntryViewsOppositeReshapeIndicesLists,
             EntryViewsOppositeInverseIndicesLists,
+            EntryContainmentsLists,
+            EntryIndicesLists,
+            EntryReshapeIndicesLists,
         >>::Stages,
     );
 

--- a/src/system/schedule/sealed.rs
+++ b/src/system/schedule/sealed.rs
@@ -34,6 +34,9 @@ pub trait Sealed<
     EntryViewsOppositeIndicesLists,
     EntryViewsOppositeReshapeIndicesLists,
     EntryViewsOppositeInverseIndicesLists,
+    EntryContainmentsLists,
+    EntryIndicesLists,
+    EntryReshapeIndicesLists,
 > where
     R: Registry,
 {
@@ -58,6 +61,9 @@ pub trait Sealed<
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     >;
 
     fn as_stages(&'a mut self) -> Self::Stages;
@@ -92,6 +98,9 @@ impl<
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     >
     Sealed<
         'a,
@@ -121,6 +130,9 @@ impl<
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     > for T
 where
     R: Registry,
@@ -152,6 +164,9 @@ where
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     >,
 {
     type Stages = <T as Scheduler<
@@ -182,6 +197,9 @@ where
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     >>::Stages;
 
     #[inline]

--- a/src/system/schedule/stage.rs
+++ b/src/system/schedule/stage.rs
@@ -48,6 +48,9 @@ pub trait Stage<
     EntryViewsOppositeIndicesList,
     EntryViewsOppositeReshapeIndicesList,
     EntryViewsOppositeInverseIndicesList,
+    EntryContainmentsList,
+    EntryIndicesList,
+    EntryReshapeIndicesList,
 >: Send where
     R: Registry,
 {
@@ -79,6 +82,9 @@ pub trait Stage<
         NextEntryViewsOppositeIndicesList,
         NextEntryViewsOppositeReshapeIndicesList,
         NextEntryViewsOppositeInverseIndicesList,
+        NextEntryContainmentsList,
+        NextEntryIndicesList,
+        NextEntryReshapeIndicesList,
     >(
         &mut self,
         world: SendableWorld<R, Resources>,
@@ -108,6 +114,9 @@ pub trait Stage<
             NextEntryViewsOppositeIndicesList,
             NextEntryViewsOppositeReshapeIndicesList,
             NextEntryViewsOppositeInverseIndicesList,
+            NextEntryContainmentsList,
+            NextEntryIndicesList,
+            NextEntryReshapeIndicesList,
         >;
 
     /// Attempt to run as many tasks within this stage as possible as add-ons to the previous
@@ -153,6 +162,9 @@ impl<R, Resources>
         Null,
         Null,
         Null,
+        Null,
+        Null,
+        Null,
     > for Null
 where
     R: Registry,
@@ -179,6 +191,9 @@ where
         NextEntryViewsOppositeIndicesList,
         NextEntryViewsOppositeReshapeIndicesList,
         NextEntryViewsOppositeInverseIndicesList,
+        NextEntryContainmentsList,
+        NextEntryIndicesList,
+        NextEntryReshapeIndicesList,
     >(
         &mut self,
         world: SendableWorld<R, Resources>,
@@ -208,6 +223,9 @@ where
             NextEntryViewsOppositeIndicesList,
             NextEntryViewsOppositeReshapeIndicesList,
             NextEntryViewsOppositeInverseIndicesList,
+            NextEntryContainmentsList,
+            NextEntryIndicesList,
+            NextEntryReshapeIndicesList,
         >,
     {
         // Check if borrowed_archetypes is empty.
@@ -257,6 +275,9 @@ fn query_archetype_identifiers<
     EntryViewsOppositeIndices,
     EntryViewsOppositeReshapeIndices,
     EntryViewsOppositeInverseIndices,
+    EntryContainments,
+    EntryIndices,
+    EntryReshapeIndices,
 >(
     world: SendableWorld<R, Resources>,
     borrowed_archetypes: &mut HashMap<archetype::IdentifierRef<R>, R::Claims, FnvBuildHasher>,
@@ -285,6 +306,9 @@ where
         EntryViewsOppositeIndices,
         EntryViewsOppositeReshapeIndices,
         EntryViewsOppositeInverseIndices,
+        EntryContainments,
+        EntryIndices,
+        EntryReshapeIndices,
     >,
 {
     let mut merged_borrowed_archetypes = borrowed_archetypes.clone();
@@ -336,6 +360,9 @@ fn query_archetype_identifiers_unchecked<
     EntryViewsOppositeIndices,
     EntryViewsOppositeReshapeIndices,
     EntryViewsOppositeInverseIndices,
+    EntryContainments,
+    EntryIndices,
+    EntryReshapeIndices,
 >(
     world: SendableWorld<R, Resources>,
     borrowed_archetypes: &mut HashMap<archetype::IdentifierRef<R>, R::Claims, FnvBuildHasher>,
@@ -363,6 +390,9 @@ fn query_archetype_identifiers_unchecked<
         EntryViewsOppositeIndices,
         EntryViewsOppositeReshapeIndices,
         EntryViewsOppositeInverseIndices,
+        EntryContainments,
+        EntryIndices,
+        EntryReshapeIndices,
     >,
 {
     for (identifier, claims) in
@@ -416,6 +446,12 @@ impl<
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndices,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainments,
+        EntryContainmentsList,
+        EntryIndices,
+        EntryIndicesList,
+        EntryReshapeIndices,
+        EntryReshapeIndicesList,
     >
     Stage<
         'a,
@@ -450,6 +486,9 @@ impl<
             EntryViewsOppositeInverseIndices,
             EntryViewsOppositeInverseIndicesList,
         ),
+        (EntryContainments, EntryContainmentsList),
+        (EntryIndices, EntryIndicesList),
+        (EntryReshapeIndices, EntryReshapeIndicesList),
     > for (&mut T, U)
 where
     R: ContainsQuery<'a, T::Filter, FI, T::Views, VI, P, I, Q>,
@@ -475,6 +514,9 @@ where
             EntryViewsOppositeIndices,
             EntryViewsOppositeReshapeIndices,
             EntryViewsOppositeInverseIndices,
+            EntryContainments,
+            EntryIndices,
+            EntryReshapeIndices,
         > + Send,
     U: Stage<
         'a,
@@ -497,6 +539,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >,
 {
     type HasRun = (bool, U::HasRun);
@@ -521,6 +566,9 @@ where
         NextEntryViewsOppositeIndicesList,
         NextEntryViewsOppositeReshapeIndicesList,
         NextEntryViewsOppositeInverseIndicesList,
+        NextEntryContainments,
+        NextEntryIndices,
+        NextEntryReshapeIndices,
     >(
         &mut self,
         world: SendableWorld<R, Resources>,
@@ -550,6 +598,9 @@ where
             NextEntryViewsOppositeIndicesList,
             NextEntryViewsOppositeReshapeIndicesList,
             NextEntryViewsOppositeInverseIndicesList,
+            NextEntryContainments,
+            NextEntryIndices,
+            NextEntryReshapeIndices,
         >,
     {
         // Determine whether this task still needs to run, or if it has been run as part of a
@@ -584,6 +635,9 @@ where
                         EntryViewsOppositeIndices,
                         EntryViewsOppositeReshapeIndices,
                         EntryViewsOppositeInverseIndices,
+                        EntryContainments,
+                        EntryIndices,
+                        EntryReshapeIndices,
                     >(world, &mut borrowed_archetypes);
 
                     self.1
@@ -622,6 +676,9 @@ where
             EntryViewsOppositeIndices,
             EntryViewsOppositeReshapeIndices,
             EntryViewsOppositeInverseIndices,
+            EntryContainments,
+            EntryIndices,
+            EntryReshapeIndices,
         >(world, &mut borrowed_archetypes)
         {
             rayon::join(

--- a/src/system/schedule/stager.rs
+++ b/src/system/schedule/stager.rs
@@ -58,6 +58,9 @@ pub trait Stager<
     EntryViewsOppositeIndicesList,
     EntryViewsOppositeReshapeIndicesList,
     EntryViewsOppositeInverseIndicesList,
+    EntryContainmentsList,
+    EntryIndicesList,
+    EntryReshapeIndicesList,
 > where
     R: Registry,
 {
@@ -82,6 +85,9 @@ pub trait Stager<
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >;
     type Remainder;
 
@@ -102,6 +108,9 @@ impl<'a, R, Resources, C, ResourcesClaims>
         Null,
         Null,
         Null,
+        stage::Null,
+        stage::Null,
+        stage::Null,
         stage::Null,
         stage::Null,
         stage::Null,
@@ -170,6 +179,9 @@ impl<
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >
     Stager<
         'a,
@@ -201,6 +213,9 @@ impl<
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     > for (task::System<T>, U)
 where
     T::EntryViews<'a>: view::Views<'a>,
@@ -270,6 +285,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >,
 {
     type Stage = <(task::System<T>, U) as Cutoff<
@@ -313,6 +331,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >>::Stage;
     type Remainder = <(task::System<T>, U) as Cutoff<
         'a,
@@ -355,6 +376,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >>::Remainder;
 
     #[inline]
@@ -401,6 +425,9 @@ impl<
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >
     Stager<
         'a,
@@ -432,6 +459,9 @@ impl<
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     > for (task::ParSystem<T>, U)
 where
     T::EntryViews<'a>: view::Views<'a>,
@@ -501,6 +531,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >,
 {
     type Stage = <(task::ParSystem<T>, U) as Cutoff<
@@ -544,6 +577,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >>::Stage;
     type Remainder = <(task::ParSystem<T>, U) as Cutoff<
         'a,
@@ -586,6 +622,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >>::Remainder;
 
     #[inline]
@@ -625,6 +664,9 @@ pub trait Cutoff<
     EntryViewsOppositeIndicesList,
     EntryViewsOppositeReshapeIndicesList,
     EntryViewsOppositeInverseIndicesList,
+    EntryContainmentsList,
+    EntryIndicesList,
+    EntryReshapeIndicesList,
 > where
     R: Registry,
 {
@@ -649,6 +691,9 @@ pub trait Cutoff<
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >;
     type Remainder;
 
@@ -670,6 +715,9 @@ impl<'a, R, Resources, T, C, ResourcesClaims>
         Null,
         Null,
         Null,
+        stage::Null,
+        stage::Null,
+        stage::Null,
         stage::Null,
         stage::Null,
         stage::Null,
@@ -750,6 +798,12 @@ impl<
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndices,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainments,
+        EntryContainmentsList,
+        EntryIndices,
+        EntryIndicesList,
+        EntryReshapeIndices,
+        EntryReshapeIndicesList,
     >
     Cutoff<
         'a,
@@ -794,6 +848,9 @@ impl<
             EntryViewsOppositeInverseIndices,
             EntryViewsOppositeInverseIndicesList,
         ),
+        (EntryContainments, EntryContainmentsList),
+        (EntryIndices, EntryIndicesList),
+        (EntryReshapeIndices, EntryReshapeIndicesList),
     > for (T, U)
 where
     R: ContainsQuery<'a, T::Filter, SFI, T::Views, SVI, SP, SI, SQ>,
@@ -819,6 +876,9 @@ where
             EntryViewsOppositeIndices,
             EntryViewsOppositeReshapeIndices,
             EntryViewsOppositeInverseIndices,
+            EntryContainments,
+            EntryIndices,
+            EntryReshapeIndices,
         > + Send
         + 'a,
     U: Stager<
@@ -851,6 +911,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >,
 {
     type Stage = (
@@ -885,6 +948,9 @@ where
             EntryViewsOppositeIndicesList,
             EntryViewsOppositeReshapeIndicesList,
             EntryViewsOppositeInverseIndicesList,
+            EntryContainmentsList,
+            EntryIndicesList,
+            EntryReshapeIndicesList,
         >>::Stage,
     );
     type Remainder = <U as Stager<
@@ -917,6 +983,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >>::Remainder;
 
     #[inline]

--- a/src/system/schedule/stages.rs
+++ b/src/system/schedule/stages.rs
@@ -35,6 +35,9 @@ pub trait Stages<
     EntryViewsOppositeIndicesLists,
     EntryViewsOppositeReshapeIndicesLists,
     EntryViewsOppositeInverseIndicesLists,
+    EntryContainmentsLists,
+    EntryIndicesLists,
+    EntryReshapeIndicesLists,
 >: Send where
     R: Registry,
 {
@@ -79,6 +82,9 @@ impl<R, Resources>
         '_,
         R,
         Resources,
+        Null,
+        Null,
+        Null,
         Null,
         Null,
         Null,
@@ -157,6 +163,12 @@ impl<
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesList,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsList,
+        EntryContainmentsLists,
+        EntryIndicesList,
+        EntryIndicesLists,
+        EntryReshapeIndicesList,
+        EntryReshapeIndicesLists,
     >
     Stages<
         'a,
@@ -200,6 +212,9 @@ impl<
             EntryViewsOppositeInverseIndicesList,
             EntryViewsOppositeInverseIndicesLists,
         ),
+        (EntryContainmentsList, EntryContainmentsLists),
+        (EntryIndicesList, EntryIndicesLists),
+        (EntryReshapeIndicesList, EntryReshapeIndicesLists),
     > for (T, U)
 where
     R: Registry,
@@ -224,6 +239,9 @@ where
         EntryViewsOppositeIndicesList,
         EntryViewsOppositeReshapeIndicesList,
         EntryViewsOppositeInverseIndicesList,
+        EntryContainmentsList,
+        EntryIndicesList,
+        EntryReshapeIndicesList,
     >,
     U: Stages<
         'a,
@@ -246,6 +264,9 @@ where
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     >,
 {
     type HasRun = T::HasRun;

--- a/src/system/schedule/task/sealed.rs
+++ b/src/system/schedule/task/sealed.rs
@@ -11,6 +11,7 @@ use crate::{
         view::Views,
         Query,
     },
+    registry,
     registry::{
         ContainsParQuery,
         ContainsQuery,
@@ -43,6 +44,9 @@ pub trait Task<
     EntryViewsOppositeIndices,
     EntryViewsOppositeReshapeIndices,
     EntryViewsOppositeInverseIndices,
+    EntryContainments,
+    EntryIndices,
+    EntryReshapeIndices,
 > where
     R: Registry,
 {
@@ -77,6 +81,9 @@ impl<
         EntryViewsOppositeIndices,
         EntryViewsOppositeReshapeIndices,
         EntryViewsOppositeInverseIndices,
+        EntryContainments,
+        EntryIndices,
+        EntryReshapeIndices,
     >
     Task<
         'a,
@@ -99,10 +106,20 @@ impl<
         EntryViewsOppositeIndices,
         EntryViewsOppositeReshapeIndices,
         EntryViewsOppositeInverseIndices,
+        EntryContainments,
+        EntryIndices,
+        EntryReshapeIndices,
     > for System<S>
 where
     S: system::System + Send,
-    R: ContainsQuery<'a, S::Filter, SFI, S::Views<'a>, SVI, SP, SI, SQ>,
+    R: ContainsQuery<'a, S::Filter, SFI, S::Views<'a>, SVI, SP, SI, SQ>
+        + registry::ContainsViews<
+            'a,
+            S::EntryViews<'a>,
+            EntryContainments,
+            EntryIndices,
+            EntryReshapeIndices,
+        >,
     Resources: 'a,
     Resources: ContainsViews<
         'a,
@@ -113,17 +130,17 @@ where
         ResourceViewsReshapeIndices,
     >,
     S::EntryViews<'a>: view::Disjoint<
-        S::Views<'a>,
-        R,
-        EntryViewsContainments,
-        EntryViewsIndices,
-        EntryViewsReshapeIndices,
-        EntryViewsInverseIndices,
-        EntryViewsOppositeContainments,
-        EntryViewsOppositeIndices,
-        EntryViewsOppositeReshapeIndices,
-        EntryViewsOppositeInverseIndices,
-    >,
+            S::Views<'a>,
+            R,
+            EntryViewsContainments,
+            EntryViewsIndices,
+            EntryViewsReshapeIndices,
+            EntryViewsInverseIndices,
+            EntryViewsOppositeContainments,
+            EntryViewsOppositeIndices,
+            EntryViewsOppositeReshapeIndices,
+            EntryViewsOppositeInverseIndices,
+        > + Views<'a>,
 {
     type Views = S::Views<'a>;
     type Filter = S::Filter;
@@ -160,6 +177,9 @@ impl<
         EntryViewsOppositeIndices,
         EntryViewsOppositeReshapeIndices,
         EntryViewsOppositeInverseIndices,
+        EntryContainments,
+        EntryIndices,
+        EntryReshapeIndices,
     >
     Task<
         'a,
@@ -182,10 +202,20 @@ impl<
         EntryViewsOppositeIndices,
         EntryViewsOppositeReshapeIndices,
         EntryViewsOppositeInverseIndices,
+        EntryContainments,
+        EntryIndices,
+        EntryReshapeIndices,
     > for ParSystem<P>
 where
     P: system::ParSystem + Send,
-    R: ContainsParQuery<'a, P::Filter, SFI, P::Views<'a>, SVI, SP, SI, SQ>,
+    R: ContainsParQuery<'a, P::Filter, SFI, P::Views<'a>, SVI, SP, SI, SQ>
+        + registry::ContainsViews<
+            'a,
+            P::EntryViews<'a>,
+            EntryContainments,
+            EntryIndices,
+            EntryReshapeIndices,
+        >,
     Resources: 'a,
     Resources: ContainsViews<
         'a,
@@ -196,17 +226,17 @@ where
         ResourceViewsReshapeIndices,
     >,
     P::EntryViews<'a>: view::Disjoint<
-        P::Views<'a>,
-        R,
-        EntryViewsContainments,
-        EntryViewsIndices,
-        EntryViewsReshapeIndices,
-        EntryViewsInverseIndices,
-        EntryViewsOppositeContainments,
-        EntryViewsOppositeIndices,
-        EntryViewsOppositeReshapeIndices,
-        EntryViewsOppositeInverseIndices,
-    >,
+            P::Views<'a>,
+            R,
+            EntryViewsContainments,
+            EntryViewsIndices,
+            EntryViewsReshapeIndices,
+            EntryViewsInverseIndices,
+            EntryViewsOppositeContainments,
+            EntryViewsOppositeIndices,
+            EntryViewsOppositeReshapeIndices,
+            EntryViewsOppositeInverseIndices,
+        > + Views<'a>,
 {
     type Views = P::Views<'a>;
     type Filter = P::Filter;

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -32,6 +32,7 @@ use crate::{
         Query,
         Result,
     },
+    registry,
     registry::{
         contains,
         ContainsEntities,
@@ -345,14 +346,31 @@ where
         EntryViewsOppositeIndices,
         EntryViewsOppositeReshapeIndices,
         EntryViewsOppositeInverseIndices,
+        EntryContainments,
+        EntryIndices,
+        EntryReshapeIndices,
     >(
         &'a mut self,
         #[allow(unused_variables)] query: Query<V, F, ResourceViews, EntryViews>,
-    ) -> Result<R, Resources, result::Iter<'a, R, F, FI, V, VI, P, I, Q>, ResourceViews, EntryViews>
+    ) -> Result<
+        R,
+        Resources,
+        result::Iter<'a, R, F, FI, V, VI, P, I, Q>,
+        ResourceViews,
+        EntryViews,
+        (EntryContainments, EntryIndices, EntryReshapeIndices),
+    >
     where
         V: Views<'a> + Filter,
         F: Filter,
-        R: ContainsQuery<'a, F, FI, V, VI, P, I, Q>,
+        R: ContainsQuery<'a, F, FI, V, VI, P, I, Q>
+            + registry::ContainsViews<
+                'a,
+                EntryViews,
+                EntryContainments,
+                EntryIndices,
+                EntryReshapeIndices,
+            >,
         Resources: ContainsViews<
             'a,
             ResourceViews,
@@ -362,17 +380,17 @@ where
             ResourceViewsReshapeIndices,
         >,
         EntryViews: view::Disjoint<
-            V,
-            R,
-            EntryViewsContainments,
-            EntryViewsIndices,
-            EntryViewsReshapeIndices,
-            EntryViewsInverseIndices,
-            EntryViewsOppositeContainments,
-            EntryViewsOppositeIndices,
-            EntryViewsOppositeReshapeIndices,
-            EntryViewsOppositeInverseIndices,
-        >,
+                V,
+                R,
+                EntryViewsContainments,
+                EntryViewsIndices,
+                EntryViewsReshapeIndices,
+                EntryViewsInverseIndices,
+                EntryViewsOppositeContainments,
+                EntryViewsOppositeIndices,
+                EntryViewsOppositeReshapeIndices,
+                EntryViewsOppositeInverseIndices,
+            > + Views<'a>,
     {
         let world = self as *mut Self;
         Result {
@@ -464,6 +482,9 @@ where
         EntryViewsOppositeIndices,
         EntryViewsOppositeReshapeIndices,
         EntryViewsOppositeInverseIndices,
+        EntryContainments,
+        EntryIndices,
+        EntryReshapeIndices,
     >(
         &'a mut self,
         #[allow(unused_variables)] query: Query<V, F, ResourceViews, EntryViews>,
@@ -473,11 +494,19 @@ where
         result::ParIter<'a, R, F, FI, V, VI, P, I, Q>,
         ResourceViews,
         EntryViews,
+        (EntryContainments, EntryIndices, EntryReshapeIndices),
     >
     where
         V: ParViews<'a> + Filter,
         F: Filter,
-        R: ContainsParQuery<'a, F, FI, V, VI, P, I, Q>,
+        R: ContainsParQuery<'a, F, FI, V, VI, P, I, Q>
+            + registry::ContainsViews<
+                'a,
+                EntryViews,
+                EntryContainments,
+                EntryIndices,
+                EntryReshapeIndices,
+            >,
         Resources: ContainsViews<
             'a,
             ResourceViews,
@@ -487,17 +516,17 @@ where
             ResourceViewsReshapeIndices,
         >,
         EntryViews: view::Disjoint<
-            V,
-            R,
-            EntryViewsContainments,
-            EntryViewsIndices,
-            EntryViewsReshapeIndices,
-            EntryViewsInverseIndices,
-            EntryViewsOppositeContainments,
-            EntryViewsOppositeIndices,
-            EntryViewsOppositeReshapeIndices,
-            EntryViewsOppositeInverseIndices,
-        >,
+                V,
+                R,
+                EntryViewsContainments,
+                EntryViewsIndices,
+                EntryViewsReshapeIndices,
+                EntryViewsInverseIndices,
+                EntryViewsOppositeContainments,
+                EntryViewsOppositeIndices,
+                EntryViewsOppositeReshapeIndices,
+                EntryViewsOppositeInverseIndices,
+            > + Views<'a>,
     {
         let world = self as *mut Self;
         Result {
@@ -565,7 +594,7 @@ where
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -573,6 +602,7 @@ where
     ///             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
+    ///             E,
     ///         >,
     ///     ) where
     ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -611,12 +641,22 @@ where
         EntryViewsOppositeIndices,
         EntryViewsOppositeReshapeIndices,
         EntryViewsOppositeInverseIndices,
+        EntryContainments,
+        EntryIndices,
+        EntryReshapeIndices,
     >(
         &'a mut self,
         system: &mut S,
     ) where
         S: System,
-        R: ContainsQuery<'a, S::Filter, FI, S::Views<'a>, VI, P, I, Q>,
+        R: ContainsQuery<'a, S::Filter, FI, S::Views<'a>, VI, P, I, Q>
+            + registry::ContainsViews<
+                'a,
+                S::EntryViews<'a>,
+                EntryContainments,
+                EntryIndices,
+                EntryReshapeIndices,
+            >,
         Resources: ContainsViews<
             'a,
             S::ResourceViews<'a>,
@@ -626,17 +666,17 @@ where
             ResourceViewsReshapeIndices,
         >,
         S::EntryViews<'a>: view::Disjoint<
-            S::Views<'a>,
-            R,
-            EntryViewsContainments,
-            EntryViewsIndices,
-            EntryViewsReshapeIndices,
-            EntryViewsInverseIndices,
-            EntryViewsOppositeContainments,
-            EntryViewsOppositeIndices,
-            EntryViewsOppositeReshapeIndices,
-            EntryViewsOppositeInverseIndices,
-        >,
+                S::Views<'a>,
+                R,
+                EntryViewsContainments,
+                EntryViewsIndices,
+                EntryViewsReshapeIndices,
+                EntryViewsInverseIndices,
+                EntryViewsOppositeContainments,
+                EntryViewsOppositeIndices,
+                EntryViewsOppositeReshapeIndices,
+                EntryViewsOppositeInverseIndices,
+            > + Views<'a>,
     {
         let result = self.query(Query::<
             S::Views<'a>,
@@ -682,7 +722,7 @@ where
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -690,6 +730,7 @@ where
     ///             result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
+    ///             E,
     ///         >,
     ///     ) where
     ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -729,12 +770,22 @@ where
         EntryViewsOppositeIndices,
         EntryViewsOppositeReshapeIndices,
         EntryViewsOppositeInverseIndices,
+        EntryContainments,
+        EntryIndices,
+        EntryReshapeIndices,
     >(
         &'a mut self,
         par_system: &mut S,
     ) where
         S: ParSystem,
-        R: ContainsParQuery<'a, S::Filter, FI, S::Views<'a>, VI, P, I, Q>,
+        R: ContainsParQuery<'a, S::Filter, FI, S::Views<'a>, VI, P, I, Q>
+            + registry::ContainsViews<
+                'a,
+                S::EntryViews<'a>,
+                EntryContainments,
+                EntryIndices,
+                EntryReshapeIndices,
+            >,
         Resources: ContainsViews<
             'a,
             S::ResourceViews<'a>,
@@ -744,17 +795,17 @@ where
             ResourceViewsReshapeIndices,
         >,
         S::EntryViews<'a>: view::Disjoint<
-            S::Views<'a>,
-            R,
-            EntryViewsContainments,
-            EntryViewsIndices,
-            EntryViewsReshapeIndices,
-            EntryViewsInverseIndices,
-            EntryViewsOppositeContainments,
-            EntryViewsOppositeIndices,
-            EntryViewsOppositeReshapeIndices,
-            EntryViewsOppositeInverseIndices,
-        >,
+                S::Views<'a>,
+                R,
+                EntryViewsContainments,
+                EntryViewsIndices,
+                EntryViewsReshapeIndices,
+                EntryViewsInverseIndices,
+                EntryViewsOppositeContainments,
+                EntryViewsOppositeIndices,
+                EntryViewsOppositeReshapeIndices,
+                EntryViewsOppositeInverseIndices,
+            > + Views<'a>,
     {
         let result = self.par_query(Query::<
             S::Views<'a>,
@@ -805,7 +856,7 @@ where
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -813,6 +864,7 @@ where
     ///             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
+    ///             E,
     ///         >,
     ///     ) where
     ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -829,7 +881,7 @@ where
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -837,6 +889,7 @@ where
     ///             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
+    ///             E,
     ///         >,
     ///     ) where
     ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -886,6 +939,9 @@ where
         EntryViewsOppositeIndicesLists,
         EntryViewsOppositeReshapeIndicesLists,
         EntryViewsOppositeInverseIndicesLists,
+        EntryContainmentsLists,
+        EntryIndicesLists,
+        EntryReshapeIndicesLists,
     >(
         &mut self,
         schedule: &'a mut S,
@@ -918,6 +974,9 @@ where
             EntryViewsOppositeIndicesLists,
             EntryViewsOppositeReshapeIndicesLists,
             EntryViewsOppositeInverseIndicesLists,
+            EntryContainmentsLists,
+            EntryIndicesLists,
+            EntryReshapeIndicesLists,
         >,
     {
         schedule.as_stages().run(self, S::Stages::new_has_run());
@@ -1838,7 +1897,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -1846,6 +1905,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1876,7 +1936,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -1884,6 +1944,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1914,7 +1975,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -1922,6 +1983,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1955,7 +2017,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -1963,6 +2025,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1998,7 +2061,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2006,6 +2069,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2038,7 +2102,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2046,6 +2110,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2075,7 +2140,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2083,6 +2148,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2112,7 +2178,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2120,6 +2186,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2149,7 +2216,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2157,6 +2224,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2189,7 +2257,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a mut Counter);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2197,6 +2265,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2229,7 +2298,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2237,6 +2306,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2268,7 +2338,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2276,6 +2346,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2307,7 +2378,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2315,6 +2386,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2349,7 +2421,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2357,6 +2429,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2393,7 +2466,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2401,6 +2474,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2434,7 +2508,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2442,6 +2516,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2472,7 +2547,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2480,6 +2555,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2510,7 +2586,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2518,6 +2594,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2548,7 +2625,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2556,6 +2633,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2589,7 +2667,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a mut Counter);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2597,6 +2675,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2629,7 +2708,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2637,6 +2716,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2655,7 +2735,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2663,6 +2743,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2705,7 +2786,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2713,6 +2794,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2731,7 +2813,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2739,6 +2821,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2779,7 +2862,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2787,6 +2870,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2805,7 +2889,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2813,6 +2897,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2831,7 +2916,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q>(
+            fn run<'a, R, S, FI, VI, P, I, Q, E>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2839,6 +2924,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
+                    E,
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -3463,5 +3463,10 @@ mod tests {
                 assert_eq!(a, &A(42));
             }
         }
+
+        let mut world = World::<Registry>::new();
+        let entity_identifier = world.insert(entity!(A(42)));
+
+        world.run_par_system(&mut EntrySystem { entity_identifier });
     }
 }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -594,7 +594,7 @@ where
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -602,7 +602,7 @@ where
     ///             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
-    ///             E,
+    ///             (EP, EI, EQ),
     ///         >,
     ///     ) where
     ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -722,7 +722,7 @@ where
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -730,7 +730,7 @@ where
     ///             result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
-    ///             E,
+    ///             (EP, EI, EQ),
     ///         >,
     ///     ) where
     ///         R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -856,7 +856,7 @@ where
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -864,7 +864,7 @@ where
     ///             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
-    ///             E,
+    ///             (EP, EI, EQ),
     ///         >,
     ///     ) where
     ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -881,7 +881,7 @@ where
     ///     type ResourceViews<'a> = Views!();
     ///     type EntryViews<'a> = Views!();
     ///
-    ///     fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    ///     fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
     ///         &mut self,
     ///         query_results: Result<
     ///             R,
@@ -889,7 +889,7 @@ where
     ///             result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
     ///             Self::ResourceViews<'a>,
     ///             Self::EntryViews<'a>,
-    ///             E,
+    ///             (EP, EI, EQ),
     ///         >,
     ///     ) where
     ///         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1897,7 +1897,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -1905,7 +1905,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1936,7 +1936,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -1944,7 +1944,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -1975,7 +1975,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -1983,7 +1983,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2017,7 +2017,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2025,7 +2025,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2061,7 +2061,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2069,7 +2069,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2102,7 +2102,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2110,7 +2110,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2140,7 +2140,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2148,7 +2148,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2178,7 +2178,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2186,7 +2186,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2216,7 +2216,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2224,7 +2224,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2257,7 +2257,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a mut Counter);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2265,7 +2265,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2298,7 +2298,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2306,7 +2306,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2338,7 +2338,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2346,7 +2346,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2378,7 +2378,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2386,7 +2386,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2421,7 +2421,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2429,7 +2429,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2466,7 +2466,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2474,7 +2474,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2508,7 +2508,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2516,7 +2516,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2547,7 +2547,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2555,7 +2555,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2586,7 +2586,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2594,7 +2594,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2625,7 +2625,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2633,7 +2633,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2667,7 +2667,7 @@ mod tests {
             type ResourceViews<'a> = Views!(&'a mut Counter);
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2675,7 +2675,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2708,7 +2708,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2716,7 +2716,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2735,7 +2735,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2743,7 +2743,7 @@ mod tests {
                     result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2786,7 +2786,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2794,7 +2794,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2813,7 +2813,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2821,7 +2821,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2862,7 +2862,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2870,7 +2870,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2889,7 +2889,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2897,7 +2897,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -2916,7 +2916,7 @@ mod tests {
             type ResourceViews<'a> = Views!();
             type EntryViews<'a> = Views!();
 
-            fn run<'a, R, S, FI, VI, P, I, Q, E>(
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
                 &mut self,
                 query_results: Result<
                     R,
@@ -2924,7 +2924,7 @@ mod tests {
                     result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
                     Self::ResourceViews<'a>,
                     Self::EntryViews<'a>,
-                    E,
+                    (EP, EI, EQ),
                 >,
             ) where
                 R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
@@ -3385,5 +3385,83 @@ mod tests {
         let mut entry = assert_some!(query_results.entries.entry(entity_identifier));
         let result!(a) = assert_some!(entry.query(Query::<Views!(&A)>::new()));
         assert_eq!(a, &A(42));
+    }
+
+    #[test]
+    fn system_with_entries() {
+        struct EntrySystem {
+            entity_identifier: entity::Identifier,
+        }
+
+        impl System for EntrySystem {
+            type Views<'a> = Views!(&'a A);
+            type Filter = filter::None;
+            type ResourceViews<'a> = Views!();
+            type EntryViews<'a> = Views!(&'a A);
+
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
+                &mut self,
+                mut query_result: Result<
+                    'a,
+                    R,
+                    S,
+                    result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
+                    Self::ResourceViews<'a>,
+                    Self::EntryViews<'a>,
+                    (EP, EI, EQ),
+                >,
+            ) where
+                R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>
+                    + registry::ContainsViews<'a, Self::EntryViews<'a>, EP, EI, EQ>,
+            {
+                for result!() in query_result.iter {
+                    let mut entry =
+                        assert_some!(query_result.entries.entry(self.entity_identifier));
+                    let result!(a) = assert_some!(entry.query(Query::<Views!(&A)>::new()));
+                    assert_eq!(a, &A(42));
+                }
+            }
+        }
+
+        let mut world = World::<Registry>::new();
+        let entity_identifier = world.insert(entity!(A(42)));
+
+        world.run_system(&mut EntrySystem { entity_identifier });
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn par_system_with_entries() {
+        struct EntrySystem {
+            entity_identifier: entity::Identifier,
+        }
+
+        impl ParSystem for EntrySystem {
+            type Views<'a> = Views!(&'a A);
+            type Filter = filter::None;
+            type ResourceViews<'a> = Views!();
+            type EntryViews<'a> = Views!(&'a A);
+
+            fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
+                &mut self,
+                mut query_result: Result<
+                    'a,
+                    R,
+                    S,
+                    result::ParIter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>,
+                    Self::ResourceViews<'a>,
+                    Self::EntryViews<'a>,
+                    (EP, EI, EQ),
+                >,
+            ) where
+                R: ContainsParQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>
+                    + registry::ContainsViews<'a, Self::EntryViews<'a>, EP, EI, EQ>,
+            {
+                // Using the Entries during parallel iteration is not supported.
+                let mut entry = assert_some!(query_result.entries.entry(self.entity_identifier));
+                let result!(a) = assert_some!(entry.query(Query::<Views!(&A)>::new()));
+                assert_eq!(a, &A(42));
+            }
+        }
     }
 }

--- a/tests/trybuild/schedule/type_unexpected_token.rs
+++ b/tests/trybuild/schedule/type_unexpected_token.rs
@@ -14,9 +14,9 @@ impl System for A {
     type ResourceViews<'a> = Views!();
     type EntryViews<'a> = Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         &mut self,
-        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
+        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
 }
@@ -29,9 +29,9 @@ impl System for B {
     type ResourceViews<'a> = Views!();
     type EntryViews<'a> = Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         &mut self,
-        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
+        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
 }

--- a/tests/trybuild/schedule/type_unexpected_token.rs
+++ b/tests/trybuild/schedule/type_unexpected_token.rs
@@ -14,9 +14,9 @@ impl System for A {
     type ResourceViews<'a> = Views!();
     type EntryViews<'a> = Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q>(
+    fn run<'a, R, S, FI, VI, P, I, Q, E>(
         &mut self,
-        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
 }
@@ -29,9 +29,9 @@ impl System for B {
     type ResourceViews<'a> = Views!();
     type EntryViews<'a> = Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q>(
+    fn run<'a, R, S, FI, VI, P, I, Q, E>(
         &mut self,
-        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
 }

--- a/tests/trybuild/schedule/unexpected_token.rs
+++ b/tests/trybuild/schedule/unexpected_token.rs
@@ -14,9 +14,9 @@ impl System for A {
     type ResourceViews<'a> = Views!();
     type EntryViews<'a> = Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         &mut self,
-        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
+        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
 }
@@ -29,9 +29,9 @@ impl System for B {
     type ResourceViews<'a> = Views!();
     type EntryViews<'a> = Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q, E>(
+    fn run<'a, R, S, FI, VI, P, I, Q, EP, EI, EQ>(
         &mut self,
-        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
+        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, (EP, EI, EQ)>,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
 }

--- a/tests/trybuild/schedule/unexpected_token.rs
+++ b/tests/trybuild/schedule/unexpected_token.rs
@@ -14,9 +14,9 @@ impl System for A {
     type ResourceViews<'a> = Views!();
     type EntryViews<'a> = Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q>(
+    fn run<'a, R, S, FI, VI, P, I, Q, E>(
         &mut self,
-        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
 }
@@ -29,9 +29,9 @@ impl System for B {
     type ResourceViews<'a> = Views!();
     type EntryViews<'a> = Views!();
 
-    fn run<'a, R, S, FI, VI, P, I, Q>(
+    fn run<'a, R, S, FI, VI, P, I, Q, E>(
         &mut self,
-        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>>,
+        _query_results: Result<R, S, result::Iter<'a, R, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q>, Self::ResourceViews<'a>, Self::EntryViews<'a>, E>,
     ) where
         R: ContainsQuery<'a, Self::Filter, FI, Self::Views<'a>, VI, P, I, Q> {}
 }


### PR DESCRIPTION
Fixes #191.

This fix is basically what I described in the issue. By changing the `query::Entry` bounds to no longer require `SubViews` and `Filter` to be contained directly in the `Registry`, we are able to  define proper trait bounds on `System::run()` (and `ParSystem::run()`) to allow the access for any generic `Registry`.