### PR TITLE
Correctly update `Entry`'s location to match `World`'s updated state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `World::run_system()` now only requires a single parameter for schedule indices.
 ### Fixed
 - `Schedule`s can now no longer access non-`Sync` components and resources.
+- Multiple calls to `Entry::add()` or `Entry::remove()` that change the shape of the entity now no longer accesses the wrong internal entity row, preventing potential undefined behavior.
 
 ## 0.8.2 - 2023-04-02
 ### Fixed

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -163,14 +163,18 @@ where
             };
 
             // Update the location.
+            // SAFETY: The archetype is guaranteed to outlive the location, as archetype is stored
+            // in the same world where the location is stored. Additionally, the location stored in
+            // this entry will be outlived by archetype due to its lifetime guarantees.
+            let location = Location::new(unsafe { archetype.identifier() }, index);
             // SAFETY: `entity_identifier` is guaranteed at creation of this `Entry` to be
             // contained in `self.world.entity_allocator`.
             unsafe {
-                self.world.entity_allocator.modify_location_unchecked(
-                    entity_identifier,
-                    Location::new(archetype.identifier(), index),
-                );
+                self.world
+                    .entity_allocator
+                    .modify_location_unchecked(entity_identifier, location);
             }
+            self.location = location;
         }
     }
 
@@ -256,14 +260,18 @@ where
             };
 
             // Update the location.
+            // SAFETY: The archetype is guaranteed to outlive the location, as archetype is stored
+            // in the same world where the location is stored. Additionally, the location stored in
+            // this entry will be outlived by archetype due to its lifetime guarantees.
+            let location = Location::new(unsafe { archetype.identifier() }, index);
             // SAFETY: `entity_identifier` is guaranteed at creation of this `Entry` to be
             // contained in `self.world.entity_allocator`.
             unsafe {
-                self.world.entity_allocator.modify_location_unchecked(
-                    entity_identifier,
-                    Location::new(archetype.identifier(), index),
-                );
+                self.world
+                    .entity_allocator
+                    .modify_location_unchecked(entity_identifier, location);
             }
+            self.location = location;
         }
     }
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -2706,7 +2706,7 @@ mod tests {
         entry.remove::<B, _>();
         entry.remove::<A, _>();
 
-        assert_some!(
+        assert_none!(
             entry.query(Query::<Views!(), filter::Or<filter::Has<A>, filter::Has<B>>>::new())
         );
     }

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -2697,6 +2697,21 @@ mod tests {
     }
 
     #[test]
+    fn entry_multiple_shape_changes() {
+        let mut world = World::<Registry>::new();
+
+        let entity_identifier = world.insert(entity!(A(1), B('a')));
+        let mut entry = assert_some!(world.entry(entity_identifier));
+
+        entry.remove::<B, _>();
+        entry.remove::<A, _>();
+
+        assert_some!(
+            entry.query(Query::<Views!(), filter::Or<filter::Has<A>, filter::Has<B>>>::new())
+        );
+    }
+
+    #[test]
     fn remove() {
         let mut world = World::<Registry>::new();
 


### PR DESCRIPTION
This fixes #216.