### PR TITLE
Make registry::ContainsViews public.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Fixed
+- `registry::ContainsViews` is now a public trait.
 
 ## 0.8.0 - 2023-04-02
 ### Added

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -50,6 +50,7 @@ pub use contains::{
     ContainsEntities,
     ContainsEntity,
     ContainsQuery,
+    ContainsViews,
 };
 pub use debug::Debug;
 pub use eq::{
@@ -59,7 +60,6 @@ pub use eq::{
 
 #[cfg(feature = "rayon")]
 pub(crate) use contains::ContainsParViews;
-pub(crate) use contains::ContainsViews;
 pub(crate) use get::Get;
 #[cfg(feature = "rayon")]
 pub(crate) use sealed::CanonicalParViews;


### PR DESCRIPTION
This was accidentally missed in #195, making the fix still not usable.