### PR TITLE
Loosen the lifetime of Entry::query().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Fixed
+- `Entry::query()` now requires a less-strict lifetime.
 
 ## 0.8.1 - 2023-04-02
 ### Fixed

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -307,14 +307,14 @@ where
     /// ```
     ///
     /// [`Views`]: trait@crate::query::view::Views
-    pub fn query<V, F, VI, FI, P, I, Q>(
-        &'a mut self,
+    pub fn query<'b, V, F, VI, FI, P, I, Q>(
+        &'b mut self,
         #[allow(unused_variables)] query: Query<V, F>,
     ) -> Option<V>
     where
-        V: Views<'a> + Filter,
+        V: Views<'b> + Filter,
         F: Filter,
-        R: ContainsQuery<'a, F, FI, V, VI, P, I, Q>,
+        R: ContainsQuery<'b, F, FI, V, VI, P, I, Q>,
     {
         // SAFETY: The `R` on which `filter()` is called is the same `R` over which the identifier
         // is generic over.


### PR DESCRIPTION
This allows more flexibility when using `Entry::query()`.

Classifying this as a bug. This is how it was intended to work all along. Additionally, this isn't a breaking change, as loosening the lifetime does not break any existing code.